### PR TITLE
Add ruby 2.0.0 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
+  - 2.0.0
 gemfile:
   - gemfiles/default-with-activesupport.gemfile
   - gemfiles/json.gemfile


### PR DESCRIPTION
I've tested locally with 2.0.0, no failures.
