### PR TITLE
Don't check blacklist if SSL verification is off

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -87,7 +87,7 @@ module Stripe
                           :ssl_ca_file => @ssl_bundle_path)
     end
 
-    unless @CERTIFICATE_VERIFIED
+    if @verify_ssl_certs and !@CERTIFICATE_VERIFIED
       @CERTIFICATE_VERIFIED = CertificateBlacklist.check_ssl_cert(@api_base, @ssl_bundle_path)
     end
 


### PR DESCRIPTION
It's helpful to be able to test the bindings with instances of the
Stripe API running locally, or running on a server that doesn't support
SSL. When `:verify_ssl_certs` is false, don't check the SSL cert against
the blacklist, as there probably isn't a certificate to check.
