### PR TITLE
Adding empty? method to ListObject.

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -13,7 +13,11 @@ module Stripe
     def each(&blk)
       self.data.each(&blk)
     end
-
+    
+    def empty?
+      count == 0
+    end
+  
     def retrieve(id, api_key=nil)
       api_key ||= @api_key
       response, api_key = Stripe.request(:get,"#{url}/#{CGI.escape(id)}", api_key)


### PR DESCRIPTION
As a Rails developer I generally expect collections to respond to `empty?`. I was supervised when learning the Stripe API with stripe-ruby Gem that this did not work:

```
customer = Stripe::Customer.retrieve(stripe_customer_id)

if customer.cards.empty?
  # Make customer add card.
else
  customer.cards.each do |card|
    # Display card..
  end
end
```

I realize you can do: `customer.cards.count == 0` but that is not as clean in my opinion.