### PR TITLE
Remove extra include from test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'stringio'
 require 'test/unit'
 require 'stripe'
 require 'mocha/setup'
-include Mocha
 
 #monkeypatch request methods
 module Stripe


### PR DESCRIPTION
Mocha is already included in the test case class.
