### PR TITLE
Adding support for listing file uploads.

### DIFF
--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -18,6 +18,13 @@ module Stripe
       Util.convert_to_stripe_object(response, api_key)
     end
 
+    def self.all(filters={}, opts={})
+      api_key, headers = Util.parse_opts(opts)
+      response, api_key = Stripe.request(
+        :get, self.url, api_key, filters, headers, UPLOADS_API_BASE)
+      Util.convert_to_stripe_object(response, api_key)
+    end
+
     def refresh
       response, api_key = Stripe.request(
         :get, url, @api_key, @retrieve_options, self.class.request_headers, UPLOADS_API_BASE)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -35,7 +35,8 @@ module Stripe
         'plan' => Plan,
         'recipient' => Recipient,
         'refund' => Refund,
-        'subscription' => Subscription,        
+        'subscription' => Subscription,
+        'file_upload' => FileUpload,
         'transfer' => Transfer
       }
     end

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -17,5 +17,12 @@ module Stripe
       c.refresh
       assert_equal 1403047735, c.created
     end
+
+    should "files should be listable" do
+      @mock.expects(:get).once.returns(test_response(test_file_array))
+      c = Stripe::FileUpload.all.data
+      assert c.kind_of? Array
+      assert c[0].kind_of? Stripe::FileUpload
+    end
   end
 end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -185,12 +185,21 @@ module Stripe
 
     def test_file(params={})
       {
+        :object => "file_upload",
         :id => "fil_test_file",
         :created => 1403047735,
         :size => 4908,
         :purpose => params[:purpose] || "dispute_evidence",
         :url => nil,
-        :mimetype => nil,
+        :type => nil,
+      }
+    end
+
+    def test_file_array
+      {
+        :data => [test_file, test_file, test_file],
+        :object => 'list',
+        :url => '/v1/files'
       }
     end
 


### PR DESCRIPTION
This allows the ruby bindings to be able to list all file upload objects.

r? @russelldavis (bindings maintainer)