### PR TITLE
Remove rubygems require

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -2,10 +2,7 @@
 # API spec at https://stripe.com/docs/api
 require 'cgi'
 require 'set'
-require 'rubygems'
 require 'openssl'
-
-gem 'rest-client', '~> 1.4'
 require 'rest_client'
 require 'multi_json'
 


### PR DESCRIPTION
Explicitly requiring rubygems is bad practice:

http://tomayko.com/writings/require-rubygems-antipattern
http://chneukirchen.github.com/rps/
