### PR TITLE
Adding inherent pagination support to ListObject

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -11,7 +11,18 @@ module Stripe
     end
 
     def each(&blk)
-      self.data.each(&blk)
+      current_list = self
+      Enumerator.new do |yielder|
+        loop do
+          params = {}
+          current_list.data.each do |obj|
+            yielder.yield obj
+            params[:starting_after] = obj.id
+          end
+          raise StopIteration unless current_list[:has_more]
+          current_list = self.all(params)
+        end
+      end.each(&blk)
     end
 
     def retrieve(id, api_key=nil)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -288,6 +288,34 @@ module Stripe
         assert c[0].card.kind_of?(Stripe::StripeObject) && c[0].card.object == 'card'
       end
 
+      context "pagination" do
+        should "fetch the first page initially" do
+          @mock.expects(:get).once.returns(test_response(test_customer_array_page_1))
+          customers = Stripe::Customer.all
+        end
+
+        should "not fetch subsequent pages unless necessary" do
+          @mock.expects(:get).once.returns(test_response(test_customer_array_page_1))
+          customers = Stripe::Customer.all
+          total_seen = 0
+          customers.each_with_index do |c, i|
+            total_seen += 1
+            break if i == 2
+          end
+          assert_equal 3, total_seen
+        end
+
+        should "fetch subsequent pages when iterating" do
+          @mock.expects(:get).twice.returns(test_response(test_customer_array_page_1), test_response(test_customer_array_page_2))
+          customers = Stripe::Customer.all
+          total_seen = 0
+          customers.each_with_index do |c, i|
+            total_seen += 1
+          end
+          assert_equal 4, total_seen
+        end
+      end
+
       context "error checking" do
 
         should "404s should raise an InvalidRequestError" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -140,6 +140,24 @@ def test_customer_array
   }
 end
 
+def test_customer_array_page_1
+  {
+    :data => [test_customer(id: 'cus_1'), test_customer(id: 'cus_2'), test_customer(id: 'cus_3')],
+    :object => 'list',
+    :url => '/v1/customers',
+    :has_more => true
+  }
+end
+
+def test_customer_array_page_2
+  {
+    :data => [test_customer(id: 'cus_4')],
+    :object => 'list',
+    :url => '/v1/customers',
+    :has_more => false
+  }
+end
+
 def test_charge(params={})
   id = params[:id] || 'ch_test_charge'
   {


### PR DESCRIPTION
The caller shouldn't have to know about the fact that the API is paginated.  Instead, iterating over a StripeList should automatically fetch data lazily.

This is a first stab at addressing the issue.  The following now works as expected:

```ruby
Stripe::Customer.all.each do |cus|
  # do something with cus
  break if some_condition
end

count = Stripe::Customer.all.count
customers = Stripe::Customer.all.to_a
```

but calling `Stripe::Customer.all.data`, will still return only the first page of results.  I'm happy to flesh out the functionality, but I'd love to get some feedback first.

Thanks!
Tony