### PR TITLE
Fixed an issue that causes an object instantiated from construct_from to...

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -322,7 +322,7 @@ module Stripe
       "/#{CGI.escape(shortname.downcase)}s"
     end
     def url
-      id = self['id']
+      id = self['id'] || self.id
       raise InvalidRequestError.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{id.inspect}", 'id') unless id
       "#{self.class.url}/#{CGI.escape(id)}"
     end


### PR DESCRIPTION
There was an issue in the url method of APIResource that was incorrectly reading the url attribute from the object. The error occurred when trying to construct a StripeObject from the construct_from method. This fix does not break existing code and simply looks for an alternative attribute.
