### PR TITLE
Correct internal usage of `#update_attributes`

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -333,43 +333,12 @@ module Stripe
         @unsaved_values.delete(k)
       end
 
-      update_attributes(values, :opts => opts)
+      update_attributes(values, opts)
       values.each do |k, _|
         @transient_values.delete(k)
         @unsaved_values.delete(k)
       end
 
-      self
-    end
-
-    # Mass assigns attributes on the model.
-    #
-    # This is a version of +update_attributes+ that takes some extra options
-    # for internal use.
-    #
-    # ==== Options
-    #
-    # * +:opts:+ Options for StripeObject like an API key.
-    # * +:raise_error:+ Set to false to suppress ArgumentErrors on keys that
-    #   don't exist.
-    def update_attributes_with_options(values, options={})
-      # `opts` are StripeObject options
-      opts        = options.fetch(:opts, {})
-      raise_error = options.fetch(:raise_error, true)
-
-      values.each do |k, v|
-        if !@@permanent_attributes.include?(k) && !self.respond_to?(:"#{k}=")
-          if raise_error
-            raise ArgumentError,
-              "#{k} is not an attribute that can be assigned on this object"
-          else
-            next
-          end
-        end
-
-        @values[k] = Util.convert_to_stripe_object(v, opts)
-        @unsaved_values.add(k)
-      end
       self
     end
   end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -84,5 +84,20 @@ module Stripe
         $stderr = old_stderr
       end
     end
+
+    should "pass opts down to children when initializing" do
+      opts = { :custom => "opts" }
+
+      # customer comes with a `sources` list that makes a convenient object to
+      # perform tests on
+      customer = Stripe::Customer.construct_from(make_customer, opts)
+
+      source = customer.sources.first
+      # Pulling `@opts` as an instance variable here is not ideal, but it's
+      # important enough argument that the test here is worth it. we should
+      # consider exposing it publicly on a future pull (and possibly renaming
+      # it to something more useful).
+      assert_equal opts, source.instance_variable_get(:@opts)
+    end
   end
 end


### PR DESCRIPTION
Unfortunately usage of `#update_attributes` had rolled over from a time
where `#update_attributes_with_options` was still in use and `opts` were
being passed in as an optional argument which had the result of further
nesting the hash internally (i.e. `:opts => { :opts => ... } }`).

This patch fixes that problem, adds a regression test to prevent it from
reappearing, and banishes the unused `#update_attributes_with_options`.

Fixes #334.