### PR TITLE
Extend Stripe::APIOperations::Create instead of including

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Account < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Update

--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -1,15 +1,9 @@
 module Stripe
   module APIOperations
     module Create
-      module ClassMethods
-        def create(params={}, opts={})
-          response, opts = request(:post, url, params, opts)
-          Util.convert_to_stripe_object(response, opts)
-        end
-      end
-
-      def self.included(base)
-        base.extend(ClassMethods)
+      def create(params={}, opts={})
+        response, opts = request(:post, url, params, opts)
+        Util.convert_to_stripe_object(response, opts)
       end
     end
   end

--- a/lib/stripe/bitcoin_receiver.rb
+++ b/lib/stripe/bitcoin_receiver.rb
@@ -1,6 +1,6 @@
 module Stripe
   class BitcoinReceiver < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -1,7 +1,7 @@
 module Stripe
   class Charge < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
     def refund(params={}, opts={})

--- a/lib/stripe/coupon.rb
+++ b/lib/stripe/coupon.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Coupon < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Customer < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     include Stripe::APIOperations::Update
     extend Stripe::APIOperations::List

--- a/lib/stripe/dispute.rb
+++ b/lib/stripe/dispute.rb
@@ -1,7 +1,7 @@
 module Stripe
   class Dispute < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
     def close(params={}, opts={})

--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -1,6 +1,6 @@
 module Stripe
   class FileUpload < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     extend Stripe::APIOperations::List
 
     def self.url

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -2,7 +2,7 @@ module Stripe
   class Invoice < APIResource
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Update
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
 
     def self.upcoming(params, opts={})
       response, opts = request(:get, upcoming_url, params, opts)

--- a/lib/stripe/invoice_item.rb
+++ b/lib/stripe/invoice_item.rb
@@ -1,7 +1,7 @@
 module Stripe
   class InvoiceItem < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     include Stripe::APIOperations::Update
   end

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -1,7 +1,7 @@
 module Stripe
   class Order < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
     def pay(params, opts={})

--- a/lib/stripe/plan.rb
+++ b/lib/stripe/plan.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Plan < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Update

--- a/lib/stripe/product.rb
+++ b/lib/stripe/product.rb
@@ -1,7 +1,7 @@
 module Stripe
   class Product < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
     # Keep APIResource#url as `api_url` to avoid letting the external URL

--- a/lib/stripe/recipient.rb
+++ b/lib/stripe/recipient.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Recipient < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     include Stripe::APIOperations::Update
     extend Stripe::APIOperations::List

--- a/lib/stripe/refund.rb
+++ b/lib/stripe/refund.rb
@@ -1,6 +1,6 @@
 module Stripe
   class Refund < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Update
   end

--- a/lib/stripe/sku.rb
+++ b/lib/stripe/sku.rb
@@ -1,7 +1,7 @@
 module Stripe
   class SKU < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
   end

--- a/lib/stripe/token.rb
+++ b/lib/stripe/token.rb
@@ -1,5 +1,5 @@
 module Stripe
   class Token < APIResource
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
   end
 end

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -1,7 +1,7 @@
 module Stripe
   class Transfer < APIResource
     extend Stripe::APIOperations::List
-    include Stripe::APIOperations::Create
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
 
     def cancel


### PR DESCRIPTION
Lets not be too shy about just using `extend` instead of `include` here
when it's more appropriate to do so. The advantage to this approach is
that the module can be either extended _or_ included with this change,
but couldn't be without it due to the `ClassMethods` meta-magic.

List has already started doing this as of #314, so we don't have to be
afraid of breaking convention here.