### PR TITLE
Small refactoring

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -41,13 +41,11 @@ module Stripe
         when StripeObject
           unsaved_keys = obj.instance_variable_get(:@unsaved_values)
           obj_values = obj.instance_variable_get(:@values)
-          update_hash = {}
 
-          unsaved_keys.each do |k|
+          unsaved_keys.reduce({}) do |update_hash, k|
             update_hash[k] = serialize_params(obj_values[k])
+            update_hash
           end
-
-          update_hash
         else
           obj
         end


### PR DESCRIPTION
Use `Enumerable#reduce` in `Stripe::APIOperations::Update#serialize_params` instead of `Enumerable#each`.

Still works the same, just a little cleaner.
