### PR TITLE
Correct update requests containing array parameters

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -2,6 +2,18 @@ module Stripe
   class StripeObject
     include Enumerable
 
+    # We use freezing when initialize objects under certain conditions (e.g.
+    # when they're nested in an array of another resource) so we use a custom
+    # error class.
+    class FrozenError < RuntimeError
+      def initialize
+        super("This object is frozen and cannot be modified. If you are " +
+          "attempting to update an object nested in another resource's " +
+          "array then try replacing the array with a new set of objects " +
+          "instead.")
+      end
+    end
+
     @@permanent_attributes = Set.new([:id])
 
     # The default :id method is deprecated and isn't useful to us
@@ -76,6 +88,8 @@ module Stripe
     #
     # * +:opts+ Options for StripeObject like an API key.
     def update_attributes(values, opts = {})
+      raise FrozenError if frozen?
+
       values.each do |k, v|
         @values[k] = Util.convert_to_stripe_object(v, opts)
         @unsaved_values.add(k)
@@ -87,6 +101,7 @@ module Stripe
     end
 
     def []=(k, v)
+      raise FrozenError if frozen?
       send(:"#{k}=", v)
     end
 
@@ -189,10 +204,13 @@ module Stripe
         obj_values.each do |k, v|
           if v.is_a?(Array)
             original_value = obj.instance_variable_get(:@original_values)[k]
+
+            # the conditional here tests whether the old and new values are
+            # different (and therefore needs an update), or the same (meaning
+            # we can leave it out of the request)
             if updated = serialize_params(v, original_value)
               update_hash[k] = updated
             else
-              # arrays are the same, so don't perform this update
               update_hash.delete(k)
             end
           elsif v.is_a?(StripeObject) || v.is_a?(Hash)
@@ -260,6 +278,8 @@ module Stripe
       # TODO: only allow setting in updateable classes.
       if name.to_s.end_with?('=')
         attr = name.to_s[0...-1].to_sym
+
+        raise FrozenError if frozen?
 
         # the second argument is only required when adding boolean accessors
         add_accessors([attr], {})

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -572,23 +572,11 @@ module Stripe
           :legal_entity => {}
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(make_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil,
+          'legal_entity[additional_owners][][first_name]=Bob').
+          returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.additional_owners = [{:first_name => 'Bob'}]
-        acct.save
-      end
-
-      should 'correctly handle array insertion' do
-        acct = Stripe::Account.construct_from({
-          :id => 'myid',
-          :legal_entity => {
-            :additional_owners => []
-          }
-        })
-
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][0][first_name]=Bob').returns(make_response({"id" => "myid"}))
-
-        acct.legal_entity.additional_owners << {:first_name => 'Bob'}
         acct.save
       end
 
@@ -600,7 +588,9 @@ module Stripe
           }
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil, 'legal_entity[additional_owners][1][first_name]=Janet').returns(make_response({"id" => "myid"}))
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts/myid", nil,
+          'legal_entity[additional_owners][][first_name]=Janet').
+          returns(make_response({"id" => "myid"}))
 
         acct.legal_entity.additional_owners[1].first_name = 'Janet'
         acct.save

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -123,17 +123,7 @@ module Stripe
         Stripe::StripeObject.serialize_params(obj))
     end
 
-    should "#serialize_params on an array as an update if possible" do
-      obj = Stripe::StripeObject.construct_from({
-        :foo => ["0-index", "1-index", "2-index"],
-      })
-      obj.foo[1] = "new-value"
-      obj.foo[2] = "new-value"
-      assert_equal({ :foo => { "1" => "new-value", "2" => "new-value" } },
-        Stripe::StripeObject.serialize_params(obj))
-    end
-
-    should "#serialize_params on an array as a replace for a new array" do
+    should "#serialize_params on an array" do
       obj = Stripe::StripeObject.construct_from({
         :foo => nil,
       })
@@ -142,7 +132,7 @@ module Stripe
         Stripe::StripeObject.serialize_params(obj))
     end
 
-    should "#serialize_params on an array as a replace for an array that shortens" do
+    should "#serialize_params on an array that shortens" do
       obj = Stripe::StripeObject.construct_from({
         :foo => ["0-index", "1-index", "2-index"],
       })
@@ -151,7 +141,7 @@ module Stripe
         Stripe::StripeObject.serialize_params(obj))
     end
 
-    should "#serialize_params on an array as a replace for an array that lengthens" do
+    should "#serialize_params on an array that lengthens" do
       obj = Stripe::StripeObject.construct_from({
         :foo => ["0-index", "1-index", "2-index"],
       })
@@ -176,6 +166,14 @@ module Stripe
 
     should "#serialize_params doesn't include unchanged values" do
       obj = Stripe::StripeObject.construct_from({ :foo => nil })
+      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array that is unchanged" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => ["0-index", "1-index", "2-index"],
+      })
+      obj.foo = ["0-index", "1-index", "2-index"]
       assert_equal({}, Stripe::StripeObject.serialize_params(obj))
     end
   end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -84,5 +84,53 @@ module Stripe
       assert_raise { Stripe::Util.normalize_opts(nil) }
       assert_raise { Stripe::Util.normalize_opts(:api_key => nil) }
     end
+
+    should "#convert_to_stripe_object should pass through unknown types" do
+      obj = Util.convert_to_stripe_object(7, {})
+      assert_equal 7, obj
+    end
+
+    should "#convert_to_stripe_object should turn hashes into StripeObjects" do
+      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {})
+      assert obj.is_a?(StripeObject)
+      assert_equal "bar", obj.foo
+    end
+
+    should "#convert_to_stripe_object should turn lists into ListObjects" do
+      obj = Util.convert_to_stripe_object({ :object => "list" }, {})
+      assert obj.is_a?(ListObject)
+    end
+
+    should "#convert_to_stripe_object should marshal other classes" do
+      obj = Util.convert_to_stripe_object({ :object => "account" }, {})
+      assert obj.is_a?(Account)
+    end
+
+    should "#convert_to_stripe_object should marshal arrays" do
+      obj = Util.convert_to_stripe_object([1, 2, 3], {})
+      assert_equal [1, 2, 3], obj
+    end
+
+    should "#convert_to_stripe_object should not freeze StripeObjects" do
+      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {})
+      assert obj.is_a?(StripeObject)
+      refute obj.frozen?
+    end
+
+    should "#convert_to_stripe_object should freeze StripeObjects within arrays" do
+      arr = Util.convert_to_stripe_object([{ :foo => "bar" }], {})
+      obj = arr.first
+      assert obj.is_a?(StripeObject)
+      refute obj.is_a?(APIResource)
+      assert obj.frozen?
+    end
+
+    should "#convert_to_stripe_object should not freeze StripeObjects within arrays if they are APIResources" do
+      arr = Util.convert_to_stripe_object([{ :object => "account" }], {})
+      obj = arr.first
+      assert obj.is_a?(StripeObject)
+      assert obj.is_a?(APIResource)
+      refute obj.frozen?
+    end
   end
 end


### PR DESCRIPTION
This patch aims to correct how arrays are sent to the Stripe API during
updates in attempt to fix such problems as seen in #340. We also add
extensive documentation and testing in an effort to spec out our desired
behavior.

Note that this patch attempts to use mechanisms for both array
replacement *and* array element replacement so that we can theoretically
do partial array updates. Unfortunately, athough confirmed that this now
works (the problem described in #340):

``` ruby
product = Stripe::Product.retrieve('prod_7Ac4LyNOPGN0an')

product.images = [
  "https://daqj0hamajdep.cloudfront.net/api/file/rnlqHhGJSxS06buwvelQ+name.jpg",
  "https://daqj0hamajdep.cloudfront.net/api/file/hXesXSFRJSNyfNcJdiwg+name.jpg",
  "https://daqj0hamajdep.cloudfront.net/api/file/sbWRFmORRYOglcd5LiT8+name.jpg",
  "https://daqj0hamajdep.cloudfront.net/api/file/GDXMYn1ITWL9GEBVrVTI+name.jpg",
  "https://daqj0hamajdep.cloudfront.net/api/file/6AULYuihQZO8Bo6SF6fl+name.jpg"
]
```

I can also confirm that this still doesn't:

``` ruby
product = Stripe::Product.retrieve('prod_7Ac4LyNOPGN0an')

product.images[3] = "https://brandur.org/image"

product.save
```

With the problem being that the server side still can't correct validate
a parameter such as `images[3]=https://brandur.org/image` as an array
(maybe unsurprisingly). The easiest fix for now may be to just strip out
the partial update logic, but I'm going to do one more pass server-side
to see whether it might be possible to repair this parameter
interpretation given that it seems to have been intended to work at some
point.

Fixes #340.