### PR TITLE
Add boolean accessors to stripe object

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -106,7 +106,11 @@ module Stripe
 
     if RUBY_VERSION < '1.9.2'
       def respond_to?(symbol)
-        @values.has_key?(symbol) || super
+        if symbol.to_s.end_with?('?')
+          has_boolean_value?(chop_symbol(symbol)) || super
+        else
+          @values.has_key?(symbol) || super
+        end
       end
     end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -233,6 +233,11 @@ module Stripe
           raise NoMethodError.new("Cannot set #{attr} on this object. HINT: you can't set: #{@@permanent_attributes.to_a.join(', ')}")
         end
         return mth.call(args[0])
+      elsif name.to_s.end_with?('?')
+        attr = name.to_s[0...-1].to_sym
+        if @values.has_key?(attr) && !!@values[attr] == @values[attr]
+          return @values[attr]
+        end
       else
         return @values[name] if @values.has_key?(name)
       end
@@ -249,7 +254,12 @@ module Stripe
     end
 
     def respond_to_missing?(symbol, include_private = false)
-      @values && @values.has_key?(symbol) || super
+      if symbol.to_s.end_with?('?')
+        name = symbol.to_s[0...-1].to_sym
+        @values.has_key?(name) && !!@values[name] == @values[name] || super
+      else
+        @values && @values.has_key?(symbol) || super
+      end
     end
   end
 end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class StripeObjectTest < Test::Unit::TestCase
     should "implement #respond_to correctly" do
-      obj = Stripe::StripeObject.construct_from({ :id => 1, :foo => 'bar', qux: true })
+      obj = Stripe::StripeObject.construct_from({ :id => 1, :foo => 'bar', :qux => true })
       assert obj.respond_to?(:id)
       assert obj.respond_to?(:foo)
       assert !obj.respond_to?(:baz)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -3,10 +3,13 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class StripeObjectTest < Test::Unit::TestCase
     should "implement #respond_to correctly" do
-      obj = Stripe::StripeObject.construct_from({ :id => 1, :foo => 'bar' })
+      obj = Stripe::StripeObject.construct_from({ :id => 1, :foo => 'bar', qux: true })
       assert obj.respond_to?(:id)
       assert obj.respond_to?(:foo)
       assert !obj.respond_to?(:baz)
+      assert obj.respond_to?(:qux)
+      assert obj.respond_to?(:qux?)
+      assert !obj.respond_to?(:foo?)
     end
 
     should "marshal a stripe object correctly" do


### PR DESCRIPTION
Adds a `value_key?` method to any boolean `value_key` on StripeObject. An
example of this is adding a `refunded?` method on a Charge object, as would be
idiomatic Ruby.

The first commit provides the above, along with tests which verify this behaviour. The second commit tidies up some of the repeated logic to make it a bit easier to follow.

We found using methods like `refunded?` made our own code easier to read and understand when working with Stripe Gem.