### PR TITLE
Correct list + retrieval of Bitcoin transactions

### DIFF
--- a/lib/stripe/bitcoin_transaction.rb
+++ b/lib/stripe/bitcoin_transaction.rb
@@ -1,4 +1,9 @@
 module Stripe
   class BitcoinTransaction < APIResource
+    include Stripe::APIOperations::List
+
+    def self.url
+      "/v1/bitcoin/transactions"
+    end
   end
 end

--- a/test/stripe/bitcoin_transaction_test.rb
+++ b/test/stripe/bitcoin_transaction_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class BitcoinTransactionTest < Test::Unit::TestCase
+    should "retrieve should retrieve bitcoin receiver" do
+      @mock.expects(:get).once.returns(make_response(make_bitcoin_transaction))
+      receiver = Stripe::BitcoinTransaction.retrieve('bttxn_test_transaction')
+      assert_equal 'btctxn_test_transaction', receiver.id
+    end
+
+    should "all should list bitcoin transactions" do
+      @mock.expects(:get).once.returns(make_response(make_bitcoin_transaction_array))
+      transactions = Stripe::BitcoinTransaction.all
+      assert_equal 3, transactions.data.length
+      assert transactions.data.kind_of? Array
+      transactions.each do |transaction|
+        assert transaction.kind_of?(Stripe::BitcoinTransaction)
+      end
+    end
+  end
+end

--- a/test/stripe/bitcoin_transaction_test.rb
+++ b/test/stripe/bitcoin_transaction_test.rb
@@ -2,14 +2,22 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class BitcoinTransactionTest < Test::Unit::TestCase
+    TEST_ID = "btctxn_test_transaction".freeze
+
     should "retrieve should retrieve bitcoin receiver" do
-      @mock.expects(:get).once.returns(make_response(make_bitcoin_transaction))
-      receiver = Stripe::BitcoinTransaction.retrieve('bttxn_test_transaction')
-      assert_equal 'btctxn_test_transaction', receiver.id
+      @mock.expects(:get).
+        with("#{Stripe.api_base}/v1/bitcoin/transactions/#{TEST_ID}", nil, nil).
+        once.
+        returns(make_response(make_bitcoin_transaction))
+      receiver = Stripe::BitcoinTransaction.retrieve(TEST_ID)
+      assert_equal TEST_ID, receiver.id
     end
 
     should "all should list bitcoin transactions" do
-      @mock.expects(:get).once.returns(make_response(make_bitcoin_transaction_array))
+      @mock.expects(:get).
+        with("#{Stripe.api_base}/v1/bitcoin/transactions", nil, nil).
+        once.
+        returns(make_response(make_bitcoin_transaction_array))
       transactions = Stripe::BitcoinTransaction.all
       assert_equal 3, transactions.data.length
       assert transactions.data.kind_of? Array


### PR DESCRIPTION
Corrects the paths at which the client looks for Bitcoin transactions
and adds a small test suite to check these results.

Fixes stripe/stripe-ruby#236.

/cc @kyleconroy