### PR TITLE
Always call to_sym instead of type checking in Stripe::StripeObject#[] m...

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -70,8 +70,7 @@ module Stripe
     end
 
     def [](k)
-      k = k.to_sym if k.kind_of?(String)
-      @values[k]
+      @values[k.to_sym]
     end
 
     def []=(k, v)


### PR DESCRIPTION
Both String and Symbol implement #to_sym, so there's no need to check that a key is a string before calling it.

Small detail, but it's more readable, and more flexible/idiomatic (can potentially use other objects that implement #to_sym as keys).
