### PR TITLE
Always initialize `original_values` ivar in `StripeObject`

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -12,6 +12,7 @@ module Stripe
     def initialize(id=nil, opts={})
       id, @retrieve_params = Util.normalize_id(id)
       @opts = Util.normalize_opts(opts)
+      @original_values = {}
       @values = {}
       # This really belongs in APIResource, but not putting it there allows us
       # to have a unified inspect method

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -105,6 +105,13 @@ module Stripe
       assert_equal({}, Stripe::StripeObject.serialize_params(obj))
     end
 
+    should "#serialize_params on a new object with a subobject" do
+      obj = Stripe::StripeObject.new
+      obj.metadata = { :foo => "bar" }
+      assert_equal({ :metadata => { :foo => "bar" } },
+        Stripe::StripeObject.serialize_params(obj))
+    end
+
     should "#serialize_params on a basic object" do
       obj = Stripe::StripeObject.construct_from({ :foo => nil })
       obj.update_attributes(:foo => "bar")


### PR DESCRIPTION
This is kind of a weird one because it'll only cause a failure when
serializing a subobject or hash of a `StripeObject`, but it's good
practice to initialize instance variables anyway.

Fixes #360.