### PR TITLE
Use correct URL for file upload retrieval

### DIFF
--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -1,22 +1,24 @@
 module Stripe
   class FileUpload < APIResource
+    include Stripe::APIOperations::Create
+    include Stripe::APIOperations::List
+
     def self.url
       "/v1/files"
+    end
+
+    def self.request(method, url, params={}, opts={})
+      opts = {
+        :api_base => Stripe::uploads_base
+      }.merge(Util.normalize_opts(opts))
+      super
     end
 
     def self.create(params={}, opts={})
       opts = {
         :content_type => 'multipart/form-data',
-        :api_base => Stripe::uploads_base
-      }.merge(opts)
-      response, opts = request(:post, url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
-    end
-
-    def self.all(filters={}, opts={})
-      opts = {:api_base => Stripe::uploads_base}.merge(opts)
-      response, opts = request(:get, url, filters, opts)
-      Util.convert_to_stripe_object(response, opts)
+      }.merge(Util.normalize_opts(opts))
+      super
     end
   end
 end

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -3,23 +3,34 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class FileUploadTest < Test::Unit::TestCase
     should "create should return a new file" do
-      @mock.expects(:post).once.returns(make_response(make_file))
-      f = Stripe::FileUpload.create({
+      params = {
         :purpose => "dispute_evidence",
         :file => File.new(__FILE__),
-      })
+      }
+
+      @mock.expects(:post).once.
+        with("#{Stripe.uploads_base}/v1/files", nil, params).
+        returns(make_response(make_file))
+
+      f = Stripe::FileUpload.create(params)
       assert_equal "fil_test_file", f.id
     end
 
     should "files should be retrievable" do
-      @mock.expects(:get).once.returns(make_response(make_file))
+      @mock.expects(:get).once.
+        with("#{Stripe.uploads_base}/v1/files/fil_test_file", nil, nil).
+        returns(make_response(make_file))
+
       c = Stripe::FileUpload.new("fil_test_file")
       c.refresh
       assert_equal 1403047735, c.created
     end
 
     should "files should be listable" do
-      @mock.expects(:get).once.returns(make_response(make_file_array))
+      @mock.expects(:get).once.
+        with("#{Stripe.uploads_base}/v1/files", nil, nil).
+        returns(make_response(make_file_array))
+
       c = Stripe::FileUpload.all.data
       assert c.kind_of? Array
       assert c[0].kind_of? Stripe::FileUpload


### PR DESCRIPTION
Supersedes https://github.com/stripe/stripe-ruby/pull/312

r? @brandur cc @andrewpthorp 