### PR TITLE
Create if #save is called on a new object

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -1,6 +1,18 @@
 module Stripe
   module APIOperations
     module Update
+      # Creates or updates an API resource.
+      #
+      # If the resource doesn't yet have an assigned ID and the resource is one
+      # that can be created, then the method attempts to create the resource.
+      # The resource is updated otherwise.
+      #
+      # ==== Attributes
+      #
+      # * +params+ - Overrides any parameters in the resource's serialized data
+      #   and includes them in the create or update. If +:req_url:+ is included
+      #   in the list, it overrides the update URL used for the create or
+      #   update.
       def save(params={})
         # Let the caller override the URL but avoid serializing it.
         req_url = params.delete(:req_url) || save_url

--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -3,16 +3,34 @@ module Stripe
     module Update
       def save(params={})
         # Let the caller override the URL but avoid serializing it.
-        req_url = params.delete(:req_url) || url
+        req_url = params.delete(:req_url) || save_url
         values = self.class.serialize_params(self).merge(params)
 
         if values.length > 0
+          # note that id gets removed here our call to #url above has already
+          # generated a uri for this object with an identifier baked in
           values.delete(:id)
 
           response, opts = request(:post, req_url, values)
           refresh_from(response, opts)
         end
         self
+      end
+
+      private
+
+      def save_url
+        # This switch essentially allows us "upsert"-like functionality. If the
+        # API resource doesn't have an ID set (suggesting that it's new) and
+        # its class responds to .create (which comes from
+        # Stripe::APIOperations::Create), then use the URL to create a new
+        # resource. Otherwise, generate a URL based on the object's identifier
+        # for a normal update.
+        if self[:id] == nil && self.class.respond_to?(:create)
+          self.class.url
+        else
+          url
+        end
       end
     end
   end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -627,6 +627,18 @@ module Stripe
 
         acct.save
       end
+
+      should 'should create a new resource when an object without an id is saved' do
+        account = Stripe::Account.construct_from({
+          :id => nil,
+          :display_name => nil,
+        })
+
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').returns(make_response({"id" => "charge_id"}))
+
+        account.display_name = 'stripe'
+        account.save
+      end
     end
   end
 end


### PR DESCRIPTION
Modifies the behavior of an update so that it can create an object if it
was new. This allows an "upsert"-like functionality where the SDK will
tend to do the right/expected thing.

This is a tad janky in that it checks for the existence of a class-level
`.create` method which is expected to come from a different module, but
most modules in the project are already fairly deeply intertwined and
co-dependent.

Fixes #165.

/cc @kyleconroy Mind taking a look at this one when you get a chance?