### PR TITLE
Add Customer#deleted?

### DIFF
--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -54,6 +54,10 @@ module Stripe
       refresh_from({ :discount => nil }, opts, true)
     end
 
+    def deleted?
+      self.respond_to?(:deleted)
+    end
+
     private
 
     def discount_url

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -84,5 +84,14 @@ module Stripe
       c.delete_discount
       assert_equal nil, c.discount
     end
+
+    should 'be able to determine if a customer is deleted' do
+      @mock.expects(:delete).once.returns(test_response(test_customer({:deleted => true})))
+      c = Stripe::Customer.new("test_customer")
+      assert !c.deleted?
+
+      c.delete
+      assert c.deleted
+    end
   end
 end


### PR DESCRIPTION
A ruby-like method to easily query the `deleted` status of a `Stripe::Customer`