### PR TITLE
Perform SSL blacklist check with a verify_callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Gemfile.lock
 .rvmrc
 Gemfile.lock
+/.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9.2')
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('1.9.2')
   gem 'rest-client', '~> 1.6.8'
   gem 'activesupport', '~> 3.2'
 end

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -96,6 +96,7 @@ module Stripe
             if CertificateBlacklist.ssl_certificate_blacklisted?(store_ctx.current_cert)
               @blacklist_failure = true
               $stderr.puts("Error: " + CertificateBlacklist::FailureMessage)
+              # can't raise here because ruby swallows the exceptions
               false
             else
               true

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -54,8 +54,6 @@ module Stripe
 
   @ssl_bundle_path  = DEFAULT_CA_BUNDLE_PATH
   @verify_ssl_certs = true
-  @CERTIFICATE_VERIFIED = false
-
 
   class << self
     attr_accessor :api_key, :api_base, :verify_ssl_certs, :api_version
@@ -81,15 +79,36 @@ module Stripe
         'email support@stripe.com if you have any questions.)')
     end
 
-    request_opts = { :verify_ssl => false }
+    @blacklist_failure = false
 
-    if ssl_preflight_passed?
-      request_opts.update(:verify_ssl => OpenSSL::SSL::VERIFY_PEER,
-                          :ssl_ca_file => @ssl_bundle_path)
-    end
+    if @verify_ssl_certs
 
-    if @verify_ssl_certs and !@CERTIFICATE_VERIFIED
-      @CERTIFICATE_VERIFIED = CertificateBlacklist.check_ssl_cert(@api_base, @ssl_bundle_path)
+      # for platforms like OS X where SSL verify_callback is broken
+      if @blacklist_failure_fail_requests
+        raise APIConnectionError.new(CertificateBlacklist::FailureMessage)
+      end
+
+      request_opts = {
+        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
+        :ssl_ca_file => @ssl_bundle_path,
+        :ssl_verify_callback => lambda { |preverify_ok, store_ctx|
+          if preverify_ok
+            if CertificateBlacklist.ssl_certificate_blacklisted?(store_ctx.current_cert)
+              @blacklist_failure = true
+              $stderr.puts("Error: " + CertificateBlacklist::FailureMessage)
+              false
+            else
+              true
+            end
+          else
+            # preverify_ok => false
+            false
+          end
+        },
+        :ssl_verify_callback_warnings => false,
+      }
+    else
+      request_opts = {:verify_ssl => false}
     end
 
     params = Util.objects_to_ids(params)
@@ -128,6 +147,18 @@ module Stripe
       end
     rescue RestClient::Exception, Errno::ECONNREFUSED => e
       handle_restclient_error(e)
+    end
+
+    # Handle platforms like OS X that don't respect the SSL verify_callback
+    # return code. If we get here and @blacklist_failure is true, it means that
+    # we really should have bailed out on the last connection. But there's no
+    # point in raising an exception since we already sent the data. Instead
+    # set an instance variable so we fail on the next request.
+    if @blacklist_failure
+      @blacklist_failure_fail_requests = true
+      $stderr.puts "WARNING: SSL verification failed at blacklist check."
+      $stderr.puts "It looks like you're on a platform like OS X where SSL" +
+        " verify_callback doesn't work. The next request will raise an error."
     end
 
     [parse(response), api_key]

--- a/lib/stripe/certificate_blacklist.rb
+++ b/lib/stripe/certificate_blacklist.rb
@@ -1,28 +1,37 @@
 require 'uri'
 require 'digest/sha1'
+require 'set'
 
 module Stripe
   module CertificateBlacklist
 
-    BLACKLIST = {
-      "api.stripe.com" => [
-        '05c0b3643694470a888c6e7feb5c9e24e823dc53',
-      ],
-      "revoked.stripe.com" => [
-        '5b7dc7fbc98d78bf76d4d4fa6f597a0c901fad5c',
-      ]
-    }
+    BLACKLIST = Set.new([
+      '05c0b3643694470a888c6e7feb5c9e24e823dc53', # api.stripe.com
+      '5b7dc7fbc98d78bf76d4d4fa6f597a0c901fad5c', # revoked.stripe.com
+    ])
+
+    FailureMessage = \
+      "Invalid server certificate. You tried to connect to a server that " \
+      "has a revoked SSL certificate, which means we cannot securely send " \
+      "data to that server. Please email support@stripe.com if you need " \
+      "help connecting to the correct API server."
+
+    def self.ssl_certificate_blacklisted?(certificate)
+      fingerprint = Digest::SHA1.hexdigest(certificate.to_der)
+
+      return BLACKLIST.include?(fingerprint)
+    end
 
     # Preflight the SSL certificate presented by the backend. This isn't 100%
     # bulletproof, in that we're not actually validating the transport used to
     # communicate with Stripe, merely that the first attempt to does not use a
     # revoked certificate.
-
+    #
     # Unfortunately the interface to OpenSSL doesn't make it easy to check the
     # certificate before sending potentially sensitive data on the wire. This
     # approach raises the bar for an attacker significantly.
-
-    def self.check_ssl_cert(uri, ca_file)
+    #
+    def self.check_ssl_cert_preflight(uri, ca_file)
       uri = URI.parse(uri)
 
       sock = TCPSocket.new(uri.host, uri.port)
@@ -33,18 +42,8 @@ module Stripe
       socket = OpenSSL::SSL::SSLSocket.new(sock, ctx)
       socket.connect
 
-      certificate = socket.peer_cert.to_der
-      fingerprint = Digest::SHA1.hexdigest(certificate)
-
-      if blacklisted_certs = BLACKLIST[uri.host]
-        if blacklisted_certs.include?(fingerprint)
-          raise APIConnectionError.new(
-            "Invalid server certificate. You tried to connect to a server that" +
-            "has a revoked SSL certificate, which means we cannot securely send" +
-            "data to that server. Please email support@stripe.com if you need" +
-            "help connecting to the correct API server."
-          )
-        end
+      if ssl_certificate_blacklisted?(socket.peer_cert)
+        raise APIConnectionError.new(FailureMessage)
       end
 
       socket.close

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://stripe.com/api'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '>= 1.6.8', '< 2.0')
   s.add_dependency('mime-types', '>= 1.25', '< 3.0')
   s.add_dependency('json', '~> 1.8.1')
 

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,6 @@ spec = Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('rest-client', '>= 1.6.8', '< 2.0')
-  s.add_dependency('mime-types', '>= 1.25', '< 3.0')
   s.add_dependency('json', '~> 1.8.1')
 
   s.add_development_dependency('mocha', '~> 0.13.2')

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -19,6 +19,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('shoulda', '~> 3.4.0')
   s.add_development_dependency('test-unit')
   s.add_development_dependency('rake')
+  s.add_development_dependency('pry')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/test/stripe/certificate_blacklist_test.rb
+++ b/test/stripe/certificate_blacklist_test.rb
@@ -5,14 +5,14 @@ module Stripe
   class CertificateBlacklistTest < Test::Unit::TestCase
     should "not trust revoked certificates" do
       assert_raises(Stripe::APIConnectionError) {
-        Stripe::CertificateBlacklist.check_ssl_cert("https://revoked.stripe.com:444",
-                                                    Stripe::DEFAULT_CA_BUNDLE_PATH)
+        Stripe::CertificateBlacklist.check_ssl_cert_preflight(
+          "https://revoked.stripe.com:444", Stripe::DEFAULT_CA_BUNDLE_PATH)
       }
     end
 
     should "trust api.stripe.com" do
-      assert_true Stripe::CertificateBlacklist.check_ssl_cert("https://api.stripe.com",
-                                                              Stripe::DEFAULT_CA_BUNDLE_PATH)
+      assert_true Stripe::CertificateBlacklist.check_ssl_cert_preflight(
+        "https://api.stripe.com", Stripe::DEFAULT_CA_BUNDLE_PATH)
     end
   end
 end


### PR DESCRIPTION
This replaces our preflight check with one that actually tests the SSL certificate being used for the connection.

On OS X, which monkey patches OpenSSL to ignore the results of the SSL `verify_callback`, we print a warning and fail subsequent requests.

We still need tests before this can be merged. Adding this PR now for comments on the rest of the code.