### PR TITLE
Pass through all paging filters to descendent pages

### DIFF
--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -8,9 +8,13 @@ module Stripe
         response, opts = request(:get, url, filters, opts)
         obj = ListObject.construct_from(response, opts)
 
-        # set a limit so that we can fetch the same number when accessing the
-        # next and previous pages
-        obj.limit = filters[:limit]
+        # set filters so that we can fetch the same limit, expansions, and
+        # predicates when accessing the next and previous pages
+        #
+        # just for general cleanliness, remove any paging options
+        obj.filters = filters.dup
+        obj.filters.delete(:ending_before)
+        obj.filters.delete(:starting_after)
 
         obj
       end

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -79,11 +79,11 @@ module Stripe
 
     should "fetch a next page through #next_page and respect limit" do
       list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
-      list.limit = 3
-      @mock.expects(:get).once.with("#{Stripe.api_base}/things?limit=3&starting_after=1", nil, nil).
+      list.filters = { :expand => ['data.source'], :limit => 3 }
+      @mock.expects(:get).once.with("#{Stripe.api_base}/things?expand[]=data.source&limit=3&starting_after=1", nil, nil).
         returns(make_response({ :data => [{ :id => 2 }], :has_more => false }))
       next_list = list.next_page
-      assert_equal 3, next_list.limit
+      assert_equal({ :expand => ['data.source'], :limit => 3 }, next_list.filters)
     end
 
     should "fetch an empty page through #next_page" do
@@ -106,11 +106,11 @@ module Stripe
 
     should "fetch a next page through #previous_page and respect limit" do
       list = TestListObject.construct_from({ :data => [{ :id => 2 }] })
-      list.limit = 3
-      @mock.expects(:get).once.with("#{Stripe.api_base}/things?ending_before=2&limit=3", nil, nil).
+      list.filters = { :expand => ['data.source'], :limit => 3 }
+      @mock.expects(:get).once.with("#{Stripe.api_base}/things?ending_before=2&expand[]=data.source&limit=3", nil, nil).
         returns(make_response({ :data => [{ :id => 1 }] }))
       next_list = list.previous_page
-      assert_equal 3, next_list.limit
+      assert_equal({ :expand => ['data.source'], :limit => 3 }, next_list.filters)
     end
 
     #


### PR DESCRIPTION
When additional filters were provided for pagination like an expansion
or a predicate, they would not propagate to any call after the first.
This patch addresses that issue by storing all filters and moving them
to any new page objects being created.

Fixes #331.