### PR TITLE
Rename test data methods

### DIFF
--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -7,7 +7,7 @@ module Stripe
       @mock.expects(:get).
         once.
         with('https://api.stripe.com/v1/account', nil, nil).
-        returns(test_response(resp))
+        returns(make_response(resp))
       a = Stripe::Account.retrieve
       assert_equal "test+bindings@stripe.com", a.email
       assert !a.charge_enabled
@@ -19,7 +19,7 @@ module Stripe
       @mock.expects(:get).
         once.
         with('https://api.stripe.com/v1/accounts/acct_foo', nil, nil).
-        returns(test_response(resp))
+        returns(make_response(resp))
       a = Stripe::Account.retrieve('acct_foo')
       assert_equal "test+bindings@stripe.com", a.email
       assert !a.charge_enabled
@@ -45,12 +45,12 @@ module Stripe
       @mock.expects(:get).
         once.
         with('https://api.stripe.com/v1/accounts/acct_foo', nil, nil).
-        returns(test_response(resp))
+        returns(make_response(resp))
 
       @mock.expects(:post).
         once.
         with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[first_name]=Bob&legal_entity[address][line1]=2%20Three%20Four').
-        returns(test_response(resp))
+        returns(make_response(resp))
 
       a = Stripe::Account.retrieve('acct_foo')
       a.legal_entity.first_name = 'Bob'
@@ -60,13 +60,13 @@ module Stripe
 
     should "be able to deauthorize an account" do
       resp = {:id => 'acct_1234', :email => "test+bindings@stripe.com", :charge_enabled => false, :details_submitted => false}
-      @mock.expects(:get).once.returns(test_response(resp))
+      @mock.expects(:get).once.returns(make_response(resp))
       a = Stripe::Account.retrieve
 
 
       @mock.expects(:post).once.with do |url, api_key, params|
         url == "#{Stripe.connect_base}/oauth/deauthorize" && api_key.nil? && CGI.parse(params) == { 'client_id' => [ 'ca_1234' ], 'stripe_user_id' => [ a.id ]}
-      end.returns(test_response({ 'stripe_user_id' => a.id }))
+      end.returns(make_response({ 'stripe_user_id' => a.id }))
       a.deauthorize('ca_1234', 'sk_test_1234')
     end
 
@@ -88,13 +88,13 @@ module Stripe
           :data => [],
         }
       }
-      @mock.expects(:get).once.returns(test_response(resp))
+      @mock.expects(:get).once.returns(make_response(resp))
       a = Stripe::Account.retrieve
 
       @mock.expects(:post).
         once.
         with('https://api.stripe.com/v1/accounts/acct_1234/external_accounts', nil, 'external_account=btok_1234').
-        returns(test_response(resp))
+        returns(make_response(resp))
       a.external_accounts.create({:external_account => 'btok_1234'})
     end
 
@@ -110,7 +110,7 @@ module Stripe
           }],
         }
       }
-      @mock.expects(:get).once.returns(test_response(resp))
+      @mock.expects(:get).once.returns(make_response(resp))
       a = Stripe::Account.retrieve
       assert_equal(BankAccount, a.external_accounts.data[0].class)
     end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -55,7 +55,7 @@ module Stripe
 
     should "specifying invalid api credentials should raise an exception" do
       Stripe.api_key = "invalid"
-      response = test_response(test_invalid_api_key_error, 401)
+      response = make_response(make_invalid_api_key_error, 401)
       assert_raises Stripe::AuthenticationError do
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 401))
         Stripe::Customer.retrieve("failing_customer")
@@ -64,7 +64,7 @@ module Stripe
 
     should "AuthenticationErrors should have an http status, http body, and JSON body" do
       Stripe.api_key = "invalid"
-      response = test_response(test_invalid_api_key_error, 401)
+      response = make_response(make_invalid_api_key_error, 401)
       begin
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 401))
         Stripe::Customer.retrieve("failing_customer")
@@ -72,14 +72,14 @@ module Stripe
         assert_equal(401, e.http_status)
         assert_equal(true, !!e.http_body)
         assert_equal(true, !!e.json_body[:error][:message])
-        assert_equal(test_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
+        assert_equal(make_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
       end
     end
 
     should "send expand on fetch properly" do
       @mock.expects(:get).once.
         with("#{Stripe.api_base}/v1/charges/ch_test_charge?expand[]=customer", nil, nil).
-        returns(test_response(test_charge))
+        returns(make_response(make_charge))
 
       Stripe::Charge.retrieve({:id => 'ch_test_charge', :expand => [:customer]})
     end
@@ -87,7 +87,7 @@ module Stripe
     should "preserve expand across refreshes" do
       @mock.expects(:get).twice.
         with("#{Stripe.api_base}/v1/charges/ch_test_charge?expand[]=customer", nil, nil).
-        returns(test_response(test_charge))
+        returns(make_response(make_charge))
 
       ch = Stripe::Charge.retrieve({:id => 'ch_test_charge', :expand => [:customer]})
       ch.refresh
@@ -97,7 +97,7 @@ module Stripe
       stripe_account = "acct_0000"
       Stripe.expects(:execute_request).with do |opts|
         opts[:headers][:stripe_account] == stripe_account
-      end.returns(test_response(test_charge))
+      end.returns(make_response(make_charge))
 
       Stripe::Charge.create({:card => {:number => '4242424242424242'}},
                             {:stripe_account => stripe_account, :api_key => 'sk_test_local'})
@@ -106,7 +106,7 @@ module Stripe
     should "not send stripe account as header when not set" do
       Stripe.expects(:execute_request).with do |opts|
         opts[:headers][:stripe_account].nil?
-      end.returns(test_response(test_charge))
+      end.returns(make_response(make_charge))
 
       Stripe::Charge.create({:card => {:number => '4242424242424242'}},
         'sk_test_local')
@@ -117,7 +117,7 @@ module Stripe
         should "use the per-object credential when creating" do
           Stripe.expects(:execute_request).with do |opts|
             opts[:headers][:authorization] == 'Bearer sk_test_local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
           Stripe::Charge.create({:card => {:number => '4242424242424242'}},
             'sk_test_local')
@@ -136,7 +136,7 @@ module Stripe
         should "use the per-object credential when creating" do
           Stripe.expects(:execute_request).with do |opts|
             opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
           Stripe::Charge.create({:card => {:number => '4242424242424242'}},
             'local')
@@ -146,11 +146,11 @@ module Stripe
           Stripe.expects(:execute_request).with do |opts|
             opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge" &&
               opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
           Stripe.expects(:execute_request).with do |opts|
             opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge/refund" &&
               opts[:headers][:authorization] == 'Bearer local'
-          end.returns(test_response(test_charge))
+          end.returns(make_response(make_charge))
 
           ch = Stripe::Charge.retrieve('ch_test_charge', 'local')
           ch.refund
@@ -162,7 +162,7 @@ module Stripe
       should "send along the idempotency-key header" do
         Stripe.expects(:execute_request).with do |opts|
           opts[:headers][:idempotency_key] == 'bar'
-        end.returns(test_response(test_charge))
+        end.returns(make_response(make_charge))
 
         Stripe::Charge.create({:card => {:number => '4242424242424242'}}, {
           :idempotency_key => 'bar',
@@ -171,14 +171,14 @@ module Stripe
       end
 
       should "urlencode values in GET params" do
-        response = test_response(test_charge_array)
+        response = make_response(make_charge_array)
         @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test%20customer", nil, nil).returns(response)
         charges = Stripe::Charge.all(:customer => 'test customer').data
         assert charges.kind_of? Array
       end
 
       should "construct URL properly with base query parameters" do
-        response = test_response(test_invoice_customer_array)
+        response = make_response(make_invoice_customer_array)
         @mock.expects(:get).with("#{Stripe.api_base}/v1/invoices?customer=test_customer", nil, nil).returns(response)
         invoices = Stripe::Invoice.all(:customer => 'test_customer')
 
@@ -187,7 +187,7 @@ module Stripe
       end
 
       should "a 400 should give an InvalidRequestError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 400)
+        response = make_response(make_missing_id_error, 400)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -199,7 +199,7 @@ module Stripe
       end
 
       should "a 401 should give an AuthenticationError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 401)
+        response = make_response(make_missing_id_error, 401)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -211,7 +211,7 @@ module Stripe
       end
 
       should "a 402 should give a CardError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 402)
+        response = make_response(make_missing_id_error, 402)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -223,7 +223,7 @@ module Stripe
       end
 
       should "a 404 should give an InvalidRequestError with http status, body, and JSON body" do
-        response = test_response(test_missing_id_error, 404)
+        response = make_response(make_missing_id_error, 404)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
         begin
           Stripe::Customer.retrieve("foo")
@@ -240,19 +240,19 @@ module Stripe
           query = CGI.parse(uri.query)
           (url =~ %r{^#{Stripe.api_base}/v1/charges?} &&
            query.keys.sort == ['offset', 'sad'])
-        end.returns(test_response({ :count => 1, :data => [test_charge] }))
+        end.returns(make_response({ :count => 1, :data => [make_charge] }))
         Stripe::Charge.all(:count => nil, :offset => 5, :sad => false)
 
         @mock.expects(:post).with do |url, api_key, params|
           url == "#{Stripe.api_base}/v1/charges" &&
             api_key.nil? &&
             CGI.parse(params) == { 'amount' => ['50'], 'currency' => ['usd'] }
-        end.returns(test_response({ :count => 1, :data => [test_charge] }))
+        end.returns(make_response({ :count => 1, :data => [make_charge] }))
         Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
       end
 
       should "requesting with a unicode ID should result in a request" do
-        response = test_response(test_missing_id_error, 404)
+        response = make_response(make_missing_id_error, 404)
         @mock.expects(:get).once.with("#{Stripe.api_base}/v1/customers/%E2%98%83", nil, nil).raises(RestClient::ExceptionWithResponse.new(response, 404))
         c = Stripe::Customer.new("☃")
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
@@ -265,7 +265,7 @@ module Stripe
 
       should "making a GET request with parameters should have a query string and no body" do
         params = { :limit => 1 }
-        @mock.expects(:get).once.with("#{Stripe.api_base}/v1/charges?limit=1", nil, nil).returns(test_response([test_charge]))
+        @mock.expects(:get).once.with("#{Stripe.api_base}/v1/charges?limit=1", nil, nil).returns(make_response([make_charge]))
         Stripe::Charge.all(params)
       end
 
@@ -273,18 +273,18 @@ module Stripe
         params = { :amount => 100, :currency => 'usd', :card => 'sc_token' }
         @mock.expects(:post).once.with do |url, get, post|
           get.nil? && CGI.parse(post) == {'amount' => ['100'], 'currency' => ['usd'], 'card' => ['sc_token']}
-        end.returns(test_response(test_charge))
+        end.returns(make_response(make_charge))
         Stripe::Charge.create(params)
       end
 
       should "loading an object should issue a GET request" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
+        @mock.expects(:get).once.returns(make_response(make_customer))
         c = Stripe::Customer.new("test_customer")
         c.refresh
       end
 
       should "using array accessors should be the same as the method interface" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
+        @mock.expects(:get).once.returns(make_response(make_customer))
         c = Stripe::Customer.new("test_customer")
         c.refresh
         assert_equal c.created, c[:created]
@@ -294,7 +294,7 @@ module Stripe
       end
 
       should "accessing a property other than id or parent on an unfetched object should fetch it" do
-        @mock.expects(:get).once.returns(test_response(test_customer))
+        @mock.expects(:get).once.returns(make_response(make_customer))
         c = Stripe::Customer.new("test_customer")
         c.charges
       end
@@ -302,14 +302,14 @@ module Stripe
       should "updating an object should issue a POST request with only the changed properties" do
         @mock.expects(:post).with do |url, api_key, params|
           url == "#{Stripe.api_base}/v1/customers/c_test_customer" && api_key.nil? && CGI.parse(params) == {'description' => ['another_mn']}
-        end.once.returns(test_response(test_customer))
-        c = Stripe::Customer.construct_from(test_customer)
+        end.once.returns(make_response(make_customer))
+        c = Stripe::Customer.construct_from(make_customer)
         c.description = "another_mn"
         c.save
       end
 
       should "updating should merge in returned properties" do
-        @mock.expects(:post).once.returns(test_response(test_customer))
+        @mock.expects(:post).once.returns(make_response(make_customer))
         c = Stripe::Customer.new("c_test_customer")
         c.description = "another_mn"
         c.save
@@ -319,8 +319,8 @@ module Stripe
       should "deleting should send no props and result in an object that has no props other deleted" do
         @mock.expects(:get).never
         @mock.expects(:post).never
-        @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/c_test_customer", nil, nil).once.returns(test_response({ "id" => "test_customer", "deleted" => true }))
-        c = Stripe::Customer.construct_from(test_customer)
+        @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/c_test_customer", nil, nil).once.returns(make_response({ "id" => "test_customer", "deleted" => true }))
+        c = Stripe::Customer.construct_from(make_customer)
         c.delete
         assert_equal true, c.deleted
 
@@ -330,13 +330,13 @@ module Stripe
       end
 
       should "loading an object with properties that have specific types should instantiate those classes" do
-        @mock.expects(:get).once.returns(test_response(test_charge))
+        @mock.expects(:get).once.returns(make_response(make_charge))
         c = Stripe::Charge.retrieve("test_charge")
         assert c.card.kind_of?(Stripe::StripeObject) && c.card.object == 'card'
       end
 
       should "loading all of an APIResource should return an array of recursively instantiated objects" do
-        @mock.expects(:get).once.returns(test_response(test_charge_array))
+        @mock.expects(:get).once.returns(make_response(make_charge_array))
         c = Stripe::Charge.all.data
         assert c.kind_of? Array
         assert c[0].kind_of? Stripe::Charge
@@ -348,7 +348,7 @@ module Stripe
           opts[:method] == :get &&
           opts[:url] == "#{Stripe.api_base}/v1/customers/c_test_customer" &&
           opts[:headers][:stripe_account] == 'acct_abc'
-        end.once.returns(test_response(test_customer))
+        end.once.returns(make_response(make_customer))
         c = Stripe::Customer.retrieve("c_test_customer", {:stripe_account => 'acct_abc'})
       end
 
@@ -357,7 +357,7 @@ module Stripe
           opts[:method] == :get &&
           opts[:url] == "#{Stripe.api_base}/v1/customers/c_test_customer" &&
           opts[:headers][:stripe_account] == 'acct_abc'
-        end.once.returns(test_response(test_customer))
+        end.once.returns(make_response(make_customer))
         c = Stripe::Customer.retrieve("c_test_customer", {:stripe_account => 'acct_abc'})
 
         Stripe.expects(:execute_request).with do |opts|
@@ -365,7 +365,7 @@ module Stripe
           opts[:url] == "#{Stripe.api_base}/v1/customers/c_test_customer" &&
           opts[:headers][:stripe_account] == 'acct_abc' &&
           opts[:payload] == 'description=FOO'
-        end.once.returns(test_response(test_customer))
+        end.once.returns(make_response(make_customer))
         c.description = 'FOO'
         c.save
       end
@@ -373,7 +373,7 @@ module Stripe
       context "error checking" do
 
         should "404s should raise an InvalidRequestError" do
-          response = test_response(test_missing_id_error, 404)
+          response = make_response(make_missing_id_error, 404)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 404))
 
           rescued = false
@@ -391,7 +391,7 @@ module Stripe
         end
 
         should "5XXs should raise an APIError" do
-          response = test_response(test_api_error, 500)
+          response = make_response(make_api_error, 500)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 500))
 
           rescued = false
@@ -407,7 +407,7 @@ module Stripe
         end
 
         should "402s should raise a CardError" do
-          response = test_response(test_invalid_exp_year_error, 402)
+          response = make_response(make_invalid_exp_year_error, 402)
           @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 402))
 
           rescued = false
@@ -436,7 +436,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[first_name]=Bob').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[first_name]=Bob').returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.first_name = 'Bob'
         acct.save
@@ -450,7 +450,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(make_response({"id" => "myid"}))
 
         acct.save
       end
@@ -464,7 +464,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/charges/charge_id", nil, '').returns(test_response({"id" => "charge_id"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/charges/charge_id", nil, '').returns(make_response({"id" => "charge_id"}))
 
         ch.customer.description = 'Bob'
         ch.save
@@ -485,7 +485,7 @@ module Stripe
             'legal_entity[first_name]=Bob&legal_entity[last_name]=',
             'legal_entity[last_name]=&legal_entity[first_name]=Bob'
           )
-        ).returns(test_response({"id" => "myid"}))
+        ).returns(make_response({"id" => "myid"}))
 
         acct.legal_entity = {:first_name => 'Bob'}
         acct.save
@@ -497,7 +497,7 @@ module Stripe
           :legal_entity => {}
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.additional_owners = [{:first_name => 'Bob'}]
         acct.save
@@ -511,7 +511,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.additional_owners << {:first_name => 'Bob'}
         acct.save
@@ -525,7 +525,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][1][first_name]=Janet').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][1][first_name]=Janet').returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.additional_owners[1].first_name = 'Janet'
         acct.save
@@ -540,7 +540,7 @@ module Stripe
           :currencies_supported => ['usd', 'cad']
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(make_response({"id" => "myid"}))
 
         acct.save
       end
@@ -553,7 +553,7 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(test_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, '').returns(make_response({"id" => "myid"}))
 
         acct.save
       end

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ApplicationFeeRefundTest < Test::Unit::TestCase
     should "refunds should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
 
       application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
 
@@ -11,7 +11,7 @@ module Stripe
     end
 
     should "refunds should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_application_fee), test_response(test_application_fee_refund(:id => 'refreshed_refund')))
+      @mock.expects(:get).twice.returns(make_response(make_application_fee), make_response(make_application_fee_refund(:id => 'refreshed_refund')))
 
       application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
       refund = application_fee.refunds.first
@@ -21,8 +21,8 @@ module Stripe
     end
 
     should "refunds should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
-      @mock.expects(:post).once.returns(test_response(test_application_fee_refund(:metadata => {'key' => 'value'})))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
+      @mock.expects(:post).once.returns(make_response(make_application_fee_refund(:metadata => {'key' => 'value'})))
 
       application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
       refund = application_fee.refunds.first
@@ -36,8 +36,8 @@ module Stripe
     end
 
     should "create should return a new refund" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee))
-      @mock.expects(:post).once.returns(test_response(test_application_fee_refund(:id => 'test_new_refund')))
+      @mock.expects(:get).once.returns(make_response(make_application_fee))
+      @mock.expects(:post).once.returns(make_response(make_application_fee_refund(:id => 'test_new_refund')))
 
       application_fee = Stripe::ApplicationFee.retrieve('test_application_fee')
       refund = application_fee.refunds.create(:amount => 20)

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ApplicationFeeTest < Test::Unit::TestCase
     should "application fees should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_application_fee_array))
+      @mock.expects(:get).once.returns(make_response(make_application_fee_array))
       fees = Stripe::ApplicationFee.all
       assert fees.data.kind_of? Array
       fees.each do |fee|
@@ -13,7 +13,7 @@ module Stripe
 
     should "application fees should be refundable" do
       @mock.expects(:get).never
-      @mock.expects(:post).once.returns(test_response({:id => "fee_test_fee", :refunded => true}))
+      @mock.expects(:post).once.returns(make_response({:id => "fee_test_fee", :refunded => true}))
       fee = Stripe::ApplicationFee.new("test_application_fee")
       fee.refund
       assert fee.refunded

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class BalanceTest < Test::Unit::TestCase
     should "balance should be retrievable" do
-      @mock.expects(:get).once.returns(test_response(test_balance))
+      @mock.expects(:get).once.returns(make_response(make_balance))
       balance = Stripe::Balance.retrieve
       assert_equal('balance', balance['object'])
     end

--- a/test/stripe/bitcoin_receiver_test.rb
+++ b/test/stripe/bitcoin_receiver_test.rb
@@ -3,19 +3,19 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class BitcoinReceiverTest < Test::Unit::TestCase
     should "retrieve should retrieve bitcoin receiver" do
-      @mock.expects(:get).once.returns(test_response(test_bitcoin_receiver))
+      @mock.expects(:get).once.returns(make_response(make_bitcoin_receiver))
       receiver = Stripe::BitcoinReceiver.retrieve('btcrcv_test_receiver')
       assert_equal 'btcrcv_test_receiver', receiver.id
     end
 
     should "create should create a bitcoin receiver" do
-      @mock.expects(:post).once.returns(test_response(test_bitcoin_receiver))
+      @mock.expects(:post).once.returns(make_response(make_bitcoin_receiver))
       receiver = Stripe::BitcoinReceiver.create
       assert_equal "btcrcv_test_receiver", receiver.id
     end
 
     should "all should list bitcoin receivers" do
-      @mock.expects(:get).once.returns(test_response(test_bitcoin_receiver_array))
+      @mock.expects(:get).once.returns(make_response(make_bitcoin_receiver_array))
       receivers = Stripe::BitcoinReceiver.all
       assert_equal 3, receivers.data.length
       assert receivers.data.kind_of? Array
@@ -28,32 +28,32 @@ module Stripe
     end
 
     should "maintain bitcoin transaction sublist" do
-      @mock.expects(:get).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, nil).once.returns(test_response(test_bitcoin_receiver))
+      @mock.expects(:get).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, nil).once.returns(make_response(make_bitcoin_receiver))
       receiver = Stripe::BitcoinReceiver.retrieve('btcrcv_test_receiver')
-      @mock.expects(:get).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver/transactions", nil, nil).once.returns(test_response(test_bitcoin_transaction_array))
+      @mock.expects(:get).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver/transactions", nil, nil).once.returns(make_response(make_bitcoin_transaction_array))
       transactions = receiver.transactions.all
       assert_equal(3, transactions.data.length)
     end
 
     should "update should update a bitcoin receiver" do
-      @mock.expects(:get).once.returns(test_response(test_bitcoin_receiver))
-      @mock.expects(:post).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, "description=details").once.returns(test_response(test_bitcoin_receiver))
-      receiver = Stripe::BitcoinReceiver.construct_from(test_bitcoin_receiver)
+      @mock.expects(:get).once.returns(make_response(make_bitcoin_receiver))
+      @mock.expects(:post).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, "description=details").once.returns(make_response(make_bitcoin_receiver))
+      receiver = Stripe::BitcoinReceiver.construct_from(make_bitcoin_receiver)
       receiver.refresh
       receiver.description = "details"
       receiver.save
     end
 
     should "delete a bitcoin receiver with no customer through top-level API" do
-      @mock.expects(:delete).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, nil).once.returns(test_response({:deleted => true, :id => "btcrcv_test_receiver"}))
-      receiver = Stripe::BitcoinReceiver.construct_from(test_bitcoin_receiver)
+      @mock.expects(:delete).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, nil).once.returns(make_response({:deleted => true, :id => "btcrcv_test_receiver"}))
+      receiver = Stripe::BitcoinReceiver.construct_from(make_bitcoin_receiver)
       response = receiver.delete
       assert(receiver.deleted)
     end
 
     should "delete a bitcoin receiver with a customer through customer's subresource API" do
-      @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/customer_foo/sources/btcrcv_test_receiver", nil, nil).once.returns(test_response({:deleted => true, :id => "btcrcv_test_receiver"}))
-      receiver = Stripe::BitcoinReceiver.construct_from(test_bitcoin_receiver(:customer => 'customer_foo'))
+      @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/customer_foo/sources/btcrcv_test_receiver", nil, nil).once.returns(make_response({:deleted => true, :id => "btcrcv_test_receiver"}))
+      receiver = Stripe::BitcoinReceiver.construct_from(make_bitcoin_receiver(:customer => 'customer_foo'))
       response = receiver.delete
       assert(receiver.deleted)
     end

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ChargeTest < Test::Unit::TestCase
     should "charges should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_charge_array))
+      @mock.expects(:get).once.returns(make_response(make_charge_array))
       c = Stripe::Charge.all
       assert c.data.kind_of? Array
       c.each do |charge|
@@ -13,7 +13,7 @@ module Stripe
 
     should "charges should be refundable" do
       @mock.expects(:get).never
-      @mock.expects(:post).once.returns(test_response({:id => "ch_test_charge", :refunded => true}))
+      @mock.expects(:post).once.returns(make_response({:id => "ch_test_charge", :refunded => true}))
       c = Stripe::Charge.new("test_charge")
       c.refund
       assert c.refunded
@@ -21,15 +21,15 @@ module Stripe
 
     should "charges should not be deletable" do
       assert_raises NoMethodError do
-        @mock.expects(:get).once.returns(test_response(test_charge))
+        @mock.expects(:get).once.returns(make_response(make_charge))
         c = Stripe::Charge.retrieve("test_charge")
         c.delete
       end
     end
 
     should "charges should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
       c = Stripe::Charge.new("test_charge")
       c.refresh
       c.mnemonic = "New charge description"
@@ -37,23 +37,23 @@ module Stripe
     end
 
     should "charges should be able to be marked as fraudulent" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
       c = Stripe::Charge.new("test_charge")
       c.refresh
       c.mark_as_fraudulent
     end
 
     should "charges should be able to be marked as safe" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_charge))
       c = Stripe::Charge.new("test_charge")
       c.refresh
       c.mark_as_safe
     end
 
     should "charges should have Card objects associated with their Card property" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
       c = Stripe::Charge.retrieve("test_charge")
       assert c.card.kind_of?(Stripe::StripeObject) && c.card.object == 'card'
     end
@@ -66,7 +66,7 @@ module Stripe
           'card[number]' => ['4242424242424242'],
           'card[exp_month]' => ['11']
         }
-      end.once.returns(test_response(test_charge))
+      end.once.returns(make_response(make_charge))
 
       c = Stripe::Charge.create({
         :amount => 100,
@@ -86,7 +86,7 @@ module Stripe
           'currency' => ['usd'], 'amount' => ['100'],
           'source' => ['btcrcv_test_receiver']
         }
-      end.once.returns(test_response(test_charge))
+      end.once.returns(make_response(make_charge))
 
       c = Stripe::Charge.create({
         :amount => 100,

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -3,14 +3,14 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class CouponTest < Test::Unit::TestCase
     should "create should return a new coupon" do
-      @mock.expects(:post).once.returns(test_response(test_coupon))
+      @mock.expects(:post).once.returns(make_response(make_coupon))
       c = Stripe::Coupon.create
       assert_equal "co_test_coupon", c.id
     end
 
     should "coupons should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_coupon))
-      @mock.expects(:post).once.returns(test_response(test_coupon))
+      @mock.expects(:get).once.returns(make_response(make_coupon))
+      @mock.expects(:post).once.returns(make_response(make_coupon))
       c = Stripe::Coupon.new("test_coupon")
       c.refresh
       c.metadata['foo'] = 'bar'

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -5,13 +5,13 @@ module Stripe
     CUSTOMER_CARD_URL = '/v1/customers/test_customer/sources/test_card'
 
     def customer
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
       Stripe::Customer.retrieve('test_customer')
     end
 
     should "customer cards should be listable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_customer_card_array(customer.id)))
+      @mock.expects(:get).once.returns(make_response(make_customer_card_array(customer.id)))
       cards = c.sources.all(:object => "card").data
       assert cards.kind_of? Array
       assert cards[0].kind_of? Stripe::Card
@@ -19,7 +19,7 @@ module Stripe
 
     should "customer cards should have the correct url" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card(
+      @mock.expects(:get).once.returns(make_response(make_card(
         :id => 'test_card',
         :customer => 'test_customer'
       )))
@@ -29,8 +29,8 @@ module Stripe
 
     should "customer cards should be deletable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card))
-      @mock.expects(:delete).once.returns(test_response(test_card(:deleted => true)))
+      @mock.expects(:get).once.returns(make_response(make_card))
+      @mock.expects(:delete).once.returns(make_response(make_card(:deleted => true)))
       card = c.sources.retrieve('card')
       card.delete
       assert card.deleted
@@ -38,8 +38,8 @@ module Stripe
 
     should "customer cards should be updateable" do
       c = customer
-      @mock.expects(:get).once.returns(test_response(test_card(:exp_year => "2000")))
-      @mock.expects(:post).once.returns(test_response(test_card(:exp_year => "2100")))
+      @mock.expects(:get).once.returns(make_response(make_card(:exp_year => "2000")))
+      @mock.expects(:post).once.returns(make_response(make_card(:exp_year => "2100")))
       card = c.sources.retrieve('card')
       assert_equal "2000", card.exp_year
       card.exp_year = "2100"
@@ -49,7 +49,7 @@ module Stripe
 
     should "create should return a new customer card" do
       c = customer
-      @mock.expects(:post).once.returns(test_response(test_card(:id => "test_card")))
+      @mock.expects(:post).once.returns(make_response(make_card(:id => "test_card")))
       card = c.sources.create(:source => "tok_41YJ05ijAaWaFS")
       assert_equal "test_card", card.id
     end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -3,22 +3,22 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class CustomerTest < Test::Unit::TestCase
     should "customers should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_customer_array))
+      @mock.expects(:get).once.returns(make_response(make_customer_array))
       c = Stripe::Customer.all.data
       assert c.kind_of? Array
       assert c[0].kind_of? Stripe::Customer
     end
 
     should "customers should be deletable" do
-      @mock.expects(:delete).once.returns(test_response(test_customer({:deleted => true})))
+      @mock.expects(:delete).once.returns(make_response(make_customer({:deleted => true})))
       c = Stripe::Customer.new("test_customer")
       c.delete
       assert c.deleted
     end
 
     should "customers should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_customer({:mnemonic => "foo"})))
-      @mock.expects(:post).once.returns(test_response(test_customer({:mnemonic => "bar"})))
+      @mock.expects(:get).once.returns(make_response(make_customer({:mnemonic => "foo"})))
+      @mock.expects(:post).once.returns(make_response(make_customer({:mnemonic => "bar"})))
       c = Stripe::Customer.new("test_customer").refresh
       assert_equal "foo", c.mnemonic
       c.mnemonic = "bar"
@@ -27,24 +27,24 @@ module Stripe
     end
 
     should "create should return a new customer" do
-      @mock.expects(:post).once.returns(test_response(test_customer))
+      @mock.expects(:post).once.returns(make_response(make_customer))
       c = Stripe::Customer.create
       assert_equal "c_test_customer", c.id
     end
 
     should "create_upcoming_invoice should create a new invoice" do
-      @mock.expects(:post).once.returns(test_response(test_invoice))
+      @mock.expects(:post).once.returns(make_response(make_invoice))
       i = Stripe::Customer.new("test_customer").create_upcoming_invoice
       assert_equal "c_test_customer", i.customer
     end
 
     should "be able to update a customer's subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
       c = Stripe::Customer.retrieve("test_customer")
 
       @mock.expects(:post).once.with do |url, api_key, params|
         url == "#{Stripe.api_base}/v1/customers/c_test_customer/subscription" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
-      end.returns(test_response(test_subscription(:plan => 'silver')))
+      end.returns(make_response(make_subscription(:plan => 'silver')))
       s = c.update_subscription({:plan => 'silver'})
 
       assert_equal 'subscription', s.object
@@ -52,15 +52,15 @@ module Stripe
     end
 
     should "be able to cancel a customer's subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
       c = Stripe::Customer.retrieve("test_customer")
 
       # Not an accurate response, but whatever
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription?at_period_end=true", nil, nil).returns(test_response(test_subscription(:plan => 'silver')))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription?at_period_end=true", nil, nil).returns(make_response(make_subscription(:plan => 'silver')))
       c.cancel_subscription({:at_period_end => 'true'})
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription", nil, nil).returns(test_response(test_subscription(:plan => 'silver')))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscription", nil, nil).returns(make_response(make_subscription(:plan => 'silver')))
       c.cancel_subscription
     end
 
@@ -69,7 +69,7 @@ module Stripe
 
       @mock.expects(:post).once.with do |url, api_key, params|
         url == "#{Stripe.api_base}/v1/customers/test_customer/subscriptions" && api_key.nil? && CGI.parse(params) == {'plan' => ['silver']}
-      end.returns(test_response(test_subscription(:plan => 'silver')))
+      end.returns(make_response(make_subscription(:plan => 'silver')))
       s = c.create_subscription({:plan => 'silver'})
 
       assert_equal 'subscription', s.object
@@ -77,10 +77,10 @@ module Stripe
     end
 
     should "be able to delete a customer's discount" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
       c = Stripe::Customer.retrieve("test_customer")
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/discount", nil, nil).returns(test_response(test_delete_discount_response))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/discount", nil, nil).returns(make_response(make_delete_discount_response))
       c.delete_discount
       assert_equal nil, c.discount
     end

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class FileUploadTest < Test::Unit::TestCase
     should "create should return a new file" do
-      @mock.expects(:post).once.returns(test_response(test_file))
+      @mock.expects(:post).once.returns(make_response(make_file))
       f = Stripe::FileUpload.create({
         :purpose => "dispute_evidence",
         :file => File.new(__FILE__),
@@ -12,14 +12,14 @@ module Stripe
     end
 
     should "files should be retrievable" do
-      @mock.expects(:get).once.returns(test_response(test_file))
+      @mock.expects(:get).once.returns(make_response(make_file))
       c = Stripe::FileUpload.new("fil_test_file")
       c.refresh
       assert_equal 1403047735, c.created
     end
 
     should "files should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_file_array))
+      @mock.expects(:get).once.returns(make_response(make_file_array))
       c = Stripe::FileUpload.all.data
       assert c.kind_of? Array
       assert c[0].kind_of? Stripe::FileUpload

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -3,35 +3,35 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class InvoiceTest < Test::Unit::TestCase
     should "retrieve should retrieve invoices" do
-      @mock.expects(:get).once.returns(test_response(test_invoice))
+      @mock.expects(:get).once.returns(make_response(make_invoice))
       i = Stripe::Invoice.retrieve('in_test_invoice')
       assert_equal 'in_test_invoice', i.id
     end
 
     should "create should create a new invoice" do
-      @mock.expects(:post).once.returns(test_response(test_invoice))
+      @mock.expects(:post).once.returns(make_response(make_invoice))
       i = Stripe::Invoice.create
       assert_equal "in_test_invoice", i.id
     end
 
     should "pay should pay an invoice" do
-      @mock.expects(:get).once.returns(test_response(test_invoice))
+      @mock.expects(:get).once.returns(make_response(make_invoice))
       i = Stripe::Invoice.retrieve('in_test_invoice')
 
-      @mock.expects(:post).once.with('https://api.stripe.com/v1/invoices/in_test_invoice/pay', nil, '').returns(test_response(test_paid_invoice))
+      @mock.expects(:post).once.with('https://api.stripe.com/v1/invoices/in_test_invoice/pay', nil, '').returns(make_response(make_paid_invoice))
       i.pay
       assert_equal nil, i.next_payment_attempt
     end
 
     should "pay with extra opts should pay an invoice" do
-      @mock.expects(:get).once.returns(test_response(test_invoice))
+      @mock.expects(:get).once.returns(make_response(make_invoice))
       i = Stripe::Invoice.retrieve('in_test_invoice', {:api_key => 'foobar'})
 
       Stripe.expects(:execute_request).with do |opts|
         opts[:url] == "#{Stripe.api_base}/v1/invoices/in_test_invoice/pay" &&
           opts[:method] == :post &&
           opts[:headers][:authorization] == 'Bearer foobar'
-      end.returns(test_response(test_paid_invoice))
+      end.returns(make_response(make_paid_invoice))
 
       i.pay
       assert_equal nil, i.next_payment_attempt

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ListObjectTest < Test::Unit::TestCase
     should "be able to retrieve full lists given a listobject" do
-      @mock.expects(:get).twice.returns(test_response(test_charge_array))
+      @mock.expects(:get).twice.returns(make_response(make_charge_array))
       c = Stripe::Charge.all
       assert c.kind_of?(Stripe::ListObject)
       assert_equal('/v1/charges', c.url)

--- a/test/stripe/metadata_test.rb
+++ b/test/stripe/metadata_test.rb
@@ -6,23 +6,23 @@ module Stripe
       @metadata_supported = {
         :charge => {
           :new => Stripe::Charge.method(:new),
-          :test => method(:test_charge),
-          :url => "/v1/charges/#{test_charge()[:id]}"
+          :test => method(:make_charge),
+          :url => "/v1/charges/#{make_charge()[:id]}"
         },
         :customer => {
           :new => Stripe::Customer.method(:new),
-          :test => method(:test_customer),
-          :url => "/v1/customers/#{test_customer()[:id]}"
+          :test => method(:make_customer),
+          :url => "/v1/customers/#{make_customer()[:id]}"
         },
         :recipient => {
           :new => Stripe::Recipient.method(:new),
-          :test => method(:test_recipient),
-          :url => "/v1/recipients/#{test_recipient()[:id]}"
+          :test => method(:make_recipient),
+          :url => "/v1/recipients/#{make_recipient()[:id]}"
         },
         :transfer => {
           :new => Stripe::Transfer.method(:new),
-          :test => method(:test_transfer),
-          :url => "/v1/transfers/#{test_transfer()[:id]}"
+          :test => method(:make_transfer),
+          :url => "/v1/transfers/#{make_transfer()[:id]}"
         }
       }
 
@@ -92,11 +92,11 @@ module Stripe
         url = @base_url + methods[:url]
 
         initial_test_obj = test.call(initial_params)
-        @mock.expects(:get).once.returns(test_response(initial_test_obj))
+        @mock.expects(:get).once.returns(make_response(initial_test_obj))
 
         final_test_obj = test.call()
         @mock.expects(:post).once.
-          returns(test_response(final_test_obj)).
+          returns(make_response(final_test_obj)).
           with(url, nil, curl_args)
 
         obj = neu.call("test")

--- a/test/stripe/recipient_card_test.rb
+++ b/test/stripe/recipient_card_test.rb
@@ -5,13 +5,13 @@ module Stripe
     RECIPIENT_CARD_URL = '/v1/recipients/test_recipient/cards/test_card'
 
     def recipient
-      @mock.expects(:get).once.returns(test_response(test_recipient))
+      @mock.expects(:get).once.returns(make_response(make_recipient))
       Stripe::Recipient.retrieve('test_recipient')
     end
 
     should "recipient cards should be listable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_recipient_card_array(recipient.id)))
+      @mock.expects(:get).once.returns(make_response(make_recipient_card_array(recipient.id)))
       cards = c.cards.all.data
       assert cards.kind_of? Array
       assert cards[0].kind_of? Stripe::Card
@@ -19,7 +19,7 @@ module Stripe
 
     should "recipient cards should have the correct url" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card(
+      @mock.expects(:get).once.returns(make_response(make_card(
         :id => 'test_card',
         :recipient => 'test_recipient'
       )))
@@ -29,8 +29,8 @@ module Stripe
 
     should "recipient cards should be deletable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card))
-      @mock.expects(:delete).once.returns(test_response(test_card(:deleted => true)))
+      @mock.expects(:get).once.returns(make_response(make_card))
+      @mock.expects(:delete).once.returns(make_response(make_card(:deleted => true)))
       card = c.cards.retrieve('card')
       card.delete
       assert card.deleted
@@ -38,8 +38,8 @@ module Stripe
 
     should "recipient cards should be updateable" do
       c = recipient
-      @mock.expects(:get).once.returns(test_response(test_card(:exp_year => "2000")))
-      @mock.expects(:post).once.returns(test_response(test_card(:exp_year => "2100")))
+      @mock.expects(:get).once.returns(make_response(make_card(:exp_year => "2000")))
+      @mock.expects(:post).once.returns(make_response(make_card(:exp_year => "2100")))
       card = c.cards.retrieve('card')
       assert_equal "2000", card.exp_year
       card.exp_year = "2100"
@@ -49,7 +49,7 @@ module Stripe
 
     should "create should return a new recipient card" do
       c = recipient
-      @mock.expects(:post).once.returns(test_response(test_card(:id => "test_card")))
+      @mock.expects(:post).once.returns(make_response(make_card(:id => "test_card")))
       card = c.cards.create(:card => "tok_41YJ05ijAaWaFS")
       assert_equal "test_card", card.id
     end

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class RefundTest < Test::Unit::TestCase
     should "refunds should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
+      @mock.expects(:get).once.returns(make_response(make_charge))
 
       charge = Stripe::Charge.retrieve('test_charge')
 
@@ -11,7 +11,7 @@ module Stripe
     end
 
     should "refunds should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_charge), test_response(test_refund(:id => 'refreshed_refund')))
+      @mock.expects(:get).twice.returns(make_response(make_charge), make_response(make_refund(:id => 'refreshed_refund')))
 
       charge = Stripe::Charge.retrieve('test_charge')
       refund = charge.refunds.first
@@ -21,8 +21,8 @@ module Stripe
     end
 
     should "refunds should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_refund(:metadata => {'key' => 'value'})))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_refund(:metadata => {'key' => 'value'})))
 
       charge = Stripe::Charge.retrieve('test_charge')
       refund = charge.refunds.first
@@ -36,8 +36,8 @@ module Stripe
     end
 
     should "create should return a new refund" do
-      @mock.expects(:get).once.returns(test_response(test_charge))
-      @mock.expects(:post).once.returns(test_response(test_refund(:id => 'test_new_refund')))
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      @mock.expects(:post).once.returns(make_response(make_refund(:id => 'test_new_refund')))
 
       charge = Stripe::Charge.retrieve('test_charge')
       refund = charge.refunds.create(:amount => 20)

--- a/test/stripe/reversal_test.rb
+++ b/test/stripe/reversal_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class ReversalTest < Test::Unit::TestCase
     should "reversals should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
+      @mock.expects(:get).once.returns(make_response(make_transfer))
 
       transfer = Stripe::Transfer.retrieve('test_transfer')
 
@@ -11,7 +11,7 @@ module Stripe
     end
 
     should "reversals should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_transfer), test_response(test_reversal(:id => 'refreshed_reversal')))
+      @mock.expects(:get).twice.returns(make_response(make_transfer), make_response(make_reversal(:id => 'refreshed_reversal')))
 
       transfer = Stripe::Transfer.retrieve('test_transfer')
       reversal = transfer.reversals.first
@@ -21,8 +21,8 @@ module Stripe
     end
 
     should "reversals should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
-      @mock.expects(:post).once.returns(test_response(test_reversal(:metadata => {'key' => 'value'})))
+      @mock.expects(:get).once.returns(make_response(make_transfer))
+      @mock.expects(:post).once.returns(make_response(make_reversal(:metadata => {'key' => 'value'})))
 
       transfer = Stripe::Transfer.retrieve('test_transfer')
       reversal = transfer.reversals.first
@@ -36,8 +36,8 @@ module Stripe
     end
 
     should "create should return a new reversal" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
-      @mock.expects(:post).once.returns(test_response(test_reversal(:id => 'test_new_reversal')))
+      @mock.expects(:get).once.returns(make_response(make_transfer))
+      @mock.expects(:post).once.returns(make_response(make_reversal(:id => 'test_new_reversal')))
 
       transfer = Stripe::Transfer.retrieve('test_transfer')
       reversals = transfer.reversals.create(:amount => 20)

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class SubscriptionTest < Test::Unit::TestCase
     should "subscriptions should be listable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
 
       customer = Stripe::Customer.retrieve('test_customer')
 
@@ -11,7 +11,7 @@ module Stripe
     end
 
     should "subscriptions should be refreshable" do
-      @mock.expects(:get).twice.returns(test_response(test_customer), test_response(test_subscription(:id => 'refreshed_subscription')))
+      @mock.expects(:get).twice.returns(make_response(make_customer), make_response(make_subscription(:id => 'refreshed_subscription')))
 
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.first
@@ -21,20 +21,20 @@ module Stripe
     end
 
     should "subscriptions should be deletable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
+      @mock.expects(:get).once.returns(make_response(make_customer))
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.first
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}?at_period_end=true", nil, nil).returns(test_response(test_subscription))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}?at_period_end=true", nil, nil).returns(make_response(make_subscription))
       subscription.delete :at_period_end => true
 
-      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}", nil, nil).returns(test_response(test_subscription))
+      @mock.expects(:delete).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/#{subscription.id}", nil, nil).returns(make_response(make_subscription))
       subscription.delete
     end
 
     should "subscriptions should be updateable" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription({:status => 'active'})))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription({:status => 'active'})))
 
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.first
@@ -47,8 +47,8 @@ module Stripe
     end
 
     should "create should return a new subscription" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription(:id => 'test_new_subscription')))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription(:id => 'test_new_subscription')))
 
       customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.create(:plan => 'silver')
@@ -56,15 +56,15 @@ module Stripe
     end
 
     should "be able to delete a subscriptions's discount" do
-      @mock.expects(:get).once.returns(test_response(test_customer))
-      @mock.expects(:post).once.returns(test_response(test_subscription(:id => 'test_new_subscription')))
+      @mock.expects(:get).once.returns(make_response(make_customer))
+      @mock.expects(:post).once.returns(make_response(make_subscription(:id => 'test_new_subscription')))
 
 
-      customer = Stripe::Customer.retrieve("test_customer")
+      customer = Stripe::Customer.retrieve('test_customer')
       subscription = customer.subscriptions.create(:plan => 'silver')
 
       url = "#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/test_new_subscription/discount"
-      @mock.expects(:delete).once.with(url, nil, nil).returns(test_response(test_delete_discount_response))
+      @mock.expects(:delete).once.with(url, nil, nil).returns(make_response(make_delete_discount_response))
       subscription.delete_discount
       assert_equal nil, subscription.discount
     end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -3,22 +3,22 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class TransferTest < Test::Unit::TestCase
     should "retrieve should retrieve transfer" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
+      @mock.expects(:get).once.returns(make_response(make_transfer))
       transfer = Stripe::Transfer.retrieve('tr_test_transfer')
       assert_equal 'tr_test_transfer', transfer.id
     end
 
     should "create should create a transfer" do
-      @mock.expects(:post).once.returns(test_response(test_transfer))
+      @mock.expects(:post).once.returns(make_response(make_transfer))
       transfer = Stripe::Transfer.create
       assert_equal "tr_test_transfer", transfer.id
     end
 
     should "cancel should cancel a transfer" do
-      @mock.expects(:get).once.returns(test_response(test_transfer))
+      @mock.expects(:get).once.returns(make_response(make_transfer))
       transfer = Stripe::Transfer.retrieve('tr_test_transfer')
 
-      @mock.expects(:post).once.with('https://api.stripe.com/v1/transfers/tr_test_transfer/cancel', nil, '').returns(test_response(test_canceled_transfer))
+      @mock.expects(:post).once.with('https://api.stripe.com/v1/transfers/tr_test_transfer/cancel', nil, '').returns(make_response(make_canceled_transfer))
       transfer.cancel
     end
   end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,6 +1,6 @@
 module Stripe
   module TestData
-    def test_response(body, code=200)
+    def make_response(body, code=200)
       # When an exception is raised, restclient clobbers method_missing.  Hence we
       # can't just use the stubs interface.
       body = JSON.generate(body) if !(body.kind_of? String)
@@ -11,7 +11,7 @@ module Stripe
       m
     end
 
-    def test_balance(params={})
+    def make_balance(params={})
       {
         :pending => [
           {:amount => 12345, :currency => "usd"}
@@ -24,7 +24,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_balance_transaction(params={})
+    def make_balance_transaction(params={})
       {
         :amount => 100,
         :net => 41,
@@ -39,15 +39,15 @@ module Stripe
       }.merge(params)
     end
 
-    def test_balance_transaction_array
+    def make_balance_transaction_array
       {
-        :data => [test_balance_transaction, test_balance_transaction, test_balance_transaction],
+        :data => [make_balance_transaction, make_balance_transaction, make_balance_transaction],
         :object => "list",
         :url => "/v1/balance/history"
       }
     end
 
-    def test_application_fee(params={})
+    def make_application_fee(params={})
       id = params[:id] || 'fee_test_fee'
       {
         :refunded => false,
@@ -59,12 +59,12 @@ module Stripe
         :livemode => false,
         :currency => "usd",
         :object => "application_fee",
-        :refunds => test_application_fee_refund_array(id),
+        :refunds => make_application_fee_refund_array(id),
         :created => 1304114826
       }.merge(params)
     end
 
-    def test_application_fee_refund(params = {})
+    def make_application_fee_refund(params = {})
       {
         :object => 'fee_refund',
         :amount => 30,
@@ -76,23 +76,23 @@ module Stripe
       }.merge(params)
     end
 
-    def test_application_fee_array
+    def make_application_fee_array
       {
-        :data => [test_application_fee, test_application_fee, test_application_fee],
+        :data => [make_application_fee, make_application_fee, make_application_fee],
         :object => 'list',
         :url => '/v1/application_fees'
       }
     end
 
-    def test_application_fee_refund_array(fee_id)
+    def make_application_fee_refund_array(fee_id)
       {
-        :data => [test_application_fee_refund, test_application_fee_refund, test_application_fee_refund],
+        :data => [make_application_fee_refund, make_application_fee_refund, make_application_fee_refund],
         :object => 'list',
         :url => '/v1/application_fees/' + fee_id + '/refunds'
       }
     end
 
-    def test_customer(params={})
+    def make_customer(params={})
       id = params[:id] || 'c_test_customer'
       {
         :subscription_history => [],
@@ -103,21 +103,21 @@ module Stripe
         :id => id,
         :default_card => "cc_test_card",
         :created => 1304114758,
-        :sources => test_customer_card_array(id),
+        :sources => make_customer_card_array(id),
         :metadata => {},
-        :subscriptions => test_subscription_array(id)
+        :subscriptions => make_subscription_array(id)
       }.merge(params)
     end
 
-    def test_customer_array
+    def make_customer_array
       {
-        :data => [test_customer, test_customer, test_customer],
+        :data => [make_customer, make_customer, make_customer],
         :object => 'list',
         :url => '/v1/customers'
       }
     end
 
-    def test_charge(params={})
+    def make_charge(params={})
       id = params[:id] || 'ch_test_charge'
       {
         :refunded => false,
@@ -138,36 +138,36 @@ module Stripe
         :currency => "usd",
         :object => "charge",
         :created => 1304114826,
-        :refunds => test_refund_array(id),
+        :refunds => make_refund_array(id),
         :metadata => {}
       }.merge(params)
     end
 
-    def test_charge_array
+    def make_charge_array
       {
-        :data => [test_charge, test_charge, test_charge],
+        :data => [make_charge, make_charge, make_charge],
         :object => 'list',
         :url => '/v1/charges'
       }
     end
 
-    def test_recipient_card_array(recipient_id)
+    def make_recipient_card_array(recipient_id)
       {
-        :data => [test_card, test_card, test_card],
+        :data => [make_card, make_card, make_card],
         :object => 'list',
         :url => '/v1/recipients/' + recipient_id + '/cards'
       }
     end
 
-    def test_customer_card_array(customer_id)
+    def make_customer_card_array(customer_id)
       {
-        :data => [test_card, test_card, test_card],
+        :data => [make_card, make_card, make_card],
         :object => 'list',
         :url => '/v1/customers/' + customer_id + '/sources'
       }
     end
 
-    def test_card(params={})
+    def make_card(params={})
       {
         :type => "Visa",
         :last4 => "4242",
@@ -180,7 +180,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_coupon(params={})
+    def make_coupon(params={})
       {
         :duration => 'repeating',
         :duration_in_months => 3,
@@ -191,7 +191,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_file(params={})
+    def make_file(params={})
       {
         :object => "file_upload",
         :id => "fil_test_file",
@@ -203,16 +203,16 @@ module Stripe
       }
     end
 
-    def test_file_array
+    def make_file_array
       {
-        :data => [test_file, test_file, test_file],
+        :data => [make_file, make_file, make_file],
         :object => 'list',
         :url => '/v1/files'
       }
     end
 
     #FIXME nested overrides would be better than hardcoding plan_id
-    def test_subscription(params = {})
+    def make_subscription(params = {})
       plan = params.delete(:plan) || 'gold'
       {
         :current_period_end => 1308681468,
@@ -234,7 +234,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_refund(params = {})
+    def make_refund(params = {})
       {
         :object => 'refund',
         :amount => 30,
@@ -246,31 +246,31 @@ module Stripe
       }.merge(params)
     end
 
-    def test_subscription_array(customer_id)
+    def make_subscription_array(customer_id)
       {
-        :data => [test_subscription, test_subscription, test_subscription],
+        :data => [make_subscription, make_subscription, make_subscription],
         :object => 'list',
         :url => '/v1/customers/' + customer_id + '/subscriptions'
       }
     end
 
-    def test_refund_array(charge_id)
+    def make_refund_array(charge_id)
       {
-        :data => [test_refund, test_refund, test_refund],
+        :data => [make_refund, make_refund, make_refund],
         :object => 'list',
         :url => '/v1/charges/' + charge_id + '/refunds'
       }
     end
 
-    def test_reversal_array(transfer_id)
+    def make_reversal_array(transfer_id)
       {
-        :data => [test_reversal, test_reversal, test_reversal],
+        :data => [make_reversal, make_reversal, make_reversal],
         :object => 'list',
         :url => '/v1/transfers/' + transfer_id + '/reversals'
       }
     end
 
-    def test_invoice
+    def make_invoice
       {
         :id => 'in_test_invoice',
         :object => 'invoice',
@@ -310,8 +310,8 @@ module Stripe
       }
     end
 
-    def test_paid_invoice
-      test_invoice.merge({
+    def make_paid_invoice
+      make_invoice.merge({
           :attempt_count => 1,
           :attempted => true,
           :closed => true,
@@ -322,15 +322,15 @@ module Stripe
         })
     end
 
-    def test_invoice_customer_array
+    def make_invoice_customer_array
       {
-        :data => [test_invoice],
+        :data => [make_invoice],
         :object => 'list',
         :url => '/v1/invoices?customer=test_customer'
       }
     end
 
-    def test_recipient(params={})
+    def make_recipient(params={})
       id = params[:id] || 'rp_test_recipient'
       {
         :name => "Stripe User",
@@ -338,7 +338,7 @@ module Stripe
         :livemode => false,
         :object => "recipient",
         :id => "rp_test_recipient",
-        :cards => test_recipient_card_array(id),
+        :cards => make_recipient_card_array(id),
         :default_card => "debit_test_card",
         :active_account => {
           :last4 => "6789",
@@ -352,15 +352,15 @@ module Stripe
       }.merge(params)
     end
 
-    def test_recipient_array
+    def make_recipient_array
       {
-        :data => [test_recipient, test_recipient, test_recipient],
+        :data => [make_recipient, make_recipient, make_recipient],
         :object => 'list',
         :url => '/v1/recipients'
       }
     end
 
-    def test_transfer(params={})
+    def make_transfer(params={})
       {
         :status => 'pending',
         :amount => 100,
@@ -374,7 +374,7 @@ module Stripe
         :fee => 0,
         :fee_details => [],
         :id => "tr_test_transfer",
-        :reversals => test_reversal_array('tr_test_transfer'),
+        :reversals => make_reversal_array('tr_test_transfer'),
         :livemode => false,
         :currency => "usd",
         :object => "transfer",
@@ -383,21 +383,21 @@ module Stripe
       }.merge(params)
     end
 
-    def test_transfer_array
+    def make_transfer_array
       {
-        :data => [test_transfer, test_transfer, test_transfer],
+        :data => [make_transfer, make_transfer, make_transfer],
         :object => 'list',
         :url => '/v1/transfers'
       }
     end
 
-    def test_canceled_transfer
-      test_transfer.merge({
+    def make_canceled_transfer
+      make_transfer.merge({
         :status => 'canceled'
       })
     end
 
-    def test_reversal(params={})
+    def make_reversal(params={})
       {
         :object => 'transfer_reversal',
         :amount => 30,
@@ -409,7 +409,7 @@ module Stripe
       }.merge(params)
     end
 
-    def test_bitcoin_receiver(params={})
+    def make_bitcoin_receiver(params={})
       {
         :id => 'btcrcv_test_receiver',
         :amount => 100,
@@ -417,19 +417,19 @@ module Stripe
         :description => 'some details',
         :metadata => {},
         :object => 'bitcoin_receiver',
-        :transactions => test_bitcoin_transaction_array
+        :transactions => make_bitcoin_transaction_array
       }.merge(params)
     end
 
-    def test_bitcoin_receiver_array
+    def make_bitcoin_receiver_array
       {
-        :data => [test_bitcoin_receiver, test_bitcoin_receiver, test_bitcoin_receiver],
+        :data => [make_bitcoin_receiver, make_bitcoin_receiver, make_bitcoin_receiver],
         :object => 'list',
         :url => '/v1/bitcoin/receivers'
       }
     end
 
-    def test_bitcoin_transaction(params={})
+    def make_bitcoin_transaction(params={})
       {
         :id => 'btctxn_test_transaction',
         :object => 'bitcoin_transaction',
@@ -440,15 +440,15 @@ module Stripe
       }.merge(params)
     end
 
-    def test_bitcoin_transaction_array
+    def make_bitcoin_transaction_array
       {
-        :data => [test_bitcoin_transaction, test_bitcoin_transaction, test_bitcoin_transaction],
+        :data => [make_bitcoin_transaction, make_bitcoin_transaction, make_bitcoin_transaction],
         :object => 'list',
         :url => "/v1/bitcoin/receivers/btcrcv_test_receiver/transactions"
       }
     end
 
-    def test_invalid_api_key_error
+    def make_invalid_api_key_error
       {
         :error => {
           :type => "invalid_request_error",
@@ -457,7 +457,7 @@ module Stripe
       }
     end
 
-    def test_invalid_exp_year_error
+    def make_invalid_exp_year_error
       {
         :error => {
           :code => "invalid_expiry_year",
@@ -468,7 +468,7 @@ module Stripe
       }
     end
 
-    def test_missing_id_error
+    def make_missing_id_error
       {
         :error => {
           :param => "id",
@@ -478,7 +478,7 @@ module Stripe
       }
     end
 
-    def test_api_error
+    def make_api_error
       {
         :error => {
           :type => "api_error"
@@ -486,7 +486,7 @@ module Stripe
       }
     end
 
-    def test_delete_discount_response
+    def make_delete_discount_response
       {
         :deleted => true,
         :id => "di_test_coupon"


### PR DESCRIPTION
Since the test data methods were prefixed with `test_` and being mixed into the UnitTest case, RakeTest was calling them as if they were unit tests. No more!