### PR TITLE
Allow to update a resource without retreiving it first

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -5,6 +5,7 @@ module Stripe
         if @unsaved_values.length > 0
           values = {}
           @unsaved_values.each { |k| values[k] = @values[k] }
+          values.delete(:id)
           response, api_key = Stripe.request(:post, url, @api_key, values)
           refresh_from(response, api_key)
         end

--- a/test/test_stripe.rb
+++ b/test/test_stripe.rb
@@ -447,6 +447,15 @@ class TestStripeRuby < Test::Unit::TestCase
           s = c.delete_discount
           assert_equal nil, c.discount
         end
+
+        should "be able to update a customer without refreshing it first" do
+          @mock.expects(:post).once.with("#{Stripe.api_base}/v1/customers/test_customer", nil, 'mnemonic=bar').returns(test_response(test_customer({:mnemonic => "bar"})))
+          c = Stripe::Customer.new("test_customer")
+          c.mnemonic = "bar"
+          c.save
+          assert_equal c.mnemonic, "bar"
+        end
+
       end
 
       context "card tests" do


### PR DESCRIPTION
Rationale:

  Sometime you don't care about the current state of a resource
  you just want to update one of it's attributes.
  It should only require one request.

fixes #52

``` ruby
  c = Stripe::Customer.new("cus_1EqKjPaFs4ZwDD")
  c.description = 'Ny new Description'
  c.save
```

Before:

``` json
{
  error: {
    type: "invalid_request_error",
    message: "A parameter provided in the URL (id) was repeated as a GET or POST parameter. You can only provide this information as a portion of the URL.",
    param: "id",
  }
}
```

After:

Successfully update the customer and return it's whole state.
