### PR TITLE
Remove use of deprecated `URI.escape`

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -1,3 +1,5 @@
+require "webrick"
+
 module Stripe
   module Util
     def self.objects_to_ids(h)
@@ -93,7 +95,10 @@ module Stripe
     end
 
     def self.url_encode(key)
-      URI.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      # Unfortunately, URI.escape was deprecated. Here we use a method from
+      # WEBrick instead given that it's a fairly close approximation (credit to
+      # the AWS Ruby SDK for coming up with the technique).
+      WEBrick::HTTPUtils.escape(key.to_s).gsub('%5B', '[').gsub('%5D', ']')
     end
 
     def self.flatten_params(params, parent_key=nil)


### PR DESCRIPTION
But we still want to percent-encode entities like spaces, so instead of
using `CGI.escape` we use a utility from WEBrick.

Fixes #286.