### PR TITLE
Revamp uname calls

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -186,13 +186,13 @@ module Stripe
 
   def self._uname_uname
     (`uname -a 2>/dev/null` || '').strip
-  rescue Errno::ENOMEM
+  rescue Errno::ENOMEM # couldn't create subprocess
     "uname lookup failed"
   end
 
   def self._uname_ver
     (`ver` || '').strip
-  rescue Errno::ENOMEM
+  rescue Errno::ENOMEM # couldn't create subprocess
     "uname lookup failed"
   end
 

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -1,9 +1,11 @@
 # Stripe Ruby bindings
 # API spec at https://stripe.com/docs/api
 require 'cgi'
-require 'set'
 require 'openssl'
-require 'rest_client'
+require 'set'
+require 'socket'
+
+require 'rest-client'
 require 'json'
 
 # Version
@@ -159,15 +161,22 @@ module Stripe
       :lang_version => lang_version,
       :platform => RUBY_PLATFORM,
       :publisher => 'stripe',
-      :uname => @uname
+      :uname => @uname,
+      :hostname => Socket.gethostname,
     }
 
   end
 
   def self.get_uname
-    `uname -a 2>/dev/null`.strip if RUBY_PLATFORM =~ /linux|darwin/i
-  rescue Errno::ENOMEM => ex # couldn't create subprocess
-    "uname lookup failed"
+    begin
+      File.read('/proc/version').strip
+    rescue SystemCallError
+      begin
+        `uname -a 2>/dev/null`.strip if RUBY_PLATFORM =~ /linux|darwin/i
+      rescue Errno::ENOMEM # couldn't create subprocess
+        "uname lookup failed"
+      end
+    end
   end
 
   def self.uri_encode(params)


### PR DESCRIPTION
Instead of shelling out to `uname`, use `/proc/version` when available.

On windows platforms, shell out to `ver` to report the OS version. On BSD and solaris platforms, also use `uname`.

And modify the checks to work on jruby, which reports a `RUBY_PLATFORM` of `java`.