### PR TITLE
Added deauthorize method to account

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -53,6 +53,7 @@ require 'stripe/errors/authentication_error'
 module Stripe
   DEFAULT_CA_BUNDLE_PATH = File.dirname(__FILE__) + '/data/ca-certificates.crt'
   @api_base = 'https://api.stripe.com'
+  @connect_base = 'https://connect.stripe.com'
 
   @ssl_bundle_path  = DEFAULT_CA_BUNDLE_PATH
   @verify_ssl_certs = true
@@ -60,7 +61,7 @@ module Stripe
 
 
   class << self
-    attr_accessor :api_key, :api_base, :verify_ssl_certs, :api_version
+    attr_accessor :api_key, :api_base, :verify_ssl_certs, :api_version, :connect_base
   end
 
   def self.api_url(url='', api_base_url=nil)

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -1,4 +1,9 @@
 module Stripe
   class Account < SingletonAPIResource
+    def deauthorize(client_id, opts={})
+      api_key, headers = Util.parse_opts(opts)
+      response, api_key = Stripe.request(:post, '/oauth/deauthorize', api_key, { 'client_id' => client_id, 'stripe_user_id' => self.id }, headers, Stripe.connect_base)
+      Util.convert_to_stripe_object(response, api_key)
+    end
   end
 end

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -10,5 +10,17 @@ module Stripe
       assert !a.charge_enabled
       assert !a.details_submitted
     end
+
+    should "be able to deauthorize an account" do
+      resp = {:id => 'acct_1234', :email => "test+bindings@stripe.com", :charge_enabled => false, :details_submitted => false}
+      @mock.expects(:get).once.returns(test_response(resp))
+      a = Stripe::Account.retrieve
+
+
+      @mock.expects(:post).once.with do |url, api_key, params|
+        url == "#{Stripe.connect_base}/oauth/deauthorize" && api_key.nil? && CGI.parse(params) == { 'client_id' => [ 'ca_1234' ], 'stripe_user_id' => [ a.id ]}
+      end.returns(test_response({ 'stripe_user_id' => a.id }))
+      a.deauthorize('ca_1234', 'sk_test_1234')
+    end
   end
 end


### PR DESCRIPTION
Fixes: #176 Added deauthorize method to account to allow for deauthorizing a stripe account from a stripe connect application
