### PR TITLE
Add a length method to ListObject.

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -1,6 +1,5 @@
 module Stripe
   class ListObject < StripeObject
-
     def [](k)
       case k
       when String, Symbol
@@ -12,6 +11,10 @@ module Stripe
 
     def each(&blk)
       self.data.each(&blk)
+    end
+
+    def length
+      self.data.length
     end
 
     def retrieve(id, api_key=nil)

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -12,5 +12,15 @@ module Stripe
       assert_equal('/v1/charges', all.url)
       assert all.data.kind_of?(Array)
     end
+
+    should "provide the data length" do
+      @mock.expects(:get).returns(test_response({
+        :data   => [test_customer, test_customer],
+        :object => 'list',
+        :url    => '/v1/customers'
+      }))
+
+      assert_equal Stripe::Customer.all.length, 2
+    end
   end
 end


### PR DESCRIPTION
ListObjects behave much like arrays, and so I'd expect the length method to exist. `count` is available via the API results, but it seems that always returns the full number of records, not the number of records in the current list. Yes, I could just use `data.length` instead, but better to take the path of least surprise.

I'd also recommend changing count to be the number of records returned, and change the existing attribute to something like total_count, as (at least in Ruby) count and length are synonyms.
