### PR TITLE
return `uname` as blank if not available.

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -160,7 +160,7 @@ module Stripe
   def self.get_uname
     `uname -a 2>/dev/null`.strip if RUBY_PLATFORM =~ /linux|darwin/i
   rescue Errno::ENOMEM => ex # couldn't create subprocess
-    "uname lookup failed"
+    ""
   end
 
   def self.uri_encode(params)


### PR DESCRIPTION
return `uname` as blank if not available.
