### PR TITLE
Update application fee refunds (round 2)

### DIFF
--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -7,14 +7,12 @@ module Stripe
     end
 
     def refund(params={}, opts={})
-      response, opts = request(:post, refund_url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
-    end
+      self.refunds.create
 
-    private
-
-    def refund_url
-      url + '/refunds'
+      # now that a refund has been created, we expect the state of this object
+      # to change as well (i.e. `refunded` will now be `true`) so refresh it
+      # from the server
+      refresh
     end
   end
 end

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -8,7 +8,7 @@ module Stripe
 
     def refund(params={}, opts={})
       response, opts = request(:post, refund_url, params, opts)
-      initialize_from(response, opts)
+      Util.convert_to_stripe_object(response, opts)
     end
 
     private

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -6,13 +6,15 @@ module Stripe
       '/v1/application_fees'
     end
 
+    # If you don't need access to an updated fee object after the refund, it's
+    # more performant to just call `fee.refunds.create` directly.
     def refund(params={}, opts={})
       self.refunds.create
 
       # now that a refund has been created, we expect the state of this object
       # to change as well (i.e. `refunded` will now be `true`) so refresh it
       # from the server
-      refresh
+      self.refresh
     end
   end
 end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -15,10 +15,10 @@ module Stripe
       @mock.expects(:get).never
       @mock.expects(:post).once.
         with("#{Stripe.api_base}/v1/application_fees/test_application_fee/refunds", nil, '').
-        returns(make_response({:id => "fee_test_fee", :refunded => true}))
+        returns(make_response(make_application_fee_refund))
       fee = Stripe::ApplicationFee.new("test_application_fee")
-      fee.refund
-      assert fee.refunded
+      refund = fee.refund
+      assert refund.kind_of?(Stripe::ApplicationFeeRefund)
     end
   end
 end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -12,13 +12,20 @@ module Stripe
     end
 
     should "application fees should be refundable" do
-      @mock.expects(:get).never
+      fee = Stripe::ApplicationFee.construct_from(make_application_fee)
+
+      # first a post to create a refund
       @mock.expects(:post).once.
-        with("#{Stripe.api_base}/v1/application_fees/test_application_fee/refunds", nil, '').
+        with("#{Stripe.api_base}/v1/application_fees/#{fee.id}/refunds", nil, '').
         returns(make_response(make_application_fee_refund))
-      fee = Stripe::ApplicationFee.new("test_application_fee")
-      refund = fee.refund
-      assert refund.kind_of?(Stripe::ApplicationFeeRefund)
+
+      # then a get to refresh the current object
+      @mock.expects(:get).once.
+        with("#{Stripe.api_base}/v1/application_fees/#{fee.id}", nil, nil).
+        returns(make_response({:id => "fee_test_fee", :refunded => true}))
+
+      fee.refund
+      assert fee.refunded
     end
   end
 end


### PR DESCRIPTION
Follows up the patch in #351, which I now believe is wrong. The trouble
is that we were mutating the application fee object, when in reality an
application fee refund is actually a completely new resource (see
[creating a refund][create-refund]). This patch edits the original
attempt to cut a new object and updates tests accordingly.

Once again, related to stripe/stripe-php#208.

CC @russelldavis Would you mind taking another look here? Thanks!

Also CC @remistr for general interest and additional sanity check.

Edit: Correct CC to Russell Davis (instead of Davies). Oops.

[create-refund]: https://stripe.com/docs/api#create_fee_refund