### PR TITLE
feat(request): optionally retry network failures

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,3 +59,16 @@ Run a single test suite:
 Run a single test:
 
     bundle exec ruby -Ilib/ test/stripe/util_test.rb -n /should.convert.names.to.symbols/
+
+== Configuration
+
+=== max_network_retries
+
+When `max_network_retries` is set to a positive integer, stripe will retry requests that 
+fail on a network error.  Idempotency keys will be added to post and get requests to ensure the 
+safety of retrying.  There will be a short delay between each retry, with an exponential backoff
+algorithm used to determine the length of the delay.  Default value is 0.
+
+Example:
+
+    Stripe.max_network_retries = 2


### PR DESCRIPTION
Retries can be turned on by setting

    Stripe.max_retries_on_network_failure = 2 # or any other positive integer

Once the `max_retries_on_network_failure` is set to a positive integer, and request that fails on a network error will be retried.  There will be a sleep between each retry, the length of which is determined using an exponential backoff algorithm.

If a post request is made without an idempotency key and retries are on, then an idempotency key will be added automatically, since it is unsafe to retry without one.

`max_retry_sleep_seconds` is a float that can be set to configure that maximum time to sleep between retries (default is 2 seconds)

`base_retry_sleep_seconds` is a float can be set to configure the time to wait before the initial retry (default is 0.5 seconds)