### PR TITLE
Refactor lib/stripe.rb

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -77,7 +77,7 @@ module Stripe
 
     case method.to_s.downcase.to_sym
     when :get, :head, :delete
-      url += "?#{uri_encode params}" if params && params.any?
+      url += "?#{uri_encode(params)}" if params && params.any?
       payload = nil
     else
       payload = uri_encode(params)


### PR DESCRIPTION
This was the first file I opened when auditing this code. IMO it needed some refactoring.

Summary of changes:
- Break apart monstrous `Stripe.request` method. It does way too much.
- Reduce cruft
- Sensible max line length for those working with the code in an editor with multiple splits, e.g. VIM

I wanted to go further with breaking up `Stripe.request` and move the RestClient exception handling into `Stripe.execute_request` but due to the way the client is mocked in testing it broke the tests despite being a simple refactor. I would have continued but it's late. I promise to go back to it if you accept these changes.

No behaviour has been changed. Tests are green.

Thanks!

S
