### PR TITLE
Fix the build

### DIFF
--- a/gemfiles/default-with-activesupport.gemfile
+++ b/gemfiles/default-with-activesupport.gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 gemspec :path => File.join(File.dirname(__FILE__), "..")
-gem "activesupport"
+gem "activesupport", "~> 3.0"

--- a/gemfiles/json.gemfile
+++ b/gemfiles/json.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gemspec :path => File.join(File.dirname(__FILE__), "..")
 gem "json"
-gem "activesupport"
+gem "activesupport", "~> 3.0"

--- a/gemfiles/yajl.gemfile
+++ b/gemfiles/yajl.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gemspec :path => File.join(File.dirname(__FILE__), "..")
 gem "yajl-ruby"
-gem "activesupport"
+gem "activesupport", "~> 3.0"

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -16,8 +16,8 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('rest-client', '~> 1.4')
   s.add_dependency('multi_json', '>= 1.0.4', '< 2')
 
-  s.add_development_dependency('mocha')
-  s.add_development_dependency('shoulda')
+  s.add_development_dependency('mocha', '~> 0.13.2')
+  s.add_development_dependency('shoulda', '~> 3.4.0')
   s.add_development_dependency('test-unit')
   s.add_development_dependency('rake')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'stringio'
 require 'test/unit'
 require 'stripe'
-require 'mocha'
+require 'mocha/setup'
 include Mocha
 
 #monkeypatch request methods

--- a/test/test_stripe.rb
+++ b/test/test_stripe.rb
@@ -2,7 +2,7 @@
 require File.expand_path('../test_helper', __FILE__)
 require 'test/unit'
 require 'shoulda'
-require 'mocha'
+require 'mocha/setup'
 require 'pp'
 require 'rest-client'
 require 'cgi'


### PR DESCRIPTION
Without a version specifier Travis will attempt to install activesupport 4.0.0, which will fail with `Gem::InstallError: activesupport requires Ruby version >= 1.9.3`

For example: https://travis-ci.org/stripe/stripe-ruby/jobs/8611599

Hopefully this fixes it. Tested locally with the default-with-activesupport.gemfile on 1.8.7, 1.9.3, and 2.0.0.
