### PR TITLE
Advise people to use new gem-specific source.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,11 @@ compromised in transit and alter the code of gems fetched securely over https:
 
   gem 'rails'
   gem 'stripe'
+  
+Bundler 1.7 makes it possible to specify a source for a single gem so alternatively 
+you can now use this in your Gemfile:
+
+  gem 'stripe', source: 'https://code.stripe.com/'
 
 == Development
 


### PR DESCRIPTION
This was introduced in Bundler 1.7. Using two sources will now trigger the following warning:

Warning: the gem 'stripe' was found in multiple sources.
Installed from: https://rubygems.org/
Also found in:
  * https://code.stripe.com/
You should add a source requirement to restrict this gem to your preferred source.
For example:
    gem 'stripe', :source => 'https://rubygems.org/'
Then uninstall the gem 'stripe' (or delete all bundled gems) and then install again.