### PR TITLE
Specify SSL version for RestClient

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -197,7 +197,7 @@ module Stripe
   end
 
   def self.execute_request(opts)
-    RestClient::Request.execute(opts)
+    RestClient::Request.execute(opts.merge(ssl_version: :SSLv23))
   end
 
   def self.parse(response)


### PR DESCRIPTION
Taken from https://www.petekeen.net/stripe-ruby-sslv3-deprecated

There have been way too many cases of people not being able to fix sslv3 issues with Stripe ruby after all the possible updates they'e tried / are able to do. Ruby has clearly not done enough to handle it, so I think Stripe should just bite the bullet.