### PR TITLE
Low memory caused our pages to 500.

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -106,7 +106,7 @@ module Stripe
         :ssl_ca_file => @@ssl_bundle_path
       }
     end
-    uname = (@@uname ||= RUBY_PLATFORM =~ /linux|darwin/i ? `uname -a 2>/dev/null`.strip : nil)
+    uname = get_uname
     lang_version = "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})"
     ua = {
       :bindings_version => Stripe::VERSION,
@@ -196,6 +196,13 @@ module Stripe
   end
 
   private
+
+  def self.get_uname
+    (@@uname ||= RUBY_PLATFORM =~ /linux|darwin/i ? `uname -a 2>/dev/null`.strip : nil)
+  rescue Errno::ENOMEM => ex # couldn't create subprocess
+    "uname lookup died"
+  end
+  
 
   def self.execute_request(opts)
     RestClient::Request.execute(opts)


### PR DESCRIPTION
Attempting to spawn a subprocess to get the uname threw an out of
memory error.  Since the uname is only needed to provide diagnostic
info in the User-Agent, it shouldn't cause stripe to fail.
