### PR TITLE
Remove sorting hack from parameter encoding

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -131,7 +131,7 @@ module Stripe
       # our 1.8.7 test suite where Hash key order is not preserved.
       #
       # https://www.igvita.com/2009/02/04/ruby-19-internals-ordered-hash/
-      result.sort_by { |(k, _)| k }
+      result
     end
 
     def self.flatten_params_array(value, calculated_key)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -127,10 +127,6 @@ module Stripe
         end
       end
 
-      # The #sort_by call here is mostly so that we can get some stability in
-      # our 1.8.7 test suite where Hash key order is not preserved.
-      #
-      # https://www.igvita.com/2009/02/04/ruby-19-internals-ordered-hash/
       result
     end
 

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -68,7 +68,7 @@ module Stripe
 
       @mock.expects(:post).
         once.
-        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[address][line1]=2+Three+Four&legal_entity[first_name]=Bob').
+        with('https://api.stripe.com/v1/accounts/acct_foo', nil, 'legal_entity[first_name]=Bob&legal_entity[address][line1]=2+Three+Four').
         returns(make_response(resp))
 
       a = Stripe::Account.retrieve('acct_foo')

--- a/test/stripe/metadata_test.rb
+++ b/test/stripe/metadata_test.rb
@@ -60,7 +60,7 @@ module Stripe
 
       if is_greater_than_ruby_1_9?
         check_metadata({:metadata => {:initial => 'true'}},
-                      'metadata[initial]=&metadata[uuid]=6735',
+                      'metadata[uuid]=6735&metadata[initial]=',
                       update_actions)
       end
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -31,15 +31,27 @@ module Stripe
         :c => "bar&baz",
         :d => { :a => "a", :b => "b" },
         :e => [0, 1],
+        :f => [
+          { :foo => "1", :bar => "2" },
+          { :foo => "3", :baz => "4" },
+        ],
       }
       assert_equal([
-        ["a",    3],
-        ["b",    "foo?"],
-        ["c",    "bar&baz"],
-        ["d[a]", "a"],
-        ["d[b]", "b"],
-        ["e[]",  0],
-        ["e[]",  1],
+        ["a",        3],
+        ["b",        "foo?"],
+        ["c",        "bar&baz"],
+        ["d[a]",     "a"],
+        ["d[b]",     "b"],
+        ["e[]",      0],
+        ["e[]",      1],
+
+        # *The key here is the order*. In order to be properly interpreted as
+        # an array of hashes on the server, everything from a single hash must
+        # come in at once. A duplicate key in an array triggers a new element.
+        ["f[][foo]", "1"],
+        ["f[][bar]", "2"],
+        ["f[][foo]", "3"],
+        ["f[][baz]", "4"],
       ], Stripe::Util.flatten_params(params))
     end
 

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -3,13 +3,14 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class UtilTest < Test::Unit::TestCase
     should "#encode_parameters should prepare parameters for an HTTP request" do
-      params = {
-        :a => 3,
-        :b => "+foo?",
-        :c => "bar&baz",
-        :d => { :a => "a", :b => "b" },
-        :e => [0, 1],
-      }
+      # use array instead of hash for 1.8.7 ordering
+      params = [
+        [:a, 3],
+        [:b, "+foo?"],
+        [:c, "bar&baz"],
+        [:d, { :a => "a", :b => "b" }],
+        [:e, [0, 1]],
+      ]
       assert_equal(
         "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
         Stripe::Util.encode_parameters(params)
@@ -25,17 +26,17 @@ module Stripe
     end
 
     should "#flatten_params should encode parameters according to Rails convention" do
-      params = {
-        :a => 3,
-        :b => "foo?",
-        :c => "bar&baz",
-        :d => { :a => "a", :b => "b" },
-        :e => [0, 1],
-        :f => [
+      params = [
+        [:a, 3],
+        [:b, "foo?"],
+        [:c, "bar&baz"],
+        [:d, { :a => "a", :b => "b" }],
+        [:e, [0, 1]],
+        [:f, [
           { :foo => "1", :bar => "2" },
           { :foo => "3", :baz => "4" },
-        ],
-      }
+        ]],
+      ]
       assert_equal([
         ["a",        3],
         ["b",        "foo?"],


### PR DESCRIPTION
I added this for a regression suite so that 1.8.7 could pass its tests,
but unfortunately this caused a regression in the way that parameters
are encoded for arrays of hashes. This patch reverts the change and adds
tests to detect a future regression.

(And 1.8.7 is expected to fail on this initial commit.)