### PR TITLE
Add information on running individual test suites and individual tests

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,4 +40,14 @@ compromised in transit and alter the code of gems fetched securely over https:
 
 == Development
 
-Test cases can be run with: `bundle exec rake test`
+Run all tests:
+
+    bundle exec rake
+
+Run a single test suite:
+
+    bundle exec ruby -Ilib/ test/stripe/util_test.rb
+
+Run a single test:
+
+    bundle exec ruby -Ilib/ test/stripe/util_test.rb -n /should.convert.names.to.symbols/


### PR DESCRIPTION
Granular running of tests is one of Minitest's many gotchas. This
change adds some more information on how to run individual test suites
and individual tests which is useful when debugging.