### PR TITLE
Special case the serialization of account's `additional_owners`

### DIFF
--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -151,5 +151,102 @@ module Stripe
       a = Stripe::Account.retrieve
       assert_equal(BankAccount, a.external_accounts.data[0].class)
     end
+
+    should "#serialize_params an a new additional_owners" do
+      obj = Stripe::Util.convert_to_stripe_object({
+        :object => "account",
+        :legal_entity => {
+        },
+      }, {})
+      obj.legal_entity.additional_owners = [
+        { :first_name => "Joe" },
+        { :first_name => "Jane" },
+      ]
+
+      expected = {
+        :legal_entity => {
+          :additional_owners => {
+            "0" => { :first_name => "Joe" },
+            "1" => { :first_name => "Jane" },
+          }
+        }
+      }
+      assert_equal(expected, obj.class.serialize_params(obj))
+    end
+
+    should "#serialize_params on an partially changed additional_owners" do
+      obj = Stripe::Util.convert_to_stripe_object({
+        :object => "account",
+        :legal_entity => {
+          :additional_owners => [
+            Stripe::StripeObject.construct_from({
+              :first_name => "Joe"
+            }),
+            Stripe::StripeObject.construct_from({
+              :first_name => "Jane"
+            }),
+          ]
+        }
+      }, {})
+      obj.legal_entity.additional_owners[1].first_name = "Stripe"
+
+      expected = {
+        :legal_entity => {
+          :additional_owners => {
+            "1" => { :first_name => "Stripe" }
+          }
+        }
+      }
+      assert_equal(expected, obj.class.serialize_params(obj))
+    end
+
+    should "#serialize_params on an unchanged additional_owners" do
+      obj = Stripe::Util.convert_to_stripe_object({
+        :object => "account",
+        :legal_entity => {
+          :additional_owners => [
+            Stripe::StripeObject.construct_from({
+              :first_name => "Joe"
+            }),
+            Stripe::StripeObject.construct_from({
+              :first_name => "Jane"
+            }),
+          ]
+        }
+      }, {})
+
+      expected = {
+        :legal_entity => {
+          :additional_owners => {}
+        }
+      }
+      assert_equal(expected, obj.class.serialize_params(obj))
+    end
+
+    # Note that the empty string that we send for this one has a special
+    # meaning for the server, which interprets it as an array unset.
+    should "#serialize_params on an unset additional_owners" do
+      obj = Stripe::Util.convert_to_stripe_object({
+        :object => "account",
+        :legal_entity => {
+          :additional_owners => [
+            Stripe::StripeObject.construct_from({
+              :first_name => "Joe"
+            }),
+            Stripe::StripeObject.construct_from({
+              :first_name => "Jane"
+            }),
+          ]
+        }
+      }, {})
+      obj.legal_entity.additional_owners = nil
+
+      expected = {
+        :legal_entity => {
+          :additional_owners => ""
+        }
+      }
+      assert_equal(expected, obj.class.serialize_params(obj))
+    end
   end
 end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -164,22 +164,6 @@ module Stripe
         Stripe::StripeObject.serialize_params(obj))
     end
 
-    should "#serialize_params on an partially changed array of hashes" do
-      obj = Stripe::StripeObject.construct_from({
-        :foo => [
-          Stripe::StripeObject.construct_from({
-            :bar => nil
-          }),
-          Stripe::StripeObject.construct_from({
-            :bar => nil
-          }),
-        ]
-      })
-      obj.foo[1].bar = "baz"
-      assert_equal({ :foo => [{}, { :bar => "baz" }] },
-        Stripe::StripeObject.serialize_params(obj))
-    end
-
     should "#serialize_params doesn't include unchanged values" do
       obj = Stripe::StripeObject.construct_from({ :foo => nil })
       assert_equal({}, Stripe::StripeObject.serialize_params(obj))

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -99,5 +99,98 @@ module Stripe
       # it to something more useful).
       assert_equal opts, source.instance_variable_get(:@opts)
     end
+
+    should "#serialize_params on an empty object" do
+      obj = Stripe::StripeObject.construct_from({})
+      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on a basic object" do
+      obj = Stripe::StripeObject.construct_from({ :foo => nil })
+      obj.update_attributes(:foo => "bar")
+      assert_equal({ :foo => "bar" }, Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on a more complex object" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => Stripe::StripeObject.construct_from({
+          :bar => nil,
+          :baz => nil,
+        }),
+      })
+      obj.foo.bar = "newbar"
+      assert_equal({ :foo => { :bar => "newbar" } },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => nil,
+      })
+      obj.foo = ["new-value"]
+      assert_equal({ :foo => ["new-value"] },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array that shortens" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => ["0-index", "1-index", "2-index"],
+      })
+      obj.foo = ["new-value"]
+      assert_equal({ :foo => ["new-value"] },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array that lengthens" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => ["0-index", "1-index", "2-index"],
+      })
+      obj.foo = ["new-value"] * 4
+      assert_equal({ :foo => ["new-value"] * 4 },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array of hashes" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => nil,
+      })
+      obj.foo = [
+        Stripe::StripeObject.construct_from({
+          :bar => nil
+        })
+      ]
+      obj.foo[0].bar = "baz"
+      assert_equal({ :foo => [{ :bar => "baz" }] },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an partially changed array of hashes" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => [
+          Stripe::StripeObject.construct_from({
+            :bar => nil
+          }),
+          Stripe::StripeObject.construct_from({
+            :bar => nil
+          }),
+        ]
+      })
+      obj.foo[1].bar = "baz"
+      assert_equal({ :foo => [{}, { :bar => "baz" }] },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params doesn't include unchanged values" do
+      obj = Stripe::StripeObject.construct_from({ :foo => nil })
+      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+    end
+
+    should "#serialize_params on an array that is unchanged" do
+      obj = Stripe::StripeObject.construct_from({
+        :foo => ["0-index", "1-index", "2-index"],
+      })
+      obj.foo = ["0-index", "1-index", "2-index"]
+      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+    end
   end
 end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -10,6 +10,9 @@ module Stripe
         [:c, "bar&baz"],
         [:d, { :a => "a", :b => "b" }],
         [:e, [0, 1]],
+
+        # note the empty hash won't even show up in the request
+        [:f, []]
       ]
       assert_equal(
         "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
@@ -83,6 +86,32 @@ module Stripe
     should "#normalize_opts should reject nil keys" do
       assert_raise { Stripe::Util.normalize_opts(nil) }
       assert_raise { Stripe::Util.normalize_opts(:api_key => nil) }
+    end
+
+    should "#convert_to_stripe_object should pass through unknown types" do
+      obj = Util.convert_to_stripe_object(7, {})
+      assert_equal 7, obj
+    end
+
+    should "#convert_to_stripe_object should turn hashes into StripeObjects" do
+      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {})
+      assert obj.is_a?(StripeObject)
+      assert_equal "bar", obj.foo
+    end
+
+    should "#convert_to_stripe_object should turn lists into ListObjects" do
+      obj = Util.convert_to_stripe_object({ :object => "list" }, {})
+      assert obj.is_a?(ListObject)
+    end
+
+    should "#convert_to_stripe_object should marshal other classes" do
+      obj = Util.convert_to_stripe_object({ :object => "account" }, {})
+      assert obj.is_a?(Account)
+    end
+
+    should "#convert_to_stripe_object should marshal arrays" do
+      obj = Util.convert_to_stripe_object([1, 2, 3], {})
+      assert_equal [1, 2, 3], obj
     end
   end
 end


### PR DESCRIPTION
We attempt to do a special encoding trick when serializing
`additional_owners` under an account: when updating a value, we actually
send the update parameters up as an integer-indexed hash rather than an
array. So instead of this:

    field[]=item1&field[]=item2&field[]=item3

We send this:

    field[0]=item1&field[1]=item2&field[2]=item3

The trouble is that this had previously been built into the core library
as the default handling for all arrays. Because of this, it was
impossible to resize a non-`additional_owners` array as described in
more detail in #340.

This patch special cases `additional_owners` and brings sane behavior
back to normal arrays along with a test suite so that we try to build
some better guarantees around both the general and non-general cases.

Fixes #340.

/cc @kyleconroy Mind taking a look at this one when you get a chance? Aside
from the (probably) unrelated to bindings issue in #343, I think it should
close our last bug :)