### PR TITLE
Check for @values in StripeObject#method_not_found

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -181,7 +181,7 @@ module Stripe
     end
 
     def respond_to_missing?(symbol, include_private = false)
-      @values.has_key?(symbol) || super
+      @values && @values.has_key?(symbol) || super
     end
   end
 end


### PR DESCRIPTION
Previous to 1.10.0 StripeObjects could be deserialized from YAML without issue. I believe #99 introduced an issue where `@values.has_key?` is called before `@values` is initialized which prevents proper deserialization from occurring. 

This is the backtrace, I got and I've verified this change resolves the issue:

```
rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/stripe-1.10.1/lib/stripe/stripe_object.rb:184:in `respond_to_missing?'
rbenv/versions/2.1.0/lib/ruby/2.1.0/psych/visitors/to_ruby.rb:343:in `respond_to?'
rbenv/versions/2.1.0/lib/ruby/2.1.0/psych/visitors/to_ruby.rb:343:in `init_with'
rbenv/versions/2.1.0/lib/ruby/2.1.0/psych/visitors/to_ruby.rb:336:in `revive'
rbenv/versions/2.1.0/lib/ruby/2.1.0/psych/visitors/to_ruby.rb:201:in `visit_Psych_Nodes_Mapping'
```
