### PR TITLE
Update minimum ruby version requirement to 1.9.2

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,8 +13,7 @@ If you want to build the gem from source:
 
 == Requirements
 
-* Ruby 1.8.7 or above. (Ruby 1.8.6 may work if you load
-  ActiveSupport.)
+* Ruby 1.9.2 or above.
 * rest-client, json
 
 == Mirrors


### PR DESCRIPTION
The last version I could find that 'gem install's to ruby 1.8.7 was 1.5.22 from November 2011.

Everything after that gives:
ERROR:  Error installing stripe:
    rest-client requires Ruby version >= 1.9.2.
