### PR TITLE
Remove json gem dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
 
 gemfile:
   - gemfiles/default-with-activesupport.gemfile
-  - gemfiles/json.gemfile
   - gemfiles/yajl.gemfile
 
 matrix:

--- a/README.rdoc
+++ b/README.rdoc
@@ -33,7 +33,7 @@ If you want to build the gem from source:
 == Requirements
 
 * Ruby 1.9.3 or above.
-* rest-client, json
+* rest-client
 
 == Bundler
 

--- a/gemfiles/json.gemfile
+++ b/gemfiles/json.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-gemspec :path => File.join(File.dirname(__FILE__), "..")
-
-gem 'activesupport'
-gem 'json'

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -14,7 +14,6 @@ spec = Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('rest-client', '~> 1.4')
-  s.add_dependency('json', '~> 1.8.1')
 
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('shoulda', '~> 3.4.0')


### PR DESCRIPTION
All required rubies include JSON as part of the stdlib.

See: https://github.com/rails/rails/pull/23453