### PR TITLE
Add `StripeObject#deleted?`

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -34,6 +34,13 @@ module Stripe
       @values == other.instance_variable_get(:@values)
     end
 
+    # Indicates whether or not the resource has been deleted on the server.
+    # Note that some, but not all, resources can indicate whether they have
+    # been deleted.
+    def deleted?
+      @values.fetch(:deleted, false)
+    end
+
     def to_s(*args)
       JSON.pretty_generate(@values)
     end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -11,6 +11,17 @@ module Stripe
       refute obj1 == obj3
     end
 
+    should "implement #deleted?" do
+      obj = Stripe::StripeObject.construct_from({})
+      refute obj.deleted?
+
+      obj = Stripe::StripeObject.construct_from({ :deleted => false })
+      refute obj.deleted?
+
+      obj = Stripe::StripeObject.construct_from({ :deleted => true })
+      assert obj.deleted?
+    end
+
     should "implement #respond_to" do
       obj = Stripe::StripeObject.construct_from({ :id => 1, :foo => 'bar' })
       assert obj.respond_to?(:id)


### PR DESCRIPTION
Adds a special helper to `StripeObject` that helps a developer to
determine whether or not an object is deleted.

As described originally in #257, this is a bit of a special case because
a non-deleted object does not respond with `deleted` as part of its
representation, so while a deleted object would have this accessor
available automatically, non-deleted objects would not. This made use of
the SDK awkward because the presence of the method was not guaranteed.

Fixes #257 (again, heh).

/cc @kyleconroy @iloveitaly