### PR TITLE
Manually override Ruby's SSL defaults when making Stripe requests

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -186,8 +186,36 @@ module Stripe
     end
   end
 
+  options = OpenSSL::SSL::OP_ALL | OpenSSL::SSL::OP_NO_SSLv2
+  if defined?(OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS)
+    options &= ~OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
+  end
+  if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
+    options |= OpenSSL::SSL::OP_NO_COMPRESSION
+  end
+  IMPROVED_SSL_DEFAULT_PARAMS = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.merge(
+    :ciphers => "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2",
+    :options => options
+    )
+
+  def self.with_better_ssl
+    # Ruby's default SSL configuration is ridiculously bad. Let's make
+    # it better
+    orig_default_params = OpenSSL::SSL::SSLContext.send(:const_get, :DEFAULT_PARAMS)
+    begin
+      OpenSSL::SSL::SSLContext.send(:remove_const, :DEFAULT_PARAMS)
+      OpenSSL::SSL::SSLContext.send(:const_set, :DEFAULT_PARAMS, IMPROVED_SSL_DEFAULT_PARAMS)
+      yield
+    ensure
+      OpenSSL::SSL::SSLContext.send(:remove_const, :DEFAULT_PARAMS)
+      OpenSSL::SSL::SSLContext.send(:const_set, :DEFAULT_PARAMS, orig_default_params)
+    end
+  end
+
   def self.execute_request(opts)
-    RestClient::Request.execute(opts)
+    with_better_ssl do
+      RestClient::Request.execute(opts)
+    end
   end
 
   def self.parse(response)


### PR DESCRIPTION
The Ruby maintainers are in the middle of a bit of a kerfluffle about the SSL defaults (which are...fine as long as you're running a recent Linux release or Mavericks and...aren't being man-in-the-middle'd)

As long as Ruby upstream is failing to take action, we're really in a position where we should be protecting our users ourselves.

This overrides Ruby's default parameters for new SSL_CTX objects for the duration of a Stripe API request. Specifically, it constrains the cipher suite list and disables SSLv2, on the off chance it's available.

Thanks to @jmhodges for making us aware of these specific issues, and more generally for his noble crusade for better SSL configurations.

@ab Could you take a look at this? I'm pretty unhappy about having to do this, but I'm not sure I see a better option.
