### PR TITLE
Include stripe account parameter for setting header.

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -127,6 +127,9 @@ module Stripe
         if opts[:idempotency_key]
           headers[:idempotency_key] = opts[:idempotency_key] 
         end
+        if opts[:stripe_account]
+          headers[:stripe_account] = opts[:stripe_account]
+        end
         return opts[:api_key], headers
       else
         raise TypeError.new("parse_opts expects a string or a hash")

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -67,6 +67,25 @@ module Stripe
       end
     end
 
+    should "send stripe account as header when set" do
+      stripe_account = "acct_0000"
+      Stripe.expects(:execute_request).with do |opts|
+        opts[:headers][:stripe_account] == stripe_account
+      end.returns(test_response(test_charge))
+
+      Stripe::Charge.create({:card => {:number => '4242424242424242'}},
+                            {:stripe_account => stripe_account, :api_key => 'sk_test_local'})
+    end
+
+    should "not send stripe account as header when not set" do
+      Stripe.expects(:execute_request).with do |opts|
+        opts[:headers][:stripe_account].nil?
+      end.returns(test_response(test_charge))
+
+      Stripe::Charge.create({:card => {:number => '4242424242424242'}},
+        'sk_test_local')
+    end
+
     context "when specifying per-object credentials" do
       context "with no global API key set" do
         should "use the per-object credential when creating" do


### PR DESCRIPTION
This PR enables you to set the stripe account that you want to send your request to, by setting the `stripe_account` header. You can now do this:

```
Stripe::Charge.create({:card => {:number => '4242424242424242'}},
  {:stripe_account => 'acct_0000', ;api_key => 'sk_test_master'})
```

The above request will send a request under the account `acct_0000`. This is useful for connect customers with multiple accounts and a single master api key.

r? @russelldavis 
cc @bkrausz 
