### PR TITLE
multi_json dependency request

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.require_paths = %w{lib}
 
   s.add_dependency('rest-client', '~> 1.4')
-  s.add_dependency('multi_json', '~> 1.1')
+  s.add_dependency('multi_json', '~> 1')
 
   s.add_development_dependency('mocha')
   s.add_development_dependency('shoulda')


### PR DESCRIPTION
Hi!

We're looking to go live soon using Stripe at Spreecast and I ran into an issue with getting the gem deployed in our system. We have a hard dependency on multi_json 1.0.4 from our versions of sidekiq and oa_oauth. I've been able to successfully create tokens and charges using the relaxed constraint here and was wondering if you could incorporate this change in an updated rev.

On the other hand, if there's newer multi_json functionality in 1.1 that's required for further integration, that would be great to know as well.

Please let me know if there's any additional info that I can provide.

Thanks!
-Sean
