### PR TITLE
Add byebug/pry as a gem development dependency

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -20,6 +20,14 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('test-unit')
   s.add_development_dependency('rake')
 
+  # to avoid problems, bring Byebug in on just versions of Ruby under which
+  # it's known to work well
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+    s.add_development_dependency("byebug")
+    s.add_development_dependency("pry")
+    s.add_development_dependency("pry-byebug")
+  end
+
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
I find myself using these quite a bit when looking into problems, and
currently have to manually re-add them to the Gemfile/gemspec to get
them in the bundle and make them available in tests.

Here we gate the debugger to only come in for Ruby > 2 so as to avoid
problems with various compatibility problems between debuggers and
versions of Ruby. If there's a demand for a pre-Ruby 2 debugger, we can
add that separately.

Any major objections to this one? Thanks.