### PR TITLE
Rename TestData method names so they aren't tests

### DIFF
--- a/test/fake_data.rb
+++ b/test/fake_data.rb
@@ -1,6 +1,6 @@
 module Stripe
-  module TestData
-    def test_response(body, code=200)
+  module FakeData
+    def make_response(body, code=200)
       # When an exception is raised, restclient clobbers method_missing.  Hence we
       # can't just use the stubs interface.
       body = JSON.generate(body) if !(body.kind_of? String)
@@ -11,7 +11,7 @@ module Stripe
       m
     end
 
-    def test_balance(params={})
+    def make_balance(params={})
       {
         :pending => [
           {:amount => 12345, :currency => "usd"}
@@ -24,7 +24,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_balance_transaction(params={})
+    def make_balance_transaction(params={})
       {
         :amount => 100,
         :net => 41,
@@ -39,61 +39,61 @@ module Stripe
       }.merge(params)
     end
 
-    def test_balance_transaction_array
+    def make_balance_transaction_array
       {
-        :data => [test_balance_transaction, test_balance_transaction, test_balance_transaction],
+        :data => [make_balance_transaction, make_balance_transaction, make_balance_transaction],
         :object => "list",
         :url => "/v1/balance/history"
       }
     end
 
-    def test_application_fee(params={})
+    def make_application_fee(params={})
       id = params[:id] || 'fee_test_fee'
       {
         :refunded => false,
         :amount => 100,
-        :application => "ca_test_application",
+        :application => "ca_make_application",
         :user => "acct_test_user",
-        :charge => "ch_test_charge",
+        :charge => "ch_make_charge",
         :id => id,
         :livemode => false,
         :currency => "usd",
         :object => "application_fee",
-        :refunds => test_application_fee_refund_array(id),
+        :refunds => make_application_fee_refund_array(id),
         :created => 1304114826
       }.merge(params)
     end
 
-    def test_application_fee_refund(params = {})
+    def make_application_fee_refund(params = {})
       {
         :object => 'fee_refund',
         :amount => 30,
         :currency => "usd",
         :created => 1308595038,
         :id => "ref_test_app_fee_refund",
-        :fee => "ca_test_application",
+        :fee => "ca_make_application",
         :metadata => {}
       }.merge(params)
     end
 
-    def test_application_fee_array
+    def make_application_fee_array
       {
-        :data => [test_application_fee, test_application_fee, test_application_fee],
+        :data => [make_application_fee, make_application_fee, make_application_fee],
         :object => 'list',
         :url => '/v1/application_fees'
       }
     end
 
-    def test_application_fee_refund_array(fee_id)
+    def make_application_fee_refund_array(fee_id)
       {
-        :data => [test_application_fee_refund, test_application_fee_refund, test_application_fee_refund],
+        :data => [make_application_fee_refund, make_application_fee_refund, make_application_fee_refund],
         :object => 'list',
         :url => '/v1/application_fees/' + fee_id + '/refunds'
       }
     end
 
-    def test_customer(params={})
-      id = params[:id] || 'c_test_customer'
+    def make_customer(params={})
+      id = params[:id] || 'c_make_customer'
       {
         :subscription_history => [],
         :bills => [],
@@ -101,24 +101,24 @@ module Stripe
         :livemode => false,
         :object => "customer",
         :id => id,
-        :default_card => "cc_test_card",
+        :default_card => "cc_make_card",
         :created => 1304114758,
-        :cards => test_card_array(id),
+        :cards => make_card_array(id),
         :metadata => {},
-        :subscriptions => test_subscription_array(id)
+        :subscriptions => make_subscription_array(id)
       }.merge(params)
     end
 
-    def test_customer_array
+    def make_customer_array
       {
-        :data => [test_customer, test_customer, test_customer],
+        :data => [make_customer, make_customer, make_customer],
         :object => 'list',
         :url => '/v1/customers'
       }
     end
 
-    def test_charge(params={})
-      id = params[:id] || 'ch_test_charge'
+    def make_charge(params={})
+      id = params[:id] || 'ch_make_charge'
       {
         :refunded => false,
         :paid => true,
@@ -129,7 +129,7 @@ module Stripe
           :exp_month => 11,
           :country => "US",
           :exp_year => 2012,
-          :id => "cc_test_card",
+          :id => "cc_make_card",
           :object => "card"
         },
         :id => id,
@@ -138,53 +138,53 @@ module Stripe
         :currency => "usd",
         :object => "charge",
         :created => 1304114826,
-        :refunds => test_refund_array(id),
+        :refunds => make_refund_array(id),
         :metadata => {}
       }.merge(params)
     end
 
-    def test_charge_array
+    def make_charge_array
       {
-        :data => [test_charge, test_charge, test_charge],
+        :data => [make_charge, make_charge, make_charge],
         :object => 'list',
         :url => '/v1/charges'
       }
     end
 
-    def test_card_array(customer_id)
+    def make_card_array(customer_id)
       {
-        :data => [test_card, test_card, test_card],
+        :data => [make_card, make_card, make_card],
         :object => 'list',
         :url => '/v1/customers/' + customer_id + '/cards'
       }
     end
 
-    def test_card(params={})
+    def make_card(params={})
       {
         :type => "Visa",
         :last4 => "4242",
         :exp_month => 11,
         :country => "US",
         :exp_year => 2012,
-        :id => "cc_test_card",
-        :customer => 'c_test_customer',
+        :id => "cc_make_card",
+        :customer => 'c_make_customer',
         :object => "card"
       }.merge(params)
     end
 
-    def test_coupon(params={})
+    def make_coupon(params={})
       {
         :duration => 'repeating',
         :duration_in_months => 3,
         :percent_off => 25,
-        :id => "co_test_coupon",
+        :id => "co_make_coupon",
         :object => "coupon",
         :metadata => {},
       }.merge(params)
     end
 
     #FIXME nested overrides would be better than hardcoding plan_id
-    def test_subscription(params = {})
+    def make_subscription(params = {})
       plan = params.delete(:plan) || 'gold'
       {
         :current_period_end => 1308681468,
@@ -201,43 +201,43 @@ module Stripe
         :object => "subscription",
         :trial_start => 1308595038,
         :trial_end => 1308681468,
-        :customer => "c_test_customer",
-        :id => 's_test_subscription'
+        :customer => "c_make_customer",
+        :id => 's_make_subscription'
       }.merge(params)
     end
 
-    def test_refund(params = {})
+    def make_refund(params = {})
       {
         :object => 'refund',
         :amount => 30,
         :currency => "usd",
         :created => 1308595038,
-        :id => "ref_test_refund",
-        :charge => "ch_test_charge",
+        :id => "ref_make_refund",
+        :charge => "ch_make_charge",
         :metadata => {}
       }.merge(params)
     end
 
-    def test_subscription_array(customer_id)
+    def make_subscription_array(customer_id)
       {
-        :data => [test_subscription, test_subscription, test_subscription],
+        :data => [make_subscription, make_subscription, make_subscription],
         :object => 'list',
         :url => '/v1/customers/' + customer_id + '/subscriptions'
       }
     end
 
-    def test_refund_array(charge_id)
+    def make_refund_array(charge_id)
       {
-        :data => [test_refund, test_refund, test_refund],
+        :data => [make_refund, make_refund, make_refund],
         :object => 'list',
         :url => '/v1/charges/' + charge_id + '/refunds'
       }
     end
 
 
-    def test_invoice
+    def make_invoice
       {
-        :id => 'in_test_invoice',
+        :id => 'in_make_invoice',
         :object => 'invoice',
         :livemode => false,
         :amount_due => 1000,
@@ -245,20 +245,20 @@ module Stripe
         :attempted => false,
         :closed => false,
         :currency => 'usd',
-        :customer => 'c_test_customer',
+        :customer => 'c_make_customer',
         :date => 1349738950,
         :lines => {
           "invoiceitems" => [
             {
-              :id => 'ii_test_invoice_item',
+              :id => 'ii_make_invoice_item',
               :object => '',
               :livemode => false,
               :amount => 1000,
               :currency => 'usd',
-              :customer => 'c_test_customer',
+              :customer => 'c_make_customer',
               :date => 1349738950,
               :description => "A Test Invoice Item",
-              :invoice => 'in_test_invoice'
+              :invoice => 'in_make_invoice'
             },
           ],
         },
@@ -275,36 +275,36 @@ module Stripe
       }
     end
 
-    def test_paid_invoice
-      test_invoice.merge({
+    def make_paid_invoice
+      make_invoice.merge({
           :attempt_count => 1,
           :attempted => true,
           :closed => true,
           :paid => true,
-          :charge => 'ch_test_charge',
+          :charge => 'ch_make_charge',
           :ending_balance => 0,
           :next_payment_attempt => nil,
         })
     end
 
-    def test_invoice_customer_array
+    def make_invoice_customer_array
       {
-        :data => [test_invoice],
+        :data => [make_invoice],
         :object => 'list',
-        :url => '/v1/invoices?customer=test_customer'
+        :url => '/v1/invoices?customer=make_customer'
       }
     end
 
-    def test_recipient(params={})
-      id = params[:id] || 'rp_test_recipient'
+    def make_recipient(params={})
+      id = params[:id] || 'rp_make_recipient'
       {
         :name => "Stripe User",
         :type => "individual",
         :livemode => false,
         :object => "recipient",
-        :id => "rp_test_recipient",
-        :cards => test_card_array(id),
-        :default_card => "debit_test_card",
+        :id => "rp_make_recipient",
+        :cards => make_card_array(id),
+        :default_card => "debit_make_card",
         :active_account => {
           :last4 => "6789",
           :bank_name => "STRIPE TEST BANK",
@@ -317,15 +317,15 @@ module Stripe
       }.merge(params)
     end
 
-    def test_recipient_array
+    def make_recipient_array
       {
-        :data => [test_recipient, test_recipient, test_recipient],
+        :data => [make_recipient, make_recipient, make_recipient],
         :object => 'list',
         :url => '/v1/recipients'
       }
     end
 
-    def test_transfer(params={})
+    def make_transfer(params={})
       {
         :status => 'pending',
         :amount => 100,
@@ -335,10 +335,10 @@ module Stripe
           :bank_name => 'STRIPE TEST BANK',
           :last4 => '6789'
         },
-        :recipient => 'test_recipient',
+        :recipient => 'make_recipient',
         :fee => 0,
         :fee_details => [],
-        :id => "tr_test_transfer",
+        :id => "tr_make_transfer",
         :livemode => false,
         :currency => "usd",
         :object => "transfer",
@@ -347,21 +347,21 @@ module Stripe
       }.merge(params)
     end
 
-    def test_transfer_array
+    def make_transfer_array
       {
-        :data => [test_transfer, test_transfer, test_transfer],
+        :data => [make_transfer, make_transfer, make_transfer],
         :object => 'list',
         :url => '/v1/transfers'
       }
     end
 
-    def test_canceled_transfer
-      test_transfer.merge({
+    def make_canceled_transfer
+      make_transfer.merge({
         :status => 'canceled'
       })
     end
 
-    def test_invalid_api_key_error
+    def make_invalid_api_key_error
       {
         :error => {
           :type => "invalid_request_error",
@@ -370,7 +370,7 @@ module Stripe
       }
     end
 
-    def test_invalid_exp_year_error
+    def make_invalid_exp_year_error
       {
         :error => {
           :code => "invalid_expiry_year",
@@ -381,7 +381,7 @@ module Stripe
       }
     end
 
-    def test_missing_id_error
+    def make_missing_id_error
       {
         :error => {
           :param => "id",
@@ -391,7 +391,7 @@ module Stripe
       }
     end
 
-    def test_api_error
+    def make_api_error
       {
         :error => {
           :type => "api_error"
@@ -399,10 +399,10 @@ module Stripe
       }
     end
 
-    def test_delete_discount_response
+    def make_delete_discount_response
       {
         :deleted => true,
-        :id => "di_test_coupon"
+        :id => "di_make_coupon"
       }
     end
   end

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -4,7 +4,7 @@ module Stripe
   class AccountTest < Test::Unit::TestCase
     should "account should be retrievable" do
       resp = {:email => "test+bindings@stripe.com", :charge_enabled => false, :details_submitted => false}
-      @mock.expects(:get).once.returns(test_response(resp))
+      @mock.expects(:get).once.returns(make_response(resp))
       a = Stripe::Account.retrieve
       assert_equal "test+bindings@stripe.com", a.email
       assert !a.charge_enabled

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -20,33 +20,33 @@ module Stripe
     should "setting an attribute should not cause a network request" do
       @mock.expects(:get).never
       @mock.expects(:post).never
-      c = Stripe::Customer.new("test_customer");
+      c = Stripe::Customer.new("make_customer");
       c.card = {:id => "somecard", :object => "card"}
     end
 
     should "accessing id should not issue a fetch" do
       @mock.expects(:get).never
-      c = Stripe::Customer.new("test_customer");
+      c = Stripe::Customer.new("make_customer");
       c.id
     end
 
     should "not specifying api credentials should raise an exception" do
       Stripe.api_key = nil
       assert_raises Stripe::AuthenticationError do
-        Stripe::Customer.new("test_customer").refresh
+        Stripe::Customer.new("make_customer").refresh
       end
     end
 
     should "specifying api credentials containing whitespace should raise an exception" do
       Stripe.api_key = "key "
       assert_raises Stripe::AuthenticationError do
-        Stripe::Customer.new("test_customer").refresh
+        Stripe::Customer.new("make_customer").refresh
       end
     end
 
     should "specifying invalid api credentials should raise an exception" do
       Stripe.api_key = "invalid"
-      response = test_response(test_invalid_api_key_error, 401)
+      response = make_response(make_invalid_api_key_error, 401)
       assert_raises Stripe::AuthenticationError do
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 401))
         Stripe::Customer.retrieve("failing_customer")
@@ -55,7 +55,7 @@ module Stripe
 
     should "AuthenticationErrors should have an http status, http body, and JSON body" do
       Stripe.api_key = "invalid"
-      response = test_response(test_invalid_api_key_error, 401)
+      response = make_response(make_invalid_api_key_error, 401)
       begin
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 401))
         Stripe::Customer.retrieve("failing_customer")
@@ -63,7 +63,7 @@ module Stripe
         assert_equal(401, e.http_status)
         assert_equal(true, !!e.http_body)
         assert_equal(true, !!e.json_body[:error][:message])
-        assert_equal(test_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
+        assert_equal(make_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
       end
     end
 
@@ -72,7 +72,7 @@ module Stripe
         should "use the per-object credential when creating" do
           Stripe.expects(:execute_request).with do |opts|
             opts[:headers][:authorization] == 'Bearer sk_test_local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
           Stripe::Charge.create({:card => {:number => '4242424242424242'}},
             'sk_test_local')
@@ -91,7 +91,7 @@ module Stripe
         should "use the per-object credential when creating" do
           Stripe.expects(:execute_request).with do |opts|
             opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
           Stripe::Charge.create({:card => {:number => '4242424242424242'}},
             'local')
@@ -99,15 +99,15 @@ module Stripe
 
         should "use the per-object credential when retrieving and making other calls" do
           Stripe.expects(:execute_request).with do |opts|
-            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge" &&
+            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_make_charge" &&
               opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
           Stripe.expects(:execute_request).with do |opts|
-            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge/refund" &&
+            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_make_charge/refund" &&
               opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
-          ch = Stripe::Charge.retrieve('ch_test_charge', 'local')
+          ch = Stripe::Charge.retrieve('ch_make_charge', 'local')
           ch.refund
         end
       end
@@ -117,30 +117,30 @@ module Stripe
       should "send along additional headers" do
         Stripe.expects(:execute_request).with do |opts|
           opts[:headers][:foo] == 'bar'
-        end.returns(test_response(test_charge))
+        end.returns(make_response(make_charge))
 
         Stripe::Charge.create({:card => {:number => '4242424242424242'}},
           'local', {:foo => 'bar'})
       end
 
       should "urlencode values in GET params" do
-        response = test_response(test_charge_array)
+        response = make_response(make_charge_array)
         @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test%20customer", nil, nil).returns(response)
         charges = Stripe::Charge.all(:customer => 'test customer').data
         assert charges.kind_of? Array
       end
 
       should "construct URL properly with base query parameters" do
-        response = test_response(test_invoice_customer_array)
-        @mock.expects(:get).with("#{Stripe.api_base}/v1/invoices?customer=test_customer", nil, nil).returns(response)
-        invoices = Stripe::Invoice.all(:customer => 'test_customer')
+        response = make_response(make_invoice_customer_array)
+        @mock.expects(:get).with("#{Stripe.api_base}/v1/invoices?customer=make_customer", nil, nil).returns(response)
+        invoices = Stripe::Invoice.all(:customer => 'make_customer')
 
-        @mock.expects(:get).with("#{Stripe.api_base}/v1/invoices?customer=test_customer&paid=true", nil, nil).returns(response)
+        @mock.expects(:get).with("#{Stripe.api_base}/v1/invoices?customer=make_customer&paid=true", nil, nil).returns(response)
         invoices.all(:paid => true)
       end
 
       should "a 400 should give an InvalidRequestError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 400)
+        response = make_response(make_missing_id_error, 400)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -152,7 +152,7 @@ module Stripe
       end
 
       should "a 401 should give an AuthenticationError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 401)
+        response = make_response(make_missing_id_error, 401)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -164,7 +164,7 @@ module Stripe
       end
 
       should "a 402 should give a CardError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 402)
+        response = make_response(make_missing_id_error, 402)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -176,7 +176,7 @@ module Stripe
       end
 
       should "a 404 should give an InvalidRequestError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 404)
+        response = make_response(make_missing_id_error, 404)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -193,19 +193,19 @@ module Stripe
           query = CGI.parse(uri.query)
           (url =~ %r{^#{Stripe.api_base}/v1/charges?} &&
            query.keys.sort == ['offset', 'sad'])
-        end.returns(test_response({ :count => 1, :data => [test_charge] }))
+        end.returns(make_response({ :count => 1, :data => [make_charge] }))
         Stripe::Charge.all(:count => nil, :offset => 5, :sad => false)
 
         @mock.expects(:post).with do |url, api_key, params|
           url == "#{Stripe.api_base}/v1/charges" &&
             api_key.nil? &&
             CGI.parse(params) == { 'amount' => ['50'], 'currency' => ['usd'] }
-        end.returns(test_response({ :count => 1, :data => [test_charge] }))
+        end.returns(make_response({ :count => 1, :data => [make_charge] }))
         Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
       end
 
       should "requesting with a unicode ID should result in a request" do
-        response = test_response(test_missing_id_error, 404)
+        response = make_response(make_missing_id_error, 404)
         @mock.expects(:get).once.with("#{Stripe.api_base}/v1/customers/%E2%98%83", nil, nil).raises(RestClient::ExceptionWithResponse.new(response, 404))
         c = Stripe::Customer.new("☃")
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
@@ -218,7 +218,7 @@ module Stripe
 
       should "making a GET request with parameters should have a query string and no body" do
         params = { :limit => 1 }
-        @mock.expects(:get).once.with("#{Stripe.api_base}/v1/charges?limit=1", nil, nil).returns(test_response([test_charge]))
+        @mock.expects(:get).once.with("#{Stripe.api_base}/v1/charges?limit=1", nil, nil).returns(make_response([make_charge]))
         Stripe::Charge.all(params)
       end
 
@@ -226,19 +226,19 @@ module Stripe
         params = { :amount => 100, :currency => 'usd', :card => 'sc_token' }
         @mock.expects(:post).once.with do |url, get, post|
           get.nil? && CGI.parse(post) == {'amount' => ['100'], 'currency' => ['usd'], 'card' => ['sc_token']}
-        end.returns(test_response(test_charge))
+        end.returns(make_response(make_charge))
         Stripe::Charge.create(params)
       end
 
       should "loading an object should issue a GET request" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
-        c = Stripe::Customer.new("test_customer")
+        @mock.expects(:get).once.returns(make_response(make_customer))
+        c = Stripe::Customer.new("make_customer")
         c.refresh
       end
 
       should "using array accessors should be the same as the method interface" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
-        c = Stripe::Customer.new("test_customer")
+        @mock.expects(:get).once.returns(make_response(make_customer))
+        c = Stripe::Customer.new("make_customer")
         c.refresh
         assert_equal c.created, c[:created]
         assert_equal c.created, c['created']
@@ -247,23 +247,23 @@ module Stripe
       end
 
       should "accessing a property other than id or parent on an unfetched object should fetch it" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
-        c = Stripe::Customer.new("test_customer")
+        @mock.expects(:get).once.returns(make_response(make_customer))
+        c = Stripe::Customer.new("make_customer")
         c.charges
       end
 
       should "updating an object should issue a POST request with only the changed properties" do
         @mock.expects(:post).with do |url, api_key, params|
-          url == "#{Stripe.api_base}/v1/customers/c_test_customer" && api_key.nil? && CGI.parse(params) == {'description' => ['another_mn']}
-        end.once.returns(test_response(test_customer))
-        c = Stripe::Customer.construct_from(test_customer)
+          url == "#{Stripe.api_base}/v1/customers/c_make_customer" && api_key.nil? && CGI.parse(params) == {'description' => ['another_mn']}
+        end.once.returns(make_response(make_customer))
+        c = Stripe::Customer.construct_from(make_customer)
         c.description = "another_mn"
         c.save
       end
 
       should "updating should merge in returned properties" do
-        @mock.expects(:post).once.returns(test_response(test_customer))
-        c = Stripe::Customer.new("c_test_customer")
+        @mock.expects(:post).once.returns(make_response(make_customer))
+        c = Stripe::Customer.new("c_make_customer")
         c.description = "another_mn"
         c.save
         assert_equal false, c.livemode
@@ -272,9 +272,9 @@ module Stripe
       should "deleting should send no props and result in an object that has no props other deleted" do
         @mock.expects(:get).never
         @mock.expects(:post).never
-        @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/c_test_customer", nil, nil).once.returns(test_response({ "id" => "test_customer", "deleted" => true }))
+        @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/c_make_customer", nil, nil).once.returns(make_response({ "id" => "make_customer", "deleted" => true }))
 
-        c = Stripe::Customer.construct_from(test_customer)
+        c = Stripe::Customer.construct_from(make_customer)
         c.delete
         assert_equal true, c.deleted
 
@@ -284,13 +284,13 @@ module Stripe
       end
 
       should "loading an object with properties that have specific types should instantiate those classes" do
-        @mock.expects(:get).once.returns(test_response(test_charge))
-        c = Stripe::Charge.retrieve("test_charge")
+        @mock.expects(:get).once.returns(make_response(make_charge))
+        c = Stripe::Charge.retrieve("make_charge")
         assert c.card.kind_of?(Stripe::StripeObject) && c.card.object == 'card'
       end
 
       should "loading all of an APIResource should return an array of recursively instantiated objects" do
-        @mock.expects(:get).once.returns(test_response(test_charge_array))
+        @mock.expects(:get).once.returns(make_response(make_charge_array))
         c = Stripe::Charge.all.data
         assert c.kind_of? Array
         assert c[0].kind_of? Stripe::Charge
@@ -300,12 +300,12 @@ module Stripe
       context "error checking" do
 
         should "404s should raise an InvalidRequestError" do
-          response = test_response(test_missing_id_error, 404)
+          response = make_response(make_missing_id_error, 404)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
 
           rescued = false
           begin
-            Stripe::Customer.new("test_customer").refresh
+            Stripe::Customer.new("make_customer").refresh
             assert false #shouldn't get here either
           rescue Stripe::InvalidRequestError => e # we don't use assert_raises because we want to examine e
             rescued = true
@@ -318,12 +318,12 @@ module Stripe
         end
 
         should "5XXs should raise an APIError" do
-          response = test_response(test_api_error, 500)
+          response = make_response(make_api_error, 500)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 500))
 
           rescued = false
           begin
-            Stripe::Customer.new("test_customer").refresh
+            Stripe::Customer.new("make_customer").refresh
             assert false #shouldn't get here either
           rescue Stripe::APIError => e # we don't use assert_raises because we want to examine e
             rescued = true
@@ -334,12 +334,12 @@ module Stripe
         end
 
         should "402s should raise a CardError" do
-          response = test_response(test_invalid_exp_year_error, 402)
+          response = make_response(make_invalid_exp_year_error, 402)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 402))
 
           rescued = false
           begin
-            Stripe::Customer.new("test_customer").refresh
+            Stripe::Customer.new("make_customer").refresh
             assert false #shouldn't get here either
           rescue Stripe::CardError => e # we don't use assert_raises because we want to examine e
             rescued = true

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -3,17 +3,17 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ApplicationFeeRefundTest < Test::Unit::TestCase
     should "refunds should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
 
-      application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
+      application_fee = Stripe::ApplicationFee.retrieve('make_application_fee')
 
       assert application_fee.refunds.first.kind_of?(Stripe::ApplicationFeeRefund)
     end
 
     should "refunds should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_application_fee), test_response(test_application_fee_refund(:id => 'refreshed_refund')))
+      @mock.expects(:get).twice.returns(make_response(make_application_fee), make_response(make_application_fee_refund(:id => 'refreshed_refund')))
 
-      application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
+      application_fee = Stripe::ApplicationFee.retrieve('make_application_fee')
       refund = application_fee.refunds.first
       refund.refresh
 
@@ -21,10 +21,10 @@ module Stripe
     end
 
     should "refunds should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
-      @mock.expects(:post).once.returns(test_response(test_application_fee_refund(:metadata => {'key' => 'value'})))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
+      @mock.expects(:post).once.returns(make_response(make_application_fee_refund(:metadata => {'key' => 'value'})))
 
-      application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
+      application_fee = Stripe::ApplicationFee.retrieve('make_application_fee')
       refund = application_fee.refunds.first
 
       assert_equal nil, refund.metadata['key']
@@ -36,10 +36,10 @@ module Stripe
     end
 
     should "create should return a new refund" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
-      @mock.expects(:post).once.returns(test_response(test_application_fee_refund(:id => 'test_new_refund')))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
+      @mock.expects(:post).once.returns(make_response(make_application_fee_refund(:id => 'test_new_refund')))
 
-      application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
+      application_fee = Stripe::ApplicationFee.retrieve('make_application_fee')
       refund = application_fee.refunds.create(:amount => 20)
       assert_equal 'test_new_refund', refund.id
     end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ApplicationFeeTest < Test::Unit::TestCase
     should "application fees should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee_array))
+      @mock.expects(:get).once.returns(make_response(make_application_fee_array))
       fees = Stripe::ApplicationFee.all
       assert fees.data.kind_of? Array
       fees.each do |fee|
@@ -13,8 +13,8 @@ module Stripe
 
     should "application fees should be refundable" do
       @mock.expects(:get).never
-      @mock.expects(:post).once.returns(test_response({:id => "fee_test_fee", :refunded => true}))
-      fee = Stripe::ApplicationFee.new("test_application_fee")
+      @mock.expects(:post).once.returns(make_response({:id => "fee_test_fee", :refunded => true}))
+      fee = Stripe::ApplicationFee.new("make_application_fee")
       fee.refund
       assert fee.refunded
     end

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ChargeTest < Test::Unit::TestCase
     should "charges should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_charge_array))
+      @mock.expects(:get).once.returns(make_response(make_charge_array))
       c = Stripe::Charge.all
       assert c.data.kind_of? Array
       c.each do |charge|
@@ -13,48 +13,48 @@ module Stripe
 
     should "charges should be refundable" do
       @mock.expects(:get).never
-      @mock.expects(:post).once.returns(test_response({:id => "ch_test_charge", :refunded => true}))
-      c = Stripe::Charge.new("test_charge")
+      @mock.expects(:post).once.returns(make_response({:id => "ch_make_charge", :refunded => true}))
+      c = Stripe::Charge.new("make_charge")
       c.refund
       assert c.refunded
     end
 
     should "charges should not be deletable" do
       assert_raises NoMethodError do
-        @mock.expects(:get).once.returns(test_response(test_charge))
-        c = Stripe::Charge.retrieve("test_charge")
+        @mock.expects(:get).once.returns(make_response(make_charge))
+        c = Stripe::Charge.retrieve("make_charge")
         c.delete
       end
     end
 
     should "charges should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
-      c = Stripe::Charge.new("test_charge")
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
+      c = Stripe::Charge.new("make_charge")
       c.refresh
       c.mnemonic = "New charge description"
       c.save
     end
 
     should "charges should be able to be marked as fraudulent" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
-      c = Stripe::Charge.new("test_charge")
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
+      c = Stripe::Charge.new("make_charge")
       c.refresh
       c.mark_as_fraudulent
     end
 
     should "charges should be able to be marked as safe" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
-      c = Stripe::Charge.new("test_charge")
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
+      c = Stripe::Charge.new("make_charge")
       c.refresh
       c.mark_as_safe
     end
 
     should "charges should have Card objects associated with their Card property" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      c = Stripe::Charge.retrieve("test_charge")
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      c = Stripe::Charge.retrieve("make_charge")
       assert c.card.kind_of?(Stripe::StripeObject) && c.card.object == 'card'
     end
 
@@ -66,7 +66,7 @@ module Stripe
           'card[number]' => ['4242424242424242'],
           'card[exp_month]' => ['11']
         }
-      end.once.returns(test_response(test_charge))
+      end.once.returns(make_response(make_charge))
 
       c = Stripe::Charge.create({
         :amount => 100,

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -3,15 +3,15 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class CouponTest < Test::Unit::TestCase
     should "create should return a new coupon" do
-      @mock.expects(:post).once.returns(test_response(test_coupon))
+      @mock.expects(:post).once.returns(make_response(make_coupon))
       c = Stripe::Coupon.create
-      assert_equal "co_test_coupon", c.id
+      assert_equal "co_make_coupon", c.id
     end
 
     should "coupons should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_coupon))
-      @mock.expects(:post).once.returns(test_response(test_coupon))
-      c = Stripe::Coupon.new("test_coupon")
+      @mock.expects(:get).once.returns(make_response(make_coupon))
+      @mock.expects(:post).once.returns(make_response(make_coupon))
+      c = Stripe::Coupon.new("make_coupon")
       c.refresh
       c.metadata['foo'] = 'bar'
       c.save

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -2,16 +2,16 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class CustomerCardTest < Test::Unit::TestCase
-    CUSTOMER_CARD_URL = '/v1/customers/test_customer/cards/test_card'
+    CUSTOMER_CARD_URL = '/v1/customers/make_customer/cards/make_card'
 
     def customer
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      Stripe::Customer.retrieve('test_customer')
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      Stripe::Customer.retrieve('make_customer')
     end
 
     should "customer cards should be listable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card_array(customer.id)))
+      @mock.expects(:get).once.returns(make_response(make_card_array(customer.id)))
       cards = c.cards.all.data
       assert cards.kind_of? Array
       assert cards[0].kind_of? Stripe::Card
@@ -19,9 +19,9 @@ module Stripe
 
     should "customer cards should have the correct url" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card(
-        :id => 'test_card',
-        :customer => 'test_customer'
+      @mock.expects(:get).once.returns(make_response(make_card(
+        :id => 'make_card',
+        :customer => 'make_customer'
       )))
       card = c.cards.retrieve('card')
       assert_equal CUSTOMER_CARD_URL, card.url
@@ -29,8 +29,8 @@ module Stripe
 
     should "customer cards should be deletable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card))
-      @mock.expects(:delete).once.returns(test_response(test_card(:deleted => true)))
+      @mock.expects(:get).once.returns(make_response(make_card))
+      @mock.expects(:delete).once.returns(make_response(make_card(:deleted => true)))
       card = c.cards.retrieve('card')
       card.delete
       assert card.deleted
@@ -38,8 +38,8 @@ module Stripe
 
     should "customer cards should be updateable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card(:exp_year => "2000")))
-      @mock.expects(:post).once.returns(test_response(test_card(:exp_year => "2100")))
+      @mock.expects(:get).once.returns(make_response(make_card(:exp_year => "2000")))
+      @mock.expects(:post).once.returns(make_response(make_card(:exp_year => "2100")))
       card = c.cards.retrieve('card')
       assert_equal "2000", card.exp_year
       card.exp_year = "2100"
@@ -49,9 +49,9 @@ module Stripe
 
     should "create should return a new customer card" do
       c = customer
-      @mock.expects(:post).once.returns(test_response(test_card(:id => "test_card")))
+      @mock.expects(:post).once.returns(make_response(make_card(:id => "make_card")))
       card = c.cards.create(:card => "tok_41YJ05ijAaWaFS")
-      assert_equal "test_card", card.id
+      assert_equal "make_card", card.id
     end
   end
 end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -3,23 +3,23 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class CustomerTest < Test::Unit::TestCase
     should "customers should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_customer_array))
+      @mock.expects(:get).once.returns(make_response(make_customer_array))
       c = Stripe::Customer.all.data
       assert c.kind_of? Array
       assert c[0].kind_of? Stripe::Customer
     end
 
     should "customers should be deletable" do
-      @mock.expects(:delete).once.returns(test_response(test_customer({:deleted => true})))
-      c = Stripe::Customer.new("test_customer")
+      @mock.expects(:delete).once.returns(make_response(make_customer({:deleted => true})))
+      c = Stripe::Customer.new("make_customer")
       c.delete
       assert c.deleted
     end
 
     should "customers should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_customer({:mnemonic => "foo"})))
-      @mock.expects(:post).once.returns(test_response(test_customer({:mnemonic => "bar"})))
-      c = Stripe::Customer.new("test_customer").refresh
+      @mock.expects(:get).once.returns(make_response(make_customer({:mnemonic => "foo"})))
+      @mock.expects(:post).once.returns(make_response(make_customer({:mnemonic => "bar"})))
+      c = Stripe::Customer.new("make_customer").refresh
       assert_equal "foo", c.mnemonic
       c.mnemonic = "bar"
       c.save
@@ -27,24 +27,24 @@ module Stripe
     end
 
     should "create should return a new customer" do
-      @mock.expects(:post).once.returns(test_response(test_customer))
+      @mock.expects(:post).once.returns(make_response(make_customer))
       c = Stripe::Customer.create
-      assert_equal "c_test_customer", c.id
+      assert_equal "c_make_customer", c.id
     end
 
     should "create_upcoming_invoice should create a new invoice" do
-      @mock.expects(:post).once.returns(test_response(test_invoice))
-      i = Stripe::Customer.new("test_customer").create_upcoming_invoice
-      assert_equal "c_test_customer", i.customer
+      @mock.expects(:post).once.returns(make_response(make_invoice))
+      i = Stripe::Customer.new("make_customer").create_upcoming_invoice
+      assert_equal "c_make_customer", i.customer
     end
 
     should "be able to update a customer's subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      c = Stripe::Customer.retrieve("test_customer")
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      c = Stripe::Customer.retrieve("make_customer")
 
       @mock.expects(:post).once.with do |url, api_key, params|
-        url == "#{Stripe.api_base}/v1/customers/c_test_customer/subscription" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
-      end.returns(test_response(test_subscription(:plan => 'silver')))
+        url == "#{Stripe.api_base}/v1/customers/c_make_customer/subscription" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
+      end.returns(make_response(make_subscription(:plan => 'silver')))
       s = c.update_subscription({:plan => 'silver'})
 
       assert_equal 'subscription', s.object
@@ -52,24 +52,24 @@ module Stripe
     end
 
     should "be able to cancel a customer's subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      c = Stripe::Customer.retrieve("test_customer")
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      c = Stripe::Customer.retrieve("make_customer")
 
       # Not an accurate response, but whatever
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription?at_period_end=true", nil, nil).returns(test_response(test_subscription(:plan => 'silver')))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_make_customer/subscription?at_period_end=true", nil, nil).returns(make_response(make_subscription(:plan => 'silver')))
       c.cancel_subscription({:at_period_end => 'true'})
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription", nil, nil).returns(test_response(test_subscription(:plan => 'silver')))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_make_customer/subscription", nil, nil).returns(make_response(make_subscription(:plan => 'silver')))
       c.cancel_subscription
     end
 
     should "be able to create a subscription for a customer" do
-      c = Stripe::Customer.new("test_customer")
+      c = Stripe::Customer.new("make_customer")
 
       @mock.expects(:post).once.with do |url, api_key, params|
-        url == "#{Stripe.api_base}/v1/customers/test_customer/subscriptions" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
-      end.returns(test_response(test_subscription(:plan => 'silver')))
+        url == "#{Stripe.api_base}/v1/customers/make_customer/subscriptions" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
+      end.returns(make_response(make_subscription(:plan => 'silver')))
       s = c.create_subscription({:plan => 'silver'})
 
       assert_equal 'subscription', s.object
@@ -77,10 +77,10 @@ module Stripe
     end
 
     should "be able to delete a customer's discount" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      c = Stripe::Customer.retrieve("test_customer")
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      c = Stripe::Customer.retrieve("make_customer")
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/discount", nil, nil).returns(test_response(test_delete_discount_response))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_make_customer/discount", nil, nil).returns(make_response(make_delete_discount_response))
       c.delete_discount
       assert_equal nil, c.discount
     end

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -3,22 +3,22 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class InvoiceTest < Test::Unit::TestCase
     should "retrieve should retrieve invoices" do
-      @mock.expects(:get).once.returns(test_response(test_invoice))
-      i = Stripe::Invoice.retrieve('in_test_invoice')
-      assert_equal 'in_test_invoice', i.id
+      @mock.expects(:get).once.returns(make_response(make_invoice))
+      i = Stripe::Invoice.retrieve('in_make_invoice')
+      assert_equal 'in_make_invoice', i.id
     end
 
     should "create should create a new invoice" do
-      @mock.expects(:post).once.returns(test_response(test_invoice))
+      @mock.expects(:post).once.returns(make_response(make_invoice))
       i = Stripe::Invoice.create
-      assert_equal "in_test_invoice", i.id
+      assert_equal "in_make_invoice", i.id
     end
 
     should "pay should pay an invoice" do
-      @mock.expects(:get).once.returns(test_response(test_invoice))
-      i = Stripe::Invoice.retrieve('in_test_invoice')
+      @mock.expects(:get).once.returns(make_response(make_invoice))
+      i = Stripe::Invoice.retrieve('in_make_invoice')
 
-      @mock.expects(:post).once.with('https://api.stripe.com/v1/invoices/in_test_invoice/pay', nil, '').returns(test_response(test_paid_invoice))
+      @mock.expects(:post).once.with('https://api.stripe.com/v1/invoices/in_make_invoice/pay', nil, '').returns(make_response(make_paid_invoice))
       i.pay
       assert_equal nil, i.next_payment_attempt
     end

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ListObjectTest < Test::Unit::TestCase
     should "be able to retrieve full lists given a listobject" do
-      @mock.expects(:get).twice.returns(test_response(test_charge_array))
+      @mock.expects(:get).twice.returns(make_response(make_charge_array))
       c = Stripe::Charge.all
       assert c.kind_of?(Stripe::ListObject)
       assert_equal('/v1/charges', c.url)

--- a/test/stripe/metadata_test.rb
+++ b/test/stripe/metadata_test.rb
@@ -6,23 +6,23 @@ module Stripe
       @metadata_supported = {
         :charge => {
           :new => Stripe::Charge.method(:new),
-          :test => method(:test_charge),
-          :url => "/v1/charges/#{test_charge()[:id]}"
+          :test => method(:make_charge),
+          :url => "/v1/charges/#{make_charge()[:id]}"
         },
         :customer => {
           :new => Stripe::Customer.method(:new),
-          :test => method(:test_customer),
-          :url => "/v1/customers/#{test_customer()[:id]}"
+          :test => method(:make_customer),
+          :url => "/v1/customers/#{make_customer()[:id]}"
         },
         :recipient => {
           :new => Stripe::Recipient.method(:new),
-          :test => method(:test_recipient),
-          :url => "/v1/recipients/#{test_recipient()[:id]}"
+          :test => method(:make_recipient),
+          :url => "/v1/recipients/#{make_recipient()[:id]}"
         },
         :transfer => {
           :new => Stripe::Transfer.method(:new),
-          :test => method(:test_transfer),
-          :url => "/v1/transfers/#{test_transfer()[:id]}"
+          :test => method(:make_transfer),
+          :url => "/v1/transfers/#{make_transfer()[:id]}"
         }
       }
 
@@ -92,11 +92,11 @@ module Stripe
         url = @base_url + methods[:url]
 
         initial_test_obj = test.call(initial_params)
-        @mock.expects(:get).once.returns(test_response(initial_test_obj))
+        @mock.expects(:get).once.returns(make_response(initial_test_obj))
 
         final_test_obj = test.call()
         @mock.expects(:post).once.
-          returns(test_response(final_test_obj)).
+          returns(make_response(final_test_obj)).
           with(url, nil, curl_args)
 
         obj = neu.call("test")

--- a/test/stripe/recipient_card_test.rb
+++ b/test/stripe/recipient_card_test.rb
@@ -2,16 +2,16 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class RecipientCardTest < Test::Unit::TestCase
-    RECIPIENT_CARD_URL = '/v1/recipients/test_recipient/cards/test_card'
+    RECIPIENT_CARD_URL = '/v1/recipients/make_recipient/cards/make_card'
 
     def recipient
-      @mock.expects(:get).once.returns(test_response(test_recipient))
-      Stripe::Recipient.retrieve('test_recipient')
+      @mock.expects(:get).once.returns(make_response(make_recipient))
+      Stripe::Recipient.retrieve('make_recipient')
     end
 
     should "recipient cards should be listable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card_array(recipient.id)))
+      @mock.expects(:get).once.returns(make_response(make_card_array(recipient.id)))
       cards = c.cards.all.data
       assert cards.kind_of? Array
       assert cards[0].kind_of? Stripe::Card
@@ -19,9 +19,9 @@ module Stripe
 
     should "recipient cards should have the correct url" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card(
-        :id => 'test_card',
-        :recipient => 'test_recipient'
+      @mock.expects(:get).once.returns(make_response(make_card(
+        :id => 'make_card',
+        :recipient => 'make_recipient'
       )))
       card = c.cards.retrieve('card')
       assert_equal RECIPIENT_CARD_URL, card.url
@@ -29,8 +29,8 @@ module Stripe
 
     should "recipient cards should be deletable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card))
-      @mock.expects(:delete).once.returns(test_response(test_card(:deleted => true)))
+      @mock.expects(:get).once.returns(make_response(make_card))
+      @mock.expects(:delete).once.returns(make_response(make_card(:deleted => true)))
       card = c.cards.retrieve('card')
       card.delete
       assert card.deleted
@@ -38,8 +38,8 @@ module Stripe
 
     should "recipient cards should be updateable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card(:exp_year => "2000")))
-      @mock.expects(:post).once.returns(test_response(test_card(:exp_year => "2100")))
+      @mock.expects(:get).once.returns(make_response(make_card(:exp_year => "2000")))
+      @mock.expects(:post).once.returns(make_response(make_card(:exp_year => "2100")))
       card = c.cards.retrieve('card')
       assert_equal "2000", card.exp_year
       card.exp_year = "2100"
@@ -49,9 +49,9 @@ module Stripe
 
     should "create should return a new recipient card" do
       c = recipient
-      @mock.expects(:post).once.returns(test_response(test_card(:id => "test_card")))
+      @mock.expects(:post).once.returns(make_response(make_card(:id => "make_card")))
       card = c.cards.create(:card => "tok_41YJ05ijAaWaFS")
-      assert_equal "test_card", card.id
+      assert_equal "make_card", card.id
     end
   end
 end

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -3,17 +3,17 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class RefundTest < Test::Unit::TestCase
     should "refunds should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
 
-      charge = Stripe::Charge.retrieve('test_charge')
+      charge = Stripe::Charge.retrieve('make_charge')
 
       assert charge.refunds.first.kind_of?(Stripe::Refund)
     end
 
     should "refunds should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_charge), test_response(test_refund(:id => 'refreshed_refund')))
+      @mock.expects(:get).twice.returns(make_response(make_charge), make_response(make_refund(:id => 'refreshed_refund')))
 
-      charge = Stripe::Charge.retrieve('test_charge')
+      charge = Stripe::Charge.retrieve('make_charge')
       refund = charge.refunds.first
       refund.refresh
 
@@ -21,10 +21,10 @@ module Stripe
     end
 
     should "refunds should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_refund(:metadata => {'key' => 'value'})))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_refund(:metadata => {'key' => 'value'})))
 
-      charge = Stripe::Charge.retrieve('test_charge')
+      charge = Stripe::Charge.retrieve('make_charge')
       refund = charge.refunds.first
 
       assert_equal nil, refund.metadata['key']
@@ -36,10 +36,10 @@ module Stripe
     end
 
     should "create should return a new refund" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_refund(:id => 'test_new_refund')))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_refund(:id => 'test_new_refund')))
 
-      charge = Stripe::Charge.retrieve('test_charge')
+      charge = Stripe::Charge.retrieve('make_charge')
       refund = charge.refunds.create(:amount => 20)
       assert_equal 'test_new_refund', refund.id
     end

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -3,17 +3,17 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class SubscriptionTest < Test::Unit::TestCase
     should "subscriptions should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
 
-      customer = Stripe::Customer.retrieve('test_customer')
+      customer = Stripe::Customer.retrieve('make_customer')
 
       assert customer.subscriptions.first.kind_of?(Stripe::Subscription)
     end
 
     should "subscriptions should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_customer), test_response(test_subscription(:id => 'refreshed_subscription')))
+      @mock.expects(:get).twice.returns(make_response(make_customer), make_response(make_subscription(:id => 'refreshed_subscription')))
 
-      customer = Stripe::Customer.retrieve('test_customer')
+      customer = Stripe::Customer.retrieve('make_customer')
       subscription = customer.subscriptions.first
       subscription.refresh
 
@@ -21,22 +21,22 @@ module Stripe
     end
 
     should "subscriptions should be deletable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      customer = Stripe::Customer.retrieve('test_customer')
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      customer = Stripe::Customer.retrieve('make_customer')
       subscription = customer.subscriptions.first
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}?at_period_end=true", nil, nil).returns(test_response(test_subscription))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_make_customer/subscriptions/#{subscription.id}?at_period_end=true", nil, nil).returns(make_response(make_subscription))
       subscription.delete :at_period_end => true
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}", nil, nil).returns(test_response(test_subscription))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_make_customer/subscriptions/#{subscription.id}", nil, nil).returns(make_response(make_subscription))
       subscription.delete
     end
 
     should "subscriptions should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription({:status => 'active'})))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription({:status => 'active'})))
 
-      customer = Stripe::Customer.retrieve('test_customer')
+      customer = Stripe::Customer.retrieve('make_customer')
       subscription = customer.subscriptions.first
       assert_equal 'trialing', subscription.status
 
@@ -47,24 +47,24 @@ module Stripe
     end
 
     should "create should return a new subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription(:id => 'test_new_subscription')))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription(:id => 'test_new_subscription')))
 
-      customer = Stripe::Customer.retrieve('test_customer')
+      customer = Stripe::Customer.retrieve('make_customer')
       subscription = customer.subscriptions.create(:plan => 'silver')
       assert_equal 'test_new_subscription', subscription.id
     end
 
     should "be able to delete a subscriptions's discount" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription(:id => 'test_new_subscription')))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription(:id => 'test_new_subscription')))
 
 
-      customer = Stripe::Customer.retrieve("test_customer")
+      customer = Stripe::Customer.retrieve("make_customer")
       subscription = customer.subscriptions.create(:plan => 'silver')
 
-      url = "#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/test_new_subscription/discount"
-      @mock.expects(:delete).once.with(url, nil, nil).returns(test_response(test_delete_discount_response))
+      url = "#{Stripe.api_base}/v1/customers/c_make_customer/subscriptions/test_new_subscription/discount"
+      @mock.expects(:delete).once.with(url, nil, nil).returns(make_response(make_delete_discount_response))
       subscription.delete_discount
       assert_equal nil, subscription.discount
     end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -3,22 +3,22 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class TransferTest < Test::Unit::TestCase
     should "retrieve should retrieve transfer" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
-      transfer = Stripe::Transfer.retrieve('tr_test_transfer')
-      assert_equal 'tr_test_transfer', transfer.id
+      @mock.expects(:get).once.returns(make_response(make_transfer))
+      transfer = Stripe::Transfer.retrieve('tr_make_transfer')
+      assert_equal 'tr_make_transfer', transfer.id
     end
 
     should "create should create a transfer" do
-      @mock.expects(:post).once.returns(test_response(test_transfer))
+      @mock.expects(:post).once.returns(make_response(make_transfer))
       transfer = Stripe::Transfer.create
-      assert_equal "tr_test_transfer", transfer.id
+      assert_equal "tr_make_transfer", transfer.id
     end
 
     should "cancel should cancel a transfer" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
-      transfer = Stripe::Transfer.retrieve('tr_test_transfer')
+      @mock.expects(:get).once.returns(make_response(make_transfer))
+      transfer = Stripe::Transfer.retrieve('tr_make_transfer')
 
-      @mock.expects(:post).once.with('https://api.stripe.com/v1/transfers/tr_test_transfer/cancel', nil, '').returns(test_response(test_canceled_transfer))
+      @mock.expects(:post).once.with('https://api.stripe.com/v1/transfers/tr_make_transfer/cancel', nil, '').returns(make_response(make_canceled_transfer))
       transfer.cancel
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 require 'mocha/setup'
 require 'stringio'
 require 'shoulda'
-require File.expand_path('../test_data', __FILE__)
+require File.expand_path('../fake_data', __FILE__)
 
 # monkeypatch request methods
 module Stripe
@@ -25,7 +25,7 @@ module Stripe
 end
 
 class Test::Unit::TestCase
-  include Stripe::TestData
+  include Stripe::FakeData
   include Mocha
 
   setup do


### PR DESCRIPTION
My test runner was getting very confused, so I renamed the
`TestData.test_*` to `FakeData.make_*`.
