### PR TITLE
Added invoices method to Subscription class

### DIFF
--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -16,6 +16,12 @@ module Stripe
       refresh_from({ :discount => nil }, opts, true)
     end
 
+    def invoices(params={}, opts={})
+      opts = @opts.merge(Util.normalize_opts(opts))
+      invoices = Invoice.all(params.merge(:customer => customer), opts)
+      invoices.select {|i| i['subscription'] == id }
+    end
+
     private
 
     def discount_url


### PR DESCRIPTION
After I create a subscription for a customer, I want to immediately access the initial charge - storing the charge id, brand (Visa, etc), etc in my database.  It seemed odd to me that subscription didn't respond to invoices, so I added a convenience method that pulls all invoices for a customer and filters by subscription.  Now you can do...

    invoice = subscription.invoices.first
    charge_id = invoice.payment