### PR TITLE
Add question mark helpers (e.g. #paid?) for boolean object values

### DIFF
--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -31,5 +31,12 @@ module Stripe
       expected_hash = { :id => 1, :nested => nested_hash, :list => [nested_hash] }
       assert_equal expected_hash, obj.to_hash
     end
+
+    should "assign question mark accessors for booleans" do
+      obj = Stripe::StripeObject.construct_from({ :id => 1, :bool => true, :not_bool => 'bar' })
+      assert obj.respond_to?(:bool?)
+      assert obj.bool?
+      refute obj.respond_to?(:not_bool?)
+    end
   end
 end


### PR DESCRIPTION
This patch adds question marks helpers (e.g. #paid?) for any values in a
StripeObject that are a boolean. This is fairly idiomatic Ruby in that
it behaves similarly to other libraries like ActiveRecord.

Note that a caveat here is that nullable booleans will not get a helper
added for them if their current value is null. For this reason, we
should eventually prefer to derive these methods from some sort of
programmatic API manifest.

Replaces #257 and #274.

/cc @kyleconroy Mind taking a look at this one when you get a chance? I think
the code will work okay, but the caveat is fairly sizable. We could potentially
work around it though by trying to squash and outstanding nullable booleans
that we find in the API. Thanks!