### PR TITLE
Update URL for API spec

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -1,5 +1,5 @@
 # Stripe Ruby bindings
-# API spec at http://stripe.com/api/spec
+# API spec at https://stripe.com/docs/api
 require 'cgi'
 require 'set'
 require 'rubygems'


### PR DESCRIPTION
The existing URL 404's (https://stripe.com/api/spec)
