### PR TITLE
Dont unset keys when they dont exist

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -129,9 +129,12 @@ module Stripe
         # e.g. as object.key = {foo => bar}
         update = new_value
         new_keys = update.keys.map(&:to_sym)
+
         # remove keys at the server, but not known locally
-        keys_to_unset = @original_values[key].keys - new_keys
-        keys_to_unset.each {|key| update[key] = ''}
+        if @original_values.include?(key)
+          keys_to_unset = @original_values[key].keys - new_keys
+          keys_to_unset.each {|key| update[key] = ''}
+        end
 
         update
       else


### PR DESCRIPTION
In the API documentation it says you can replace an existing customer's credit card like this:

```ruby
cu = Stripe::Customer.retrieve({CUSTOMER_ID})
cu.source = {
  'object' => 'card',
  'number' => '424242424242',
  ..
}
cu.save
```
https://stripe.com/docs/api/ruby#update_customer

When you do this via the Stripe gem it will raise this error:
```
NoMethodError: undefined method `keys' for nil:NilClass
	from ~/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/stripe-1.20.4/lib/stripe/stripe_object.rb:136:in `serialize_nested_object'
	from ~/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/stripe-1.20.4/lib/stripe/stripe_object.rb:161:in `block in serialize_params'
	from ~/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/stripe-1.20.4/lib/stripe/stripe_object.rb:159:in `each'
	from ~/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/stripe-1.20.4/lib/stripe/stripe_object.rb:159:in `serialize_params'
	from ~/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/stripe-1.20.4/lib/stripe/api_operations/update.rb:5:in `save'
	from (irb):16
```

This is caused because `StripeObject` attempts to unset the `source` key on the `@original_values` hash.
I fixed this by checking existence of the key before trying to unset them.