### PR TITLE
Replace deprecated `URI.escape` with a customized `CGI.escape`

### DIFF
--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -68,7 +68,7 @@ module Stripe
 
       @mock.expects(:post).
         once.
-        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[address][line1]=2%20Three%20Four&legal_entity[first_name]=Bob').
+        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[address][line1]=2+Three+Four&legal_entity[first_name]=Bob').
         returns(make_response(resp))
 
       a = Stripe::Account.retrieve('acct_foo')

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -230,7 +230,7 @@ module Stripe
 
       should "urlencode values in GET params" do
         response = make_response(make_charge_array)
-        @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test%20customer", nil, nil).returns(response)
+        @mock.expects(:get).with("#{Stripe.api_base}/v1/charges?customer=test+customer", nil, nil).returns(response)
         charges = Stripe::Charge.list(:customer => 'test customer').data
         assert charges.kind_of? Array
       end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -21,9 +21,7 @@ module Stripe
       assert_equal "foo",      Stripe::Util.url_encode(:foo)
       assert_equal "foo%2B",   Stripe::Util.url_encode("foo+")
       assert_equal "foo%26",   Stripe::Util.url_encode("foo&")
-    # Actually, we're going to alter the behavior of #url_encode slightly to
-    # simplify the form encoding path. This does not yet succeed.
-    # assert_equal "foo[bar]", Stripe::Util.url_encode("foo[bar]")
+      assert_equal "foo[bar]", Stripe::Util.url_encode("foo[bar]")
     end
 
     should "#flatten_params should encode parameters according to Rails convention" do


### PR DESCRIPTION
Replaces my original attempt in #319 in a way that doesn't depend on `URI.encode_www_form` which doesn't exist in 1.8.7. This should hopefully get us the best of all worlds.

Caveats around use of `+` instead of `%20` as detailed in #319 still apply. @zenazn, If you have any insights into whether that might be a problem for our stack, please let me know. Thanks!

Fixes #286.