### PR TITLE
Refactor Stripe::Util.convert_to_stripe_object method

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -35,8 +35,8 @@ module Stripe
       when Array
         resp.map { |i| convert_to_stripe_object(i, api_key) }
       when Hash
-        # Try converting to a known object class.  If none available, fall back to generic APIResource
-        object_classes.fetch(resp[:object]) { StripeObject }.construct_from(resp, api_key)
+        # Try converting to a known object class.  If none available, fall back to generic StripeObject
+        object_classes.fetch(resp[:object], StripeObject).construct_from(resp, api_key)
       else
         resp
       end


### PR DESCRIPTION
The `Hash#fetch` method neatly abstracts the "lookup this key and if it's not in the hash use this default value" pattern. Jumped out at me whilst reading through the code.

Also: the comment doesn't agree with the implementation: it suggests the default value should be `APIResource` instead of `StripeObject`. Not sure which is correct, but one of them presumably needs changing.
# NotUrgentButEveryLittleHelps :)
