### PR TITLE
Add per-request headers

### DIFF
--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -2,8 +2,8 @@ module Stripe
   module APIOperations
     module Create
       module ClassMethods
-        def create(params={}, api_key=nil)
-          response, api_key = Stripe.request(:post, self.url, api_key, params)
+        def create(params={}, api_key=nil, headers={})
+          response, api_key = Stripe.request(:post, self.url, api_key, params, headers)
           Util.convert_to_stripe_object(response, api_key)
         end
       end

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -1,8 +1,8 @@
 module Stripe
   module APIOperations
     module Delete
-      def delete(params = {})
-        response, api_key = Stripe.request(:delete, url, @api_key, params)
+      def delete(params = {}, api_key=nil, headers={})
+        response, api_key = Stripe.request(:delete, url, api_key, params, headers)
         refresh_from(response, api_key)
       end
     end

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -2,8 +2,8 @@ module Stripe
   module APIOperations
     module List
       module ClassMethods
-        def all(filters={}, api_key=nil)
-          response, api_key = Stripe.request(:get, url, api_key, filters)
+        def all(filters={}, api_key=nil, headers={})
+          response, api_key = Stripe.request(:get, url, api_key, filters, headers)
           Util.convert_to_stripe_object(response, api_key)
         end
       end

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -4,18 +4,18 @@ module Stripe
     include Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
-    def refund(params={})
-      response, api_key = Stripe.request(:post, refund_url, @api_key, params)
+    def refund(params={}, headers={})
+      response, api_key = Stripe.request(:post, refund_url, @api_key, params, headers)
       refresh_from(response, api_key)
     end
 
-    def capture(params={})
-      response, api_key = Stripe.request(:post, capture_url, @api_key, params)
+    def capture(params={}, headers={})
+      response, api_key = Stripe.request(:post, capture_url, @api_key, params, headers)
       refresh_from(response, api_key)
     end
 
-    def update_dispute(params)
-      response, api_key = Stripe.request(:post, dispute_url, @api_key, params)
+    def update_dispute(params={}, headers={})
+      response, api_key = Stripe.request(:post, dispute_url, @api_key, params, headers)
       refresh_from({ :dispute => response }, api_key, true)
       dispute
     end

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -29,20 +29,20 @@ module Stripe
       Invoice.create(params.merge(:customer => id), @api_key)
     end
 
-    def cancel_subscription(params={})
-      response, api_key = Stripe.request(:delete, subscription_url, @api_key, params)
+    def cancel_subscription(params={}, headers={})
+      response, api_key = Stripe.request(:delete, subscription_url, @api_key, params, headers)
       refresh_from({ :subscription => response }, api_key, true)
       subscription
     end
 
-    def update_subscription(params)
-      response, api_key = Stripe.request(:post, subscription_url, @api_key, params)
+    def update_subscription(params={}, headers={})
+      response, api_key = Stripe.request(:post, subscription_url, @api_key, params, headers)
       refresh_from({ :subscription => response }, api_key, true)
       subscription
     end
 
-    def create_subscription(params)
-      response, api_key = Stripe.request(:post, subscriptions_url, @api_key, params)
+    def create_subscription(params={}, headers={})
+      response, api_key = Stripe.request(:post, subscriptions_url, @api_key, params, headers)
       refresh_from({ :subscription => response }, api_key, true)
       subscription
     end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -114,6 +114,15 @@ module Stripe
     end
 
     context "with valid credentials" do
+      should "send along additional headers" do
+        Stripe.expects(:execute_request).with do |opts|
+          opts[:headers][:foo] == 'bar'
+        end.returns(test_response(test_charge))
+
+        Stripe::Charge.create({:card => {:number => '4242424242424242'}},
+          'local', {:foo => 'bar'})
+      end
+
       should "urlencode values in GET params" do
         response = test_response(test_charge_array)
         @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test%20customer", nil, nil).returns(response)


### PR DESCRIPTION
Just like per-request API keys, you can now add headers for individual method calls
