### PR TITLE
StripeObject: use Util.normalize_opts

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -11,7 +11,7 @@ module Stripe
 
     def initialize(id=nil, opts={})
       id, @retrieve_params = Util.normalize_id(id)
-      @opts = opts
+      @opts = Util.normalize_opts(opts)
       @values = {}
       # This really belongs in APIResource, but not putting it there allows us
       # to have a unified inspect method
@@ -34,7 +34,7 @@ module Stripe
     end
 
     def refresh_from(values, opts, partial=false)
-      @opts = opts
+      @opts = Util.normalize_opts(opts)
       @original_values = Marshal.load(Marshal.dump(values)) # deep copy
       removed = partial ? Set.new : Set.new(@values.keys - values.keys)
       added = Set.new(values.keys - @values.keys)


### PR DESCRIPTION
Problem
We broke API compatibility when we changed the interface for `initialize` from taking `api_key` as the second arg to an opts hash. If someone attempts to upgrade, calls from subclasses of StripeObject will  throw a `NoMethodError: merge` and log the api key in the process (it's not the expected hash)

Solution
For object initialization and refresh_from, call `normalize_opts` so `@opts` is always the expected hash.

cc @kyleconroy 