### PR TITLE
Added delete_discount method to Stripe::Customer

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -369,7 +369,16 @@ module Stripe
       subscription
     end
 
+    def delete_discount(params={})
+      Stripe.request(:delete, discount_url, @api_key, params)
+      refresh_from({ :discount => nil }, api_key, true)
+    end
+
     private
+
+    def discount_url
+      url + '/discount'
+    end
 
     def subscription_url
       url + '/subscription'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -167,3 +167,10 @@ def test_api_error
     }
   }
 end
+
+def test_delete_discount_response
+  {
+    :deleted => true,
+    :id => "di_test_coupon"
+  }
+end

--- a/test/test_stripe.rb
+++ b/test/test_stripe.rb
@@ -313,6 +313,14 @@ class TestStripeRuby < Test::Unit::TestCase
           @mock.expects(:delete).once.with("https://api.stripe.com/v1/customers/c_test_customer/subscription", {}, nil).returns(test_response(test_subscription('silver')))
           s = c.cancel_subscription
         end
+
+        should "be able to delete a customer's discount" do
+          @mock.expects(:get).once.returns(test_response(test_customer))
+          c = Stripe::Customer.retrieve("test_customer")
+
+          @mock.expects(:delete).once.with("https://api.stripe.com/v1/customers/c_test_customer/discount", {}, nil).returns(test_response(test_delete_discount_response))
+          s = c.delete_discount
+        end
       end
 
       context "card tests" do


### PR DESCRIPTION
I know this API is still being developed/tested, but I went ahead and added it to the ruby library so I could start using it in my application.  So, feel free to use this as a head start when it comes time to update all of the stripe libraries.
