### PR TITLE
Encode consistently between "create" and "update"

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -168,8 +168,6 @@ module Stripe
 
     def self.serialize_params(obj, original_value=nil)
       case obj
-      when nil
-        ''
       when Array
         update = obj.map { |v| serialize_params(v) }
         if original_value != update

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -8,7 +8,7 @@ module Stripe
         h.id
       when Hash
         res = {}
-        h.each { |k, v| res[k] = objects_to_ids(v) unless v.nil? }
+        h.each { |k, v| res[k] = v ? objects_to_ids(v) : nil }
         res
       when Array
         h.map { |v| objects_to_ids(v) }
@@ -106,12 +106,16 @@ module Stripe
     # Encodes a string in a way that makes it suitable for use in a set of
     # query parameters in a URI or in a set of form parameters in a request
     # body.
-    def self.url_encode(key)
-      CGI.escape(key.to_s).
-        # Don't use strict form encoding by changing the square bracket control
-        # characters back to their literals. This is fine by the server, and
-        # makes these parameter strings easier to read.
-        gsub('%5B', '[').gsub('%5D', ']')
+    def self.url_encode(val)
+      if val
+        CGI.escape(val.to_s).
+          # Don't use strict form encoding by changing the square bracket control
+          # characters back to their literals. This is fine by the server, and
+          # makes these parameter strings easier to read.
+          gsub('%5B', '[').gsub('%5D', ']')
+      else
+        ""
+      end
     end
 
     def self.flatten_params(params, parent_key=nil)

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -243,7 +243,7 @@ module Stripe
 
       expected = {
         :legal_entity => {
-          :additional_owners => ""
+          :additional_owners => nil
         }
       }
       assert_equal(expected, obj.class.serialize_params(obj))

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -304,23 +304,6 @@ module Stripe
         end
       end
 
-      should "setting a nil value for a param should exclude that param from the request" do
-        @mock.expects(:get).with do |url, api_key, params|
-          uri = URI(url)
-          query = CGI.parse(uri.query)
-          (url =~ %r{^#{Stripe.api_base}/v1/charges?} &&
-           query.keys.sort == ['offset', 'sad'])
-        end.returns(make_response({ :count => 1, :data => [make_charge] }))
-        Stripe::Charge.list(:count => nil, :offset => 5, :sad => false)
-
-        @mock.expects(:post).with do |url, api_key, params|
-          url == "#{Stripe.api_base}/v1/charges" &&
-            api_key.nil? &&
-            CGI.parse(params) == { 'amount' => ['50'], 'currency' => ['usd'] }
-        end.returns(make_response({ :count => 1, :data => [make_charge] }))
-        Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-      end
-
       should "requesting with a unicode ID should result in a request" do
         response = make_response(make_missing_id_error, 404)
         @mock.expects(:get).once.with("#{Stripe.api_base}/v1/customers/%E2%98%83", nil, nil).raises(RestClient::ExceptionWithResponse.new(response, 404))

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -10,12 +10,13 @@ module Stripe
         [:c, "bar&baz"],
         [:d, { :a => "a", :b => "b" }],
         [:e, [0, 1]],
+        [:f, nil],
 
-        # note the empty hash won't even show up in the request
-        [:f, []]
+        # note the empty array won't even show up in the request
+        [:g, []]
       ]
       assert_equal(
-        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1",
+        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1&f=",
         Stripe::Util.encode_parameters(params)
       )
     end


### PR DESCRIPTION
Looking into a reported `legal_entity` bug, I discovered that the
handling of a `nil` found in parameters for a create, e.g.

    account = Stripe::Account.create(country: nil)

Is fundamentally different than for an update:

    account.country = nil
    account.save

Essentially the internal behavior has always been to prune `nil`
values for our `.create` and `.list` methods, while on update, values
get run through an additional filter than converts `nil` to an empty
string (and are therefore not prune). It seems like this has been in
place for a while.

Sufficed to say, it would be nice to correct this incredibly
inconsistent behavior because it's illogical and can be very confusing
for anyone who accidentally comes across it. It seems like we should be
able to change `.create` and `.list` to behave the same as an update
here. There is a test in place to verify the pruning of `nil` values,
but it's not clear what would break if we stopped doing it (if
anything).

Another nice side effect of the change is that the `nil` to empty string
conversion gets moved to the encoding step, which would potentially
allow us to just send a `nil` for request encodes that support one (i.e.
`application/json`).

/cc @kyleconroy @russelldavies Any idea if this would break anything?

/cc @remistr @dlambeth For general follow-up.