### PR TITLE
Allow the CA bundle to be configured

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,6 +62,12 @@ Run a single test:
 
 == Configuration
 
+=== ca_bundle_path
+
+The location of a file containing a bundle of CA certificates. By default the
+library will use an included bundle that can successfully validate Stripe
+certificates.
+
 === max_network_retries
 
 When `max_network_retries` is set to a positive integer, stripe will retry requests that 

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -72,7 +72,7 @@ module Stripe
   @max_network_retry_delay = 2
   @initial_network_retry_delay = 0.5
 
-  @ssl_bundle_path  = DEFAULT_CA_BUNDLE_PATH
+  @ca_bundle_path  = DEFAULT_CA_BUNDLE_PATH
   @verify_ssl_certs = true
 
   @open_timeout = 30
@@ -109,7 +109,7 @@ module Stripe
 
     if verify_ssl_certs
       request_opts = {:verify_ssl => OpenSSL::SSL::VERIFY_PEER,
-                      :ssl_ca_file => @ssl_bundle_path}
+                      :ssl_ca_file => @ca_bundle_path}
     else
       request_opts = {:verify_ssl => false}
       unless @verify_ssl_warned
@@ -143,6 +143,17 @@ module Stripe
     response = execute_request_with_rescues(request_opts, api_base_url)
 
     [parse(response), api_key]
+  end
+
+  # The location of a file containing a bundle of CA certificates. By default
+  # the library will use an included bundle that can successfully validate
+  # Stripe certificates.
+  def self.ca_bundle_path
+    @ca_bundle_path
+  end
+
+  def self.ca_bundle_path=(path)
+    @ca_bundle_path = path
   end
 
   def self.max_network_retries

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -13,4 +13,24 @@ class StripeTest < Test::Unit::TestCase
       $stderr = old_stderr
     end
   end
+
+  should "allow ca_bundle_path to be configured" do
+    begin
+      old = Stripe.ca_bundle_path
+      Stripe.ca_bundle_path = "path/to/ca/bundle"
+      assert_equal "path/to/ca/bundle", Stripe.ca_bundle_path
+    ensure
+      Stripe.ca_bundle_path = old
+    end
+  end
+
+  should "allow max_network_retries to be configured" do
+    begin
+      old = Stripe.max_network_retries
+      Stripe.max_network_retries = 99
+      assert_equal 99, Stripe.max_network_retries
+    ensure
+      Stripe.max_network_retries = old
+    end
+  end
 end


### PR DESCRIPTION
As requested in #370, this will allow advanced users to configure a
certificate bundle that is expected to be more up-to-date than what
we've managed to include with the gem.

/cc @kyleconroy Would you mind taking a review pass on this one? Thanks!