### PR TITLE
Don't give build notifications via e-mail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,7 @@ matrix:
     - rvm: jruby-19mode
       gemfile: gemfiles/yajl.gemfile
 
+notifications:
+  email: false
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       gemfile: gemfiles/yajl.gemfile
 
 notifications:
-  email: false
+  email:
+    on_success: never
 
 sudo: false


### PR DESCRIPTION
I personally find that just looking at the red/green status of any given
pull request is enough information on the status of current builds.

@kyleconroy Thoughts on this change? Thanks!