### PR TITLE
Update list_object.rb

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -6,7 +6,7 @@ module Stripe
     end
 
     def all(filters={})
-      response, api_key = Stripe.request(:get, url, api_key, filters)
+      response = Stripe.request(:get, url, api_key, filters)
       Util.convert_to_stripe_object(response, api_key)
     end
 


### PR DESCRIPTION
Removed the api_key variable assignment here, as it doesn't seem to pose any purpose? Also, it blanks out the api_key variable, potentially causing the wrong API key to be used, when you try to do the following: 

Stripe::Transfer.retrieve('tr_asdfasdf', 'sk_live_asdfasdf').transactions.all
