### PR TITLE
Add regression suite for testing parameter encoding

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -120,13 +120,13 @@ module Stripe
     case method.to_s.downcase.to_sym
     when :get, :head, :delete
       # Make params into GET parameters
-      url += "#{URI.parse(url).query ? '&' : '?'}#{uri_encode(params)}" if params && params.any?
+      url += "#{URI.parse(url).query ? '&' : '?'}#{Util.encode_parameters(params)}" if params && params.any?
       payload = nil
     else
       if headers[:content_type] && headers[:content_type] == "multipart/form-data"
         payload = params
       else
-        payload = uri_encode(params)
+        payload = Util.encode_parameters(params)
       end
     end
 
@@ -205,10 +205,9 @@ module Stripe
     "uname lookup failed"
   end
 
-
+  # DEPRECATED. Use `Util#encode_parameters` instead.
   def self.uri_encode(params)
-    Util.flatten_params(params).
-      map { |k,v| "#{k}=#{Util.url_encode(v)}" }.join('&')
+    Util.encode_parameters(params)
   end
 
   def self.request_headers(api_key)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -92,6 +92,15 @@ module Stripe
       end
     end
 
+    # Encodes a hash of parameters in a way that's suitable for use as query
+    # parameters in a URI or as form parameters in a request body. This mainly
+    # involves escaping special characters from parameter keys and values (e.g.
+    # `&`).
+    def self.encode_parameters(params)
+      Util.flatten_params(params).
+        map { |k,v| "#{k}=#{Util.url_encode(v)}" }.join('&')
+    end
+
     def self.url_encode(key)
       URI.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
     end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -117,7 +117,12 @@ module Stripe
           result << [calculated_key, value]
         end
       end
-      result
+
+      # The #sort_by call here is mostly so that we can get some stability in
+      # our 1.8.7 test suite where Hash key order is not preserved.
+      #
+      # https://www.igvita.com/2009/02/04/ruby-19-internals-ordered-hash/
+      result.sort_by { |(k, _)| k }
     end
 
     def self.flatten_params_array(value, calculated_key)

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -68,7 +68,7 @@ module Stripe
 
       @mock.expects(:post).
         once.
-        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[first_name]=Bob&legal_entity[address][line1]=2%20Three%20Four').
+        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[address][line1]=2%20Three%20Four&legal_entity[first_name]=Bob').
         returns(make_response(resp))
 
       a = Stripe::Account.retrieve('acct_foo')

--- a/test/stripe/metadata_test.rb
+++ b/test/stripe/metadata_test.rb
@@ -60,7 +60,7 @@ module Stripe
 
       if is_greater_than_ruby_1_9?
         check_metadata({:metadata => {:initial => 'true'}},
-                      'metadata[uuid]=6735&metadata[initial]=',
+                      'metadata[initial]=&metadata[uuid]=6735',
                       update_actions)
       end
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -2,7 +2,40 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class UtilTest < Test::Unit::TestCase
-    should "symbolize_names should convert names to symbols" do
+    should "#encode_parameters should prepare parameters for an HTTP request" do
+      params = {
+        :a => 3,
+        :b => "+foo?",
+        :c => "bar&baz",
+        :d => { :a => "a", :b => "b" },
+        :e => [0, 1],
+      }
+      assert_equal(
+        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
+        Stripe::Util.encode_parameters(params)
+      )
+    end
+
+    should "#flatten_params should encode parameters according to Rails convention" do
+      params = {
+        :a => 3,
+        :b => "foo?",
+        :c => "bar&baz",
+        :d => { :a => "a", :b => "b" },
+        :e => [0, 1],
+      }
+      assert_equal([
+        ["a",    3],
+        ["b",    "foo?"],
+        ["c",    "bar&baz"],
+        ["d[a]", "a"],
+        ["d[b]", "b"],
+        ["e[]",  0],
+        ["e[]",  1],
+      ], Stripe::Util.flatten_params(params))
+    end
+
+    should "#symbolize_names should convert names to symbols" do
       start = {
         'foo' => 'bar',
         'array' => [{ 'foo' => 'bar' }],
@@ -26,7 +59,7 @@ module Stripe
       assert_equal(finish, symbolized)
     end
 
-    should "normalize_opts should reject nil keys" do
+    should "#normalize_opts should reject nil keys" do
       assert_raise { Stripe::Util.normalize_opts(nil) }
       assert_raise { Stripe::Util.normalize_opts(:api_key => nil) }
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -16,6 +16,16 @@ module Stripe
       )
     end
 
+    should "#url_encode should prepare strings for HTTP" do
+      assert_equal "foo",      Stripe::Util.url_encode("foo")
+      assert_equal "foo",      Stripe::Util.url_encode(:foo)
+      assert_equal "foo%2B",   Stripe::Util.url_encode("foo+")
+      assert_equal "foo%26",   Stripe::Util.url_encode("foo&")
+    # Actually, we're going to alter the behavior of #url_encode slightly to
+    # simplify the form encoding path. This does not yet succeed.
+    # assert_equal "foo[bar]", Stripe::Util.url_encode("foo[bar]")
+    end
+
     should "#flatten_params should encode parameters according to Rails convention" do
       params = {
         :a => 3,


### PR DESCRIPTION
Pulls the test suite out of #319 so that we can get some coverage around
parameter encoding. This should prevent any recurrence of #318.

Also includes a little bit of refactoring.