### PR TITLE
Enable standard rails configuration mechanism

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -43,6 +43,9 @@ require 'stripe/errors/card_error'
 require 'stripe/errors/invalid_request_error'
 require 'stripe/errors/authentication_error'
 
+# Rails
+require 'stripe/railtie' if defined?(Rails) && Rails.version > '3'
+
 module Stripe
   @@ssl_bundle_path = File.join(File.dirname(__FILE__), 'data/ca-certificates.crt')
   @@api_key = nil

--- a/lib/stripe/railtie.rb
+++ b/lib/stripe/railtie.rb
@@ -1,0 +1,12 @@
+module Stripe
+  class Railtie < ::Rails::Railtie
+    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs).new
+
+    initializer 'stripe.setup' do |app|
+      [:api_base, :api_key, :verify_ssl_certs].each do |key|
+        value = app.config.stripe.send(key)
+        Stripe.send("#{key}=", value) unless value.nil?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Whenever the stripe gem is required inside a
modern Rails environment, it will extend the
standard configuration with a `stripe` attribute
which can be used to set stripe parameters as 
part of the standard Rails initialization process.

This makes it much easier to override config
parameters in a per-environment fashion. As well
as make stripe configurable by other railties and
engines.

e.g. development.rb:

``` ruby
config.stripe.api_base = 'http://localhost:3002'
config.stripe.verify_ssl_certs = false
config.stripe.api_key = 'DEV_KEY'
```

production.rb:

``` ruby
config.stripe.api_key = 'PRODUCTION_KEY'
```
## Testing Question

I didn't check in my testcase for this since it involves basically stubbing out the whole rails engine which is quite a bit more code than the railtie itself. Not sure how you feel about it faking it, or if you want to test it with a separate process that bring in rails or what.
