### PR TITLE
update mime-types requirement to allow 1.x and 2.x

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('rest-client', '~> 1.4')
-  s.add_dependency('mime-types', '~> 1.25')
+  s.add_dependency('mime-types', '>= 1.25', '< 3.0')
   s.add_dependency('json', '~> 1.8.1')
 
   s.add_development_dependency('mocha', '~> 0.13.2')


### PR DESCRIPTION
Hi all,

In Rails 4.2, the mail gem is updated which allows mime-types to be updated to 2.x. In my app, the only gem holding on to a mime-types 1.x requirement is stripe.

I changed the requirement to `>= 1.25 && < 3.0`. All the tests pass. I am able to run my app on Rails 4.1.4, mime-types 1.25 as well as Rails 4.2.0.alpha (on master) and mime-types 2.3.

-Nick
