### PR TITLE
BitcoinReceiver refresh fix

### DIFF
--- a/lib/stripe/bitcoin_receiver.rb
+++ b/lib/stripe/bitcoin_receiver.rb
@@ -10,7 +10,7 @@ module Stripe
     end
 
     def url
-      if respond_to?(:customer)
+      if respond_to?(:customer) && !self.customer.nil?
         "#{Customer.url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
       else
         "#{self.class.url}/#{CGI.escape(id)}"

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -458,6 +458,7 @@ module Stripe
         :description => 'some details',
         :metadata => {},
         :object => 'bitcoin_receiver',
+        :customer => nil,
         :transactions => make_bitcoin_transaction_array
       }.merge(params)
     end


### PR DESCRIPTION
Stripe API responses include `customer: nil`, which caused `refresh` to throw an exception.