### PR TITLE
Handle error responses that are not hashes more gracefully

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -250,7 +250,8 @@ module Stripe
     begin
       error_obj = JSON.parse(resp.body)
       error_obj = Util.symbolize_names(error_obj)
-      error = error_obj[:error] or raise StripeError.new # escape from parsing
+      error = error_obj[:error]
+      raise StripeError.new unless error && error.is_a?(Hash)
 
     rescue JSON::ParserError, StripeError
       raise general_api_error(resp.code, resp.body)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -125,6 +125,28 @@ module Stripe
         'sk_test_local')
     end
 
+    should "handle error response with empty body" do
+      response = make_response('', 500)
+      @mock.expects(:post).once.raises(RestClient::ExceptionWithResponse.new(response, 500))
+
+      e = assert_raises Stripe::APIError do
+        Stripe::Charge.create
+      end
+
+      assert_equal 'Invalid response object from API: "" (HTTP response code was 500)', e.message
+    end
+
+    should "handle error response with non-object error value" do
+      response = make_response('{"error": "foo"}', 500)
+      @mock.expects(:post).once.raises(RestClient::ExceptionWithResponse.new(response, 500))
+
+      e = assert_raises Stripe::APIError do
+        Stripe::Charge.create
+      end
+
+      assert_equal 'Invalid response object from API: "{\"error\": \"foo\"}" (HTTP response code was 500)', e.message
+    end
+
     should "have default open and read timeouts" do
       assert_equal Stripe.open_timeout, 30
       assert_equal Stripe.read_timeout, 80


### PR DESCRIPTION
Fixes #290.

r? @bkrausz 
