### PR TITLE
Add customer.upcoming_invoice convenience method

### DIFF
--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -17,6 +17,10 @@ module Stripe
       InvoiceItem.all({ :customer => id }, @api_key)
     end
 
+    def upcoming_invoice
+      Invoice.upcoming({ :customer => id })
+    end
+
     def charges
       Charge.all({ :customer => id }, @api_key)
     end


### PR DESCRIPTION
It seems to embrace the 'Ruby Way' (and more convenient in my own code) to be able to access an upcoming invoice from the customer itself rather than de-reference the customer id and ask the Invoice class itself for that info.

thanks

rob
