### PR TITLE
Add ability to create subscriptions without fetching customer record

### DIFF
--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -41,6 +41,12 @@ module Stripe
       subscription
     end
 
+    def create_subscription(params)
+      response, api_key = Stripe.request(:post, subscriptions_url, @api_key, params)
+      refresh_from({ :subscription => response }, api_key, true)
+      subscription
+    end
+
     def delete_discount
       Stripe.request(:delete, discount_url, @api_key)
       refresh_from({ :discount => nil }, api_key, true)
@@ -54,6 +60,10 @@ module Stripe
 
     def subscription_url
       url + '/subscription'
+    end
+
+    def subscriptions_url
+      url + '/subscriptions'
     end
   end
 end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -64,6 +64,18 @@ module Stripe
       c.cancel_subscription
     end
 
+    should "be able to create a subscription for a customer" do
+      c = Stripe::Customer.new("test_customer")
+
+      @mock.expects(:post).once.with do |url, api_key, params|
+        url == "#{Stripe.api_base}/v1/customers/test_customer/subscriptions" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
+      end.returns(test_response(test_subscription(:plan => 'silver')))
+      s = c.create_subscription({:plan => 'silver'})
+
+      assert_equal 'subscription', s.object
+      assert_equal 'silver', s.plan.identifier
+    end
+
     should "be able to delete a customer's discount" do
       @mock.expects(:get).once.returns(test_response(test_customer))
       c = Stripe::Customer.retrieve("test_customer")


### PR DESCRIPTION
This commit adds `Customer#create_subscription`, which allows a
subscription to be created on a customer without first fetching the
customer record.

Previously:

``` ruby
customer = Stripe::Customer.retrieve('cus_abc123def') # GET request
customer.subscriptions.create(plan: 'cool-plan-1')    # POST request
```

_No alteration has been made to the above method; the preceding
implementation still functions as it did previously._

With `#create_subscription`:

``` ruby
customer = Stripe::Customer.new('cus_abc123def')      # No request
customer.create_subscription(plan: 'cool-plan-1')     # POST request
```

This method removes the initial `GET` request and instead issues a
`POST` directly to create the subscription.

Reference: #120

/cc @jimdanz
