### PR TITLE
Add Account to business object mapping

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -21,6 +21,7 @@ module Stripe
         'list' => ListObject,
 
         # business objects
+        'account' => Account,
         'application_fee' => ApplicationFee,
         'balance' => Balance,
         'balance_transaction' => BalanceTransaction,


### PR DESCRIPTION
Fixes an issue where creating an `Account` did not return an `Account` instance.