### PR TITLE
Deprecate `#refund` helpers on `Charge` and `ApplicationFee`

### DIFF
--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -1,6 +1,5 @@
 module Stripe
   class ApplicationFee < APIResource
-    extend Gem::Deprecate
     extend Stripe::APIOperations::List
 
     def self.url
@@ -17,6 +16,5 @@ module Stripe
       # from the server
       self.refresh
     end
-    deprecate :refund, "application_fee.refunds.create", 2016, 07
   end
 end

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -1,5 +1,6 @@
 module Stripe
   class ApplicationFee < APIResource
+    extend Gem::Deprecate
     extend Stripe::APIOperations::List
 
     def self.url
@@ -16,7 +17,6 @@ module Stripe
       # from the server
       self.refresh
     end
-    extend Gem::Deprecate
     deprecate :refund, "application_fee.refunds.create", 2016, 07
   end
 end

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -16,5 +16,7 @@ module Stripe
       # from the server
       self.refresh
     end
+    extend Gem::Deprecate
+    deprecate :refund, "application_fee.refunds.create", 2016, 07
   end
 end

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -1,6 +1,5 @@
 module Stripe
   class Charge < APIResource
-    extend Gem::Deprecate
     extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
@@ -13,7 +12,6 @@ module Stripe
       # from the server
       self.refresh
     end
-    deprecate :refund, "charge.refunds.create", 2016, 07
 
     def capture(params={}, opts={})
       response, opts = request(:post, capture_url, params, opts)

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -1,5 +1,6 @@
 module Stripe
   class Charge < APIResource
+    extend Gem::Deprecate
     extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
@@ -12,7 +13,6 @@ module Stripe
       # from the server
       self.refresh
     end
-    extend Gem::Deprecate
     deprecate :refund, "charge.refunds.create", 2016, 07
 
     def capture(params={}, opts={})

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -5,8 +5,12 @@ module Stripe
     include Stripe::APIOperations::Update
 
     def refund(params={}, opts={})
-      response, opts = request(:post, refund_url, params, opts)
-      initialize_from(response, opts)
+      self.refunds.create
+
+      # now that a refund has been created, we expect the state of this object
+      # to change as well (i.e. `refunded` will now be `true`) so refresh it
+      # from the server
+      self.refresh
     end
     extend Gem::Deprecate
     deprecate :refund, "charge.refunds.create", 2016, 07

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -8,6 +8,8 @@ module Stripe
       response, opts = request(:post, refund_url, params, opts)
       initialize_from(response, opts)
     end
+    extend Gem::Deprecate
+    deprecate :refund, "charge.refunds.create", 2016, 07
 
     def capture(params={}, opts={})
       response, opts = request(:post, capture_url, params, opts)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -206,12 +206,12 @@ module Stripe
               opts[:headers][:authorization] == 'Bearer local'
           end.returns(make_response(make_charge))
           Stripe.expects(:execute_request).with do |opts|
-            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge/refund" &&
+            opts[:url] == "#{Stripe.api_base}/v1/charges/ch_test_charge/refunds" &&
               opts[:headers][:authorization] == 'Bearer local'
-          end.returns(make_response(make_charge))
+          end.returns(make_response(make_refund))
 
           ch = Stripe::Charge.retrieve('ch_test_charge', 'local')
-          ch.refund
+          ch.refunds.create
         end
       end
     end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -21,31 +21,5 @@ module Stripe
       refund = fee.refunds.create
       assert refund.is_a?(Stripe::ApplicationFeeRefund)
     end
-
-    should "warn that #refund is deprecated" do
-      old_stderr = $stderr
-      $stderr = StringIO.new
-      begin
-        fee = Stripe::ApplicationFee.construct_from(make_application_fee)
-
-        # creates the refund (this is not how the endpoint would actually
-        # respond, but we discard the result anyway)
-        @mock.expects(:post).once.
-          with("#{Stripe.api_base}/v1/application_fees/#{fee.id}/refunds", nil, '').
-          returns(make_response({}))
-
-        # reloads the application fee to get the field updates
-        @mock.expects(:get).once.
-          with("#{Stripe.api_base}/v1/application_fees/#{fee.id}", nil, nil).
-          returns(make_response({:id => fee.id, :refunded => true}))
-
-        fee.refund
-        message = "NOTE: Stripe::ApplicationFee#refund is deprecated; use " +
-          "application_fee.refunds.create instead"
-        assert_match Regexp.new(message), $stderr.string
-      ensure
-        $stderr = old_stderr
-      end
-    end
   end
 end

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -28,7 +28,8 @@ module Stripe
       begin
         fee = Stripe::ApplicationFee.construct_from(make_application_fee)
 
-        # creates the refund
+        # creates the refund (this is not how the endpoint would actually
+        # respond, but we discard the result anyway)
         @mock.expects(:post).once.
           with("#{Stripe.api_base}/v1/application_fees/#{fee.id}/refunds", nil, '').
           returns(make_response({}))

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -120,9 +120,18 @@ module Stripe
       $stderr = StringIO.new
       begin
         charge = Stripe::Charge.construct_from(make_charge)
+
+        # creates the refund (this is not how the endpoint would actually
+        # respond, but we discard the result anyway)
         @mock.expects(:post).once.
-          with("#{Stripe.api_base}/v1/charges/#{charge.id}/refund", nil, '').
+          with("#{Stripe.api_base}/v1/charges/#{charge.id}/refunds", nil, '').
+          returns(make_response({}))
+
+        # reloads the charge to get the field updates
+        @mock.expects(:get).once.
+          with("#{Stripe.api_base}/v1/charges/#{charge.id}", nil, nil).
           returns(make_response({:id => charge.id, :refunded => true}))
+
         charge.refund
         message = "NOTE: Stripe::Charge#refund is deprecated; use " +
           "charge.refunds.create instead"

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -114,31 +114,5 @@ module Stripe
       })
       assert c.paid
     end
-
-    should "warn that #refund is deprecated" do
-      old_stderr = $stderr
-      $stderr = StringIO.new
-      begin
-        charge = Stripe::Charge.construct_from(make_charge)
-
-        # creates the refund (this is not how the endpoint would actually
-        # respond, but we discard the result anyway)
-        @mock.expects(:post).once.
-          with("#{Stripe.api_base}/v1/charges/#{charge.id}/refunds", nil, '').
-          returns(make_response({}))
-
-        # reloads the charge to get the field updates
-        @mock.expects(:get).once.
-          with("#{Stripe.api_base}/v1/charges/#{charge.id}", nil, nil).
-          returns(make_response({:id => charge.id, :refunded => true}))
-
-        charge.refund
-        message = "NOTE: Stripe::Charge#refund is deprecated; use " +
-          "charge.refunds.create instead"
-        assert_match Regexp.new(message), $stderr.string
-      ensure
-        $stderr = old_stderr
-      end
-    end
   end
 end


### PR DESCRIPTION
As discussed previously in #354 and alluded to in #363, this patch
deprecates the `#refund` helpers on `Charge` and `ApplicationFee` in
favor of the resource-centric approach (i.e. `charge.refunds.create`).

We do this for a few reasons:

1. The new approach is far preferred and uses our modern endpoints. It's
   also been the mechanism suggested by the documentation for ages now.
2. The old approach is somewhat risky in that a forgotten "s" can lead
   to an accidental refund (i.e. `charge.refund` instead of
   `charge.refunds`).

Follows up #354. Fixes #363.

Also reimplements `Charge#refund` to use our new refunds endpoint 
like we did in #354.

@kyleconroy @russelldavis If you guys have any thoughts on this one, I'd love
to hear them. Thanks!