### PR TITLE
Better Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,24 @@
 task :default => [:all]
 
-task :test do
-  ret = true
-  Dir["test/**/*_test.rb"].each do |f|
-    ret = ret && ruby(f, '')
-  end
+def self.dash_r(filenames)
+  filenames.map { |name| "-r #{name}" }.join(" ")
 end
 
+def self.run_tests(*filenames_to_require)
+  sh "ruby -rbundler/setup"                      +# add Bundler
+         " -I lib"                               +# put lib into the load path
+         " #{dash_r filenames_to_require}"       +# the passed in files to require
+         " #{dash_r Dir["./test/**/*_test.rb"]}" +# load tests by requiring their files
+         " -e ''"                                 # no runner file
+end
+
+desc 'Runs the tests'
+task :test do
+  run_tests
+end
+
+desc 'Runs the tests with and without ActiveSupport'
 task :all do
-  Rake::Task["test"].invoke
-  require 'active_support/all'
-  Rake::Task["test"].reenable
-  Rake::Task["test"].invoke
+  run_tests
+  run_tests 'active_support/all'
 end


### PR DESCRIPTION
- Add description so tasks show up in `rake -T`
- Move body of `test` task into a method, the invoke/reenable/invoke
  dance shows that it's not a dependency, it's a method
- The `require 'active_support/all'` was doing nothing, I'm assuming it
  was intended to run the tests again with ActiveSupport loaded, but
  since the tests are running in a separate process, they won't be
  affected by the Rakefile requiring files. I added it with -r so that
  it will affect the test environment.
- Run all tests at once instead of one at a time, this way we don't pay
  the cost of constantly reloading the environment. Takes test time from
  20 seconds to 4.
