### PR TITLE
Mix `Enumerable` into `ListObject`

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -1,5 +1,6 @@
 module Stripe
   class ListObject < StripeObject
+    include Enumerable
     include Stripe::APIOperations::Request
 
     def [](k)

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -12,5 +12,12 @@ module Stripe
       assert_equal('/v1/charges', all.url)
       assert all.data.kind_of?(Array)
     end
+
+    should "provide enumerable functionality" do
+      @mock.expects(:get).once.returns(make_response(make_charge_array))
+      c = Stripe::Charge.all
+      assert c.kind_of?(Stripe::ListObject)
+      assert_equal 3, c.count
+    end
   end
 end


### PR DESCRIPTION
This pulls the `Enumerable` mixin into `ListObject`. There is some
question in pulls like #167 as to the future of `ListObject` and how it
might change when pagination is introduced, but because we're unlikely
to make any backward incompatible changes to the API, it's likely that
`ListObject` will continue to represent a page of data that's been
extracted from the API. Given that assumption, pulling `Enumerable` in
should be relatively safe.

Fixes #227.