### PR TITLE
Allow save to take opts

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -1,8 +1,7 @@
 module Stripe
   module APIOperations
     module Update
-      def save(opts={}, api_key=nil)
-        api_key ||= @api_key
+      def save(opts={})
         values = serialize_params(self).merge(opts)
 
         if @values[:metadata]
@@ -12,8 +11,8 @@ module Stripe
         if values.length > 0
           values.delete(:id)
 
-          response, key = Stripe.request(:post, url, api_key, values)
-          refresh_from(response, key)
+          response, api_key = Stripe.request(:post, url, @api_key, values)
+          refresh_from(response, api_key)
         end
         self
       end


### PR DESCRIPTION
Allow `#save` to take opts so we can expand on the results.

Fixes #78
