### PR TITLE
Allow creation of new Invoice off Customer

### DIFF
--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -25,6 +25,10 @@ module Stripe
       Charge.all({ :customer => id }, @api_key)
     end
 
+    def create_upcoming_invoice(params={})
+      Invoice.create(params.merge(:customer => id), @api_key)
+    end
+
     def cancel_subscription(params={})
       response, api_key = Stripe.request(:delete, subscription_url, @api_key, params)
       refresh_from({ :subscription => response }, api_key, true)

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -32,6 +32,12 @@ module Stripe
       assert_equal "c_test_customer", c.id
     end
 
+    should "create_upcoming_invoice should create a new invoice" do
+      @mock.expects(:post).once.returns(test_response(test_invoice))
+      i = Stripe::Customer.new("test_customer").create_upcoming_invoice
+      assert_equal "c_test_customer", i.customer
+    end
+
     should "be able to update a customer's subscription" do
       @mock.expects(:get).once.returns(test_response(test_customer))
       c = Stripe::Customer.retrieve("test_customer")

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -8,6 +8,12 @@ module Stripe
       assert_equal 'in_test_invoice', i.id
     end
 
+    should "create should create a new invoice" do
+      @mock.expects(:post).once.returns(test_response(test_invoice))
+      i = Stripe::Invoice.create
+      assert_equal "in_test_invoice", i.id
+    end
+
     should "pay should pay an invoice" do
       @mock.expects(:get).once.returns(test_response(test_invoice))
       i = Stripe::Invoice.retrieve('in_test_invoice')


### PR DESCRIPTION
The `Customer` object has the ability to view an upcoming invoice through `.upcoming_invoice`. However, the `Invoice` that gets returned is only a preview of what the invoice will look like.  In other words, the upcoming invoice does not have an invoice id and does not actually exist yet.

This means that if I want to create a new invoice immediately for a customer, I have to turn back to the `Invoice` class, passing in my customer and token again.

It would be much nicer just to be able to create a new invoice off the customer itself.  This makes a lot of sense given that it is already possible to create invoice items off a customer, view an upcoming invoice, but no way to immediately create a new invoice.
