### PR TITLE
Consistently use symbols for hash keys

### DIFF
--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -63,7 +63,7 @@ module Stripe
         assert_equal(401, e.http_status)
         assert_equal(true, !!e.http_body)
         assert_equal(true, !!e.json_body[:error][:message])
-        assert_equal(test_invalid_api_key_error['error']['message'], e.json_body[:error][:message])
+        assert_equal(test_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
       end
     end
 

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -363,20 +363,20 @@ module Stripe
 
     def test_invalid_api_key_error
       {
-        "error" => {
-          "type" => "invalid_request_error",
-          "message" => "Invalid API Key provided: invalid"
+        :error => {
+          :type => "invalid_request_error",
+          :message => "Invalid API Key provided: invalid"
         }
       }
     end
 
     def test_invalid_exp_year_error
       {
-        "error" => {
-          "code" => "invalid_expiry_year",
-          "param" => "exp_year",
-          "type" => "card_error",
-          "message" => "Your card's expiration year is invalid"
+        :error => {
+          :code => "invalid_expiry_year",
+          :param => "exp_year",
+          :type => "card_error",
+          :message => "Your card's expiration year is invalid"
         }
       }
     end


### PR DESCRIPTION
- Updated Hash keys to symbols to match the rest of the test helper file
