### PR TITLE
Parameter encoding bug fix and clean-up

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -120,13 +120,13 @@ module Stripe
     case method.to_s.downcase.to_sym
     when :get, :head, :delete
       # Make params into GET parameters
-      url += "#{URI.parse(url).query ? '&' : '?'}#{uri_encode(params)}" if params && params.any?
+      url += "#{URI.parse(url).query ? '&' : '?'}#{Util.encode_parameters(params)}" if params && params.any?
       payload = nil
     else
       if headers[:content_type] && headers[:content_type] == "multipart/form-data"
         payload = params
       else
-        payload = uri_encode(params)
+        payload = Util.encode_parameters(params)
       end
     end
 
@@ -206,9 +206,9 @@ module Stripe
   end
 
 
+  # DEPRECATED. Use Util#encode_parameters.
   def self.uri_encode(params)
-    Util.flatten_params(params).
-      map { |k,v| "#{k}=#{Util.url_encode(v)}" }.join('&')
+    Util.encode_parameters(params)
   end
 
   def self.request_headers(api_key)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -95,8 +95,8 @@ module Stripe
     end
 
     def self.encode_parameters(params)
-      URI.encode_www_form(Util.flatten_params(params))
-        .gsub('%5B', '[').gsub('%5D', ']')
+      URI.encode_www_form(Util.flatten_params(params)).
+        gsub('%5B', '[').gsub('%5D', ']')
     end
 
     def self.flatten_params(params, parent_key=nil)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -1,4 +1,4 @@
-require "webrick"
+require "uri"
 
 module Stripe
   module Util
@@ -94,17 +94,15 @@ module Stripe
       end
     end
 
-    def self.url_encode(key)
-      # Unfortunately, URI.escape was deprecated. Here we use a method from
-      # WEBrick instead given that it's a fairly close approximation (credit to
-      # the AWS Ruby SDK for coming up with the technique).
-      WEBrick::HTTPUtils.escape(key.to_s).gsub('%5B', '[').gsub('%5D', ']')
+    def self.encode_parameters(params)
+      URI.encode_www_form(Util.flatten_params(params))
+        .gsub('%5B', '[').gsub('%5D', ']')
     end
 
     def self.flatten_params(params, parent_key=nil)
       result = []
       params.each do |key, value|
-        calculated_key = parent_key ? "#{parent_key}[#{url_encode(key)}]" : url_encode(key)
+        calculated_key = parent_key ? "#{parent_key}[#{key}]" : key.to_s
         if value.is_a?(Hash)
           result += flatten_params(value, calculated_key)
         elsif value.is_a?(Array)

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -68,7 +68,7 @@ module Stripe
 
       @mock.expects(:post).
         once.
-        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[first_name]=Bob&legal_entity[address][line1]=2%20Three%20Four').
+        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[first_name]=Bob&legal_entity[address][line1]=2+Three+Four').
         returns(make_response(resp))
 
       a = Stripe::Account.retrieve('acct_foo')

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -230,7 +230,7 @@ module Stripe
 
       should "urlencode values in GET params" do
         response = make_response(make_charge_array)
-        @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test%20customer", nil, nil).returns(response)
+        @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test+customer", nil, nil).returns(response)
         charges = Stripe::Charge.list(:customer => 'test customer').data
         assert charges.kind_of? Array
       end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -2,7 +2,40 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class UtilTest < Test::Unit::TestCase
-    should "symbolize_names should convert names to symbols" do
+    should "#encode_parameters should prepare parameters for an HTTP request" do
+      params = {
+        :a => 3,
+        :b => "foo?",
+        :c => "bar&baz",
+        :d => { :a => "a", :b => "b" },
+        :e => [0, 1],
+      }
+      assert_equal(
+        "a=3&b=foo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
+        Stripe::Util.encode_parameters(params)
+      )
+    end
+
+    should "#flatten_params should encode parameters according to Rails convention" do
+      params = {
+        :a => 3,
+        :b => "foo?",
+        :c => "bar&baz",
+        :d => { :a => "a", :b => "b" },
+        :e => [0, 1],
+      }
+      assert_equal([
+        ["a",    3],
+        ["b",    "foo?"],
+        ["c",    "bar&baz"],
+        ["d[a]", "a"],
+        ["d[b]", "b"],
+        ["e[]",  0],
+        ["e[]",  1],
+      ], Stripe::Util.flatten_params(params))
+    end
+
+    should "#symbolize_names should convert names to symbols" do
       start = {
         'foo' => 'bar',
         'array' => [{ 'foo' => 'bar' }],
@@ -26,7 +59,7 @@ module Stripe
       assert_equal(finish, symbolized)
     end
 
-    should "normalize_opts should reject nil keys" do
+    should "#normalize_opts should reject nil keys" do
       assert_raise { Stripe::Util.normalize_opts(nil) }
       assert_raise { Stripe::Util.normalize_opts(:api_key => nil) }
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -5,13 +5,13 @@ module Stripe
     should "#encode_parameters should prepare parameters for an HTTP request" do
       params = {
         :a => 3,
-        :b => "foo?",
+        :b => "+foo?",
         :c => "bar&baz",
         :d => { :a => "a", :b => "b" },
         :e => [0, 1],
       }
       assert_equal(
-        "a=3&b=foo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
+        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
         Stripe::Util.encode_parameters(params)
       )
     end


### PR DESCRIPTION
I believe that in #299 I introduced a bug that doesn't allow values
containing an ampersand to be properly encoded as described in #318.
(This is a little weird though, because as far as I can tell, the old
`URI.escape` didn't do the right thing there either.) This patch
implements a fix for that bug by dropping a custom escape implementation
and just using `URI.encode_www_form` to get the behavior we want.

Also introduces a number of tests to actually verify that the behavior
works as we expect.

One notable shift in implementation is that spaces in query parameters
are now encoded as `+` instead of `%20`. According to [1] this area is
still fairly poorly defined, but the `+` is more correct for query
values or form bodies (`%20` is more correct for URI paths, which is why
`URI.escape` was previously generating it for us). We should be fine
server side as I believe most HTTP implementations will tolerate either
at this point. See Rack's tests for that here for example [2].

Fixes #318.

/cc @russelldavis @kyleconroy Can I get a sanity check from one of you 
on this one? Thank-you!

[1] https://stackoverflow.com/questions/1634271/url-encoding-the-space-character-or-20
[2] https://github.com/rack/rack/blob/d938cb586cf2ac09521fc91e19edf77ecca99c1a/test/spec_utils.rb#L80,L81