### PR TITLE
Remove test hacks introduced to work around Ruby 1.8 limitations

### DIFF
--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -81,10 +81,8 @@ module Stripe
       list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
       list.filters = { :expand => ['data.source'], :limit => 3 }
       @mock.expects(:get).with do |url, _, _|
-        # apparently URI.parse in 1.8.7 doesn't support query parameters ...
-        url, query = url.split("?")
         u = URI.parse(url)
-        params = CGI.parse(query)
+        params = CGI.parse(u.query)
         u.host == URI.parse(Stripe.api_base).host && u.path == "/things" && params == {
           "expand[]"       => ["data.source"],
           "limit"          => ["3"],

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -3,18 +3,17 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class UtilTest < Test::Unit::TestCase
     should "#encode_parameters should prepare parameters for an HTTP request" do
-      # use array instead of hash for 1.8.7 ordering
-      params = [
-        [:a, 3],
-        [:b, "+foo?"],
-        [:c, "bar&baz"],
-        [:d, { :a => "a", :b => "b" }],
-        [:e, [0, 1]],
-        [:f, ""],
+      params = {
+        :a => 3,
+        :b => "+foo?",
+        :c => "bar&baz",
+        :d => { :a => "a", :b => "b" },
+        :e => [0, 1],
+        :f => "",
 
         # note the empty hash won't even show up in the request
-        [:g, []]
-      ]
+        :g => [],
+      }
       assert_equal(
         "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1&f=",
         Stripe::Util.encode_parameters(params)


### PR DESCRIPTION
Pulls out a few pieces that were added specifically to support 1.8isms.