### PR TITLE
to_hash should also walk into arrays to make recursive call.

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -93,8 +93,17 @@ module Stripe
     end
 
     def to_hash
+      maybe_to_hash = lambda do |value|
+        value.respond_to?(:to_hash) ? value.to_hash : value
+      end
+
       @values.inject({}) do |acc, (key, value)|
-        acc[key] = value.respond_to?(:to_hash) ? value.to_hash : value
+        acc[key] = case value
+                   when Array
+                     value.map(&maybe_to_hash)
+                   else
+                     maybe_to_hash.call(value)
+                   end
         acc
       end
     end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -19,9 +19,10 @@ module Stripe
     end
 
     should "recursively call to_hash on its values" do
-      nested = Stripe::StripeObject.construct_from({ :id => 7, :foo => 'bar' })
-      obj = Stripe::StripeObject.construct_from({ :id => 1, :nested => nested })
-      expected_hash = { :id => 1, :nested => { :id => 7, :foo => 'bar' } }
+      nested_hash = { :id => 7, :foo => 'bar' }
+      nested = Stripe::StripeObject.construct_from(nested_hash)
+      obj = Stripe::StripeObject.construct_from({ :id => 1, :nested => nested, :list => [nested] })
+      expected_hash = { :id => 1, :nested => nested_hash, :list => [nested_hash] }
       assert_equal expected_hash, obj.to_hash
     end
   end


### PR DESCRIPTION
I am trying to store stripe object into database using `to_hash`, realizing that it's not handling arrays properly.

Thanks for adding this.