### PR TITLE
Add #empty? helper on ListObject

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -16,6 +16,11 @@ module Stripe
       self.data.each(&blk)
     end
 
+    # Returns true if the page object contains no elements.
+    def empty?
+      self.data.empty?
+    end
+
     def retrieve(id, opts={})
       id, retrieve_params = Util.normalize_id(id)
       response, opts = request(:get,"#{url}/#{CGI.escape(id)}", retrieve_params, opts)

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -13,6 +13,13 @@ module Stripe
       assert all.data.kind_of?(Array)
     end
 
+    should "provide #empty?" do
+      object = Stripe::ListObject.construct_from({ :data => [] })
+      assert object.empty?
+      object = Stripe::ListObject.construct_from({ :data => [{}] })
+      refute object.empty?
+    end
+
     should "provide enumerable functionality" do
       @mock.expects(:get).once.returns(make_response(make_charge_array))
       c = Stripe::Charge.all


### PR DESCRIPTION
This makes ListObject behave a little more like an Array in that it gets
an #empty? helper. This should fit pretty well with the Enumerable
methods that it already has.

Replaces #193.