### PR TITLE
Basic Pagination Support

### DIFF
--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -4,8 +4,9 @@ module Stripe
       module ClassMethods
         def all(filters={}, opts={})
           opts = Util.normalize_opts(opts)
-          response, opts = request(:get, url, filters, opts)
-          Util.convert_to_stripe_object(response, opts)
+
+          list = Stripe::ListObject.construct_from({ url: url }, opts)
+          list.all(filters, opts)
         end
       end
 

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -27,7 +27,37 @@ module Stripe
 
     def all(params={}, opts={})
       response, opts = request(:get, url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      Util.convert_to_stripe_object(response.merge({ filters: params }), opts)
+    end
+
+    def each_in_batches(&blk)
+      list = self
+
+      loop do
+        list.each(&blk)
+
+        break unless list = list.next
+      end
+    end
+
+    def next(params={}, opts={})
+      return nil unless self[:has_more]
+
+      filters[:limit] -= self.data.size
+
+      return nil if filters[:limit] <= 0
+
+      all(filters.to_hash.merge(params).merge(:starting_after => data.last.id), @opts.merge(opts))
+    end
+
+    def previous(params={}, opts={})
+      return nil unless self[:has_more]
+
+      filters[:limit] -= self.data.size
+
+      return nil if filters[:limit] <= 0
+
+      all(filters.to_hash.merge(params).merge(:ending_before => data.first.id), @opts.merge(opts))
     end
   end
 end


### PR DESCRIPTION
For #167

* This is my first time looking at the stripe-ruby source, but I couldn't find a good reason not to use `ListObject.all` instead of duplicating a similar command on the `APIOperations::List` object
* Not digging the `each_in_batches` name and implementation. For huge data sets this would most likely cause memory issues. Open to suggestions here.

Wanted to get some feedback before I dive in and write some specs.