### PR TITLE
Fix #266: Add Token to object classes map

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -39,6 +39,7 @@ module Stripe
         'refund' => Refund,
         'subscription' => Subscription,
         'file_upload' => FileUpload,
+        'token' => Token,
         'transfer' => Transfer,
         'transfer_reversal' => Reversal,
         'bitcoin_receiver' => BitcoinReceiver,


### PR DESCRIPTION
The issue in #266 occurs because the "token" object isn't mapped to a class. This pull request fixes that.