### PR TITLE
Fix incorrect error message- Stripe::Card.retrieve

### DIFF
--- a/lib/stripe/card.rb
+++ b/lib/stripe/card.rb
@@ -13,7 +13,7 @@ module Stripe
     end
 
     def self.retrieve(id, opts=nil)
-      raise NotImplementedError.new("Cards cannot be retrieved without a customer ID. Retrieve a card using customer.cards.retrieve('card_id')")
+      raise NotImplementedError.new("Cards cannot be retrieved without a customer ID. Retrieve a card using customer.sources.retrieve('card_id')")
     end
   end
 end

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -53,5 +53,11 @@ module Stripe
       card = c.sources.create(:source => "tok_41YJ05ijAaWaFS")
       assert_equal "test_card", card.id
     end
+
+    should "raise if accessing Stripe::Card.retrieve directly" do
+      assert_raises NotImplementedError do
+        Stripe::Card.retrieve "card_12345"
+      end
+    end
   end
 end


### PR DESCRIPTION
* This error message said "Cards cannot be retrieved without a customer
ID. Retrieve a card using customer.cards.retrieve('card_id')"

This is incorrect. `customer.cards` throws a `NoMethodError: undefined
method `cards' for #<Stripe::Customer:0x0000010c8bdca8>`.

* The correct method is `Stripe::Customer#sources`, and this fixes the
error message.