### PR TITLE
Add request IDs to all API errors

### DIFF
--- a/lib/stripe/errors/card_error.rb
+++ b/lib/stripe/errors/card_error.rb
@@ -2,8 +2,9 @@ module Stripe
   class CardError < StripeError
     attr_reader :param, :code
 
-    def initialize(message, param, code, http_status=nil, http_body=nil, json_body=nil)
-      super(message, http_status, http_body, json_body)
+    def initialize(message, param, code, http_status=nil, http_body=nil, json_body=nil,
+                   http_headers=nil)
+      super(message, http_status, http_body, json_body, http_headers)
       @param = param
       @code = code
     end

--- a/lib/stripe/errors/invalid_request_error.rb
+++ b/lib/stripe/errors/invalid_request_error.rb
@@ -2,8 +2,9 @@ module Stripe
   class InvalidRequestError < StripeError
     attr_accessor :param
 
-    def initialize(message, param, http_status=nil, http_body=nil, json_body=nil)
-      super(message, http_status, http_body, json_body)
+    def initialize(message, param, http_status=nil, http_body=nil, json_body=nil,
+                   http_headers=nil)
+      super(message, http_status, http_body, json_body, http_headers)
       @param = param
     end
   end

--- a/lib/stripe/errors/stripe_error.rb
+++ b/lib/stripe/errors/stripe_error.rb
@@ -3,18 +3,24 @@ module Stripe
     attr_reader :message
     attr_reader :http_status
     attr_reader :http_body
+    attr_reader :http_headers
+    attr_reader :request_id
     attr_reader :json_body
 
-    def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil)
+    def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil,
+                   http_headers=nil)
       @message = message
       @http_status = http_status
       @http_body = http_body
+      @http_headers = http_headers || {}
       @json_body = json_body
+      @request_id = @http_headers[:request_id]
     end
 
     def to_s
       status_string = @http_status.nil? ? "" : "(Status #{@http_status}) "
-      "#{status_string}#{@message}"
+      id_string = @request_id.nil? ? "" : "(Request #{@request_id}) "
+      "#{status_string}#{id_string}#{@message}"
     end
   end
 end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -5,9 +5,14 @@ module Stripe
       # can't just use the stubs interface.
       body = JSON.generate(body) if !(body.kind_of? String)
       m = mock
-      m.instance_variable_set('@stripe_values', { :body => body, :code => code })
+      m.instance_variable_set('@stripe_values', {
+        :body => body,
+        :code => code,
+        :headers => {},
+      })
       def m.body; @stripe_values[:body]; end
       def m.code; @stripe_values[:code]; end
+      def m.headers; @stripe_values[:headers]; end
       m
     end
 


### PR DESCRIPTION
Now that [request IDs](https://stripe.com/docs/api#request_ids) are out, add them to all Stripe exceptions. Exception message will now also include the request ID, e.g. `(Status 404) (Request req_6XGwmgBn5LoBGM) No such customer: foo`
