### PR TITLE
Correct URL used for refunding application fees

### DIFF
--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -14,7 +14,7 @@ module Stripe
     private
 
     def refund_url
-      url + '/refund'
+      url + '/refunds'
     end
   end
 end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -13,7 +13,9 @@ module Stripe
 
     should "application fees should be refundable" do
       @mock.expects(:get).never
-      @mock.expects(:post).once.returns(make_response({:id => "fee_test_fee", :refunded => true}))
+      @mock.expects(:post).once.
+        with("#{Stripe.api_base}/v1/application_fees/test_application_fee/refunds", nil, '').
+        returns(make_response({:id => "fee_test_fee", :refunded => true}))
       fee = Stripe::ApplicationFee.new("test_application_fee")
       fee.refund
       assert fee.refunded


### PR DESCRIPTION
This uses the new endpoint instead of the deprecated one.

Related to stripe/stripe-php#208.

/cc @russelldavies It seems like you have a fair bit of context on this one.
Would you mind taking a look? Thanks!