### PR TITLE
Add attribute mass assignment and use it in #save

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -16,6 +16,15 @@ module Stripe
       def save(params={})
         # Let the caller override the URL but avoid serializing it.
         req_url = params.delete(:req_url) || save_url
+
+        # We started unintentionally (sort of) allowing attributes send to
+        # +save+ to override values used during the update. So as not to break
+        # the API, this makes that official here.
+        update_attributes_with_options(params, raise_error: false)
+
+        # Now remove any parameters that look like object attributes.
+        params = params.reject { |k, _| respond_to?(k) }
+
         values = self.class.serialize_params(self).merge(params)
 
         if values.length > 0

--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -20,7 +20,7 @@ module Stripe
         # We started unintentionally (sort of) allowing attributes send to
         # +save+ to override values used during the update. So as not to break
         # the API, this makes that official here.
-        update_attributes_with_options(params, raise_error: false)
+        update_attributes_with_options(params, :raise_error => false)
 
         # Now remove any parameters that look like object attributes.
         params = params.reject { |k, _| respond_to?(k) }

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -70,37 +70,6 @@ module Stripe
       update_attributes_with_options(values, {})
     end
 
-    # Mass assigns attributes on the model.
-    #
-    # This is a version of +update_attributes+ that takes some extra options
-    # for internal use.
-    #
-    # ==== Options
-    #
-    # * +:opts:+ Options for StripeObject like an API key.
-    # * +:raise_error:+ Set to false to suppress ArgumentErrors on keys that
-    #   don't exist.
-    def update_attributes_with_options(values, options={})
-      # `opts` are StripeObject options
-      opts        = options.fetch(:opts, {})
-      raise_error = options.fetch(:raise_error, true)
-
-      values.each do |k, v|
-        if !@@permanent_attributes.include?(k) && !self.respond_to?(:"#{k}=")
-          if raise_error
-            raise ArgumentError,
-              "#{k} is not an attribute that can be assigned on this object"
-          else
-            next
-          end
-        end
-
-        @values[k] = Util.convert_to_stripe_object(v, opts)
-        @unsaved_values.add(k)
-      end
-      self
-    end
-
     def [](k)
       @values[k.to_sym]
     end
@@ -308,6 +277,37 @@ module Stripe
 
     def respond_to_missing?(symbol, include_private = false)
       @values && @values.has_key?(symbol) || super
+    end
+
+    # Mass assigns attributes on the model.
+    #
+    # This is a version of +update_attributes+ that takes some extra options
+    # for internal use.
+    #
+    # ==== Options
+    #
+    # * +:opts:+ Options for StripeObject like an API key.
+    # * +:raise_error:+ Set to false to suppress ArgumentErrors on keys that
+    #   don't exist.
+    def update_attributes_with_options(values, options={})
+      # `opts` are StripeObject options
+      opts        = options.fetch(:opts, {})
+      raise_error = options.fetch(:raise_error, true)
+
+      values.each do |k, v|
+        if !@@permanent_attributes.include?(k) && !self.respond_to?(:"#{k}=")
+          if raise_error
+            raise ArgumentError,
+              "#{k} is not an attribute that can be assigned on this object"
+          else
+            next
+          end
+        end
+
+        @values[k] = Util.convert_to_stripe_object(v, opts)
+        @unsaved_values.add(k)
+      end
+      self
     end
   end
 end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -56,13 +56,49 @@ module Stripe
         @unsaved_values.delete(k)
       end
 
-      values.each do |k, v|
-        @values[k] = Util.convert_to_stripe_object(v, @opts)
+      update_attributes_with_options(values, opts: opts)
+      values.each do |k, _|
         @transient_values.delete(k)
         @unsaved_values.delete(k)
       end
 
       return self
+    end
+
+    # Mass assigns attributes on the model.
+    def update_attributes(values)
+      update_attributes_with_options(values, {})
+    end
+
+    # Mass assigns attributes on the model.
+    #
+    # This is a version of +update_attributes+ that takes some extra options
+    # for internal use.
+    #
+    # ==== Options
+    #
+    # * +:opts:+ Options for StripeObject like an API key.
+    # * +:raise_error:+ Set to false to suppress ArgumentErrors on keys that
+    #   don't exist.
+    def update_attributes_with_options(values, options={})
+      # `opts` are StripeObject options
+      opts        = options.fetch(:opts, {})
+      raise_error = options.fetch(:raise_error, true)
+
+      values.each do |k, v|
+        if !@@permanent_attributes.include?(k) && !self.respond_to?(:"#{k}=")
+          if raise_error
+            raise ArgumentError,
+              "#{k} is not an attribute that can be assigned on this object"
+          else
+            next
+          end
+        end
+
+        @values[k] = Util.convert_to_stripe_object(v, opts)
+        @unsaved_values.add(k)
+      end
+      self
     end
 
     def [](k)

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -56,7 +56,7 @@ module Stripe
         @unsaved_values.delete(k)
       end
 
-      update_attributes_with_options(values, opts: opts)
+      update_attributes_with_options(values, :opts => opts)
       values.each do |k, _|
         @transient_values.delete(k)
         @unsaved_values.delete(k)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -634,10 +634,23 @@ module Stripe
           :display_name => nil,
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').returns(make_response({"id" => "charge_id"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').
+          returns(make_response({"id" => "charge_id"}))
 
         account.display_name = 'stripe'
         account.save
+      end
+
+      should 'set attributes as part of save' do
+        account = Stripe::Account.construct_from({
+          :id => nil,
+          :display_name => nil,
+        })
+
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').
+          returns(make_response({"id" => "charge_id"}))
+
+        account.save(display_name: 'stripe')
       end
     end
   end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -650,7 +650,7 @@ module Stripe
         @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').
           returns(make_response({"id" => "charge_id"}))
 
-        account.save(display_name: 'stripe')
+        account.save(:display_name => 'stripe')
       end
     end
   end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -38,5 +38,16 @@ module Stripe
       assert obj.bool?
       refute obj.respond_to?(:not_bool?)
     end
+
+    should "mass assign values with #update_attributes" do
+      obj = Stripe::StripeObject.construct_from({ :id => 1, :name => 'Stripe' })
+      obj.update_attributes(:name => 'STRIPE')
+      assert_equal "STRIPE", obj.name
+
+      e = assert_raises(ArgumentError) do
+        obj.update_attributes(:foo => 'bar')
+      end
+      assert_equal "foo is not an attribute that can be assigned on this object", e.message
+    end
   end
 end


### PR DESCRIPTION
As detailed in issue #119, we've somewhat unfortunately been allowing
object attributes to be passed in during a #save because we mix any
arguments directly into the serialized hash (it seems that this was
originally intended to be used more for meta parameters that go to the
request).

As also noted in #119, this use causes problems when certain types of
parameters (like subobjects) are used. We're now left in the somewhat
awkward position of either:

1. Removing this functionality on #save and breaking what may be
   behavior that people depend on.
2. Fully support this mass assignment.

This patch takes the second path by extracting a new #update_attributes
method and using it from #save. It's still far from a perfect approach
because keys that have the same name as certain options (e.g. `req_url`)
are not going to work, but it should capture the behavior that most
people want.

Fixes #119.

/cc @kyleconroy Would definitely appreciate your perspective on this one. 
Thanks!