### PR TITLE
Run tests using TestTask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,7 @@
-task :default => [:all]
+require 'rake/testtask'
 
-task :test do
-  ret = true
-  Dir["test/**/*_test.rb"].each do |f|
-    ret = ret && ruby(f, '')
-  end
-end
+task :default => [:test]
 
-task :all do
-  Rake::Task["test"].invoke
-  require 'active_support/all'
-  Rake::Task["test"].reenable
-  Rake::Task["test"].invoke
+Rake::TestTask.new do |t|
+  t.pattern = './test/**/*_test.rb'
 end


### PR DESCRIPTION
- Runs all tests at once instead of one at a time, this way we don't pay
  the cost of constantly reloading the environment. Takes test time from 20
  seconds to 4.
- Removes the separate testing using activesupport/all, which wasn't actually
  doing anything since the tests were running in a separate process.

Thanks to @JoshCheek for surfacing these issues.
