### PR TITLE
Perform deep name symbolization from .construct_from

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -21,6 +21,7 @@ module Stripe
     end
 
     def self.construct_from(values, opts={})
+      values = Stripe::Util.symbolize_names(values)
       self.new(values[:id]).refresh_from(values, opts)
     end
 

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -9,6 +9,12 @@ module Stripe
       assert !obj.respond_to?(:baz)
     end
 
+    should "marshal be insensitive to strings vs. symbols when constructin" do
+      obj = Stripe::StripeObject.construct_from({ :id => 1, 'name' => 'Stripe' })
+      assert_equal 1, obj[:id]
+      assert_equal 'Stripe', obj[:name]
+    end
+
     should "marshal a stripe object correctly" do
       obj = Stripe::StripeObject.construct_from({ :id => 1, :name => 'Stripe' }, {:api_key => 'apikey'})
       m = Marshal.load(Marshal.dump(obj))


### PR DESCRIPTION
When constructing an object using .construct_from treat keys that are
strings the same as keys which are symbols by calling Util's
symbolize_names on an input hash. This makes guarantees around
consistency a little better.

Fixes #151.