### PR TITLE
Fix order of assert_equal calls that were backwards

### DIFF
--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -20,10 +20,10 @@ module Stripe
       @mock.expects(:get).once.returns(test_response(test_customer({:mnemonic => "foo"})))
       @mock.expects(:post).once.returns(test_response(test_customer({:mnemonic => "bar"})))
       c = Stripe::Customer.new("test_customer").refresh
-      assert_equal c.mnemonic, "foo"
+      assert_equal "foo", c.mnemonic
       c.mnemonic = "bar"
       c.save
-      assert_equal c.mnemonic, "bar"
+      assert_equal "bar", c.mnemonic
     end
 
     should "create should return a new customer" do

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -20,7 +20,7 @@ module Stripe
 
       @mock.expects(:post).once.with('https://api.stripe.com/v1/invoices/in_test_invoice/pay', nil, '').returns(test_response(test_paid_invoice))
       i.pay
-      assert_equal i.next_payment_attempt, nil
+      assert_equal nil, i.next_payment_attempt
     end
   end
 end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -12,9 +12,9 @@ module Stripe
     should "marshal a stripe object correctly" do
       obj = Stripe::StripeObject.construct_from({ :id => 1, :name => 'Stripe' }, 'apikey')
       m = Marshal.load(Marshal.dump(obj))
-      assert_equal m.id, 1
-      assert_equal m.name, 'Stripe'
-      assert_equal m.api_key, 'apikey'
+      assert_equal 1, m.id
+      assert_equal 'Stripe', m.name
+      assert_equal 'apikey', m.api_key
     end
   end
 end

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -17,7 +17,7 @@ module Stripe
       subscription = customer.subscriptions.first
       subscription.refresh
 
-      assert_equal subscription.id, 'refreshed_subscription'
+      assert_equal 'refreshed_subscription', subscription.id
     end
 
     should "subscriptions should be deletable" do
@@ -38,12 +38,12 @@ module Stripe
 
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.first
-      assert_equal subscription.status, 'trialing'
+      assert_equal 'trialing', subscription.status
 
       subscription.status = 'active'
       subscription.save
 
-      assert_equal subscription.status, 'active'
+      assert_equal 'active', subscription.status
     end
 
     should "create should return a new subscription" do
@@ -52,7 +52,7 @@ module Stripe
 
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.create(:plan => 'silver')
-      assert_equal subscription.id, 'test_new_subscription'
+      assert_equal 'test_new_subscription', subscription.id
     end
 
     should "be able to delete a subscriptions's discount" do


### PR DESCRIPTION
The expected value is the first argument, and the actual value the second. This fixes all instances of `assert_equal` that were backwards.
