### PR TITLE
Pass params and opts through on `ApplicationFee#refund`

### DIFF
--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -9,7 +9,7 @@ module Stripe
     # If you don't need access to an updated fee object after the refund, it's
     # more performant to just call `fee.refunds.create` directly.
     def refund(params={}, opts={})
-      self.refunds.create
+      self.refunds.create(params, opts)
 
       # now that a refund has been created, we expect the state of this object
       # to change as well (i.e. `refunded` will now be `true`) so refresh it


### PR DESCRIPTION
`params` and `opts` are not currently passed through when using the
`#refund` helper on `ApplicationFee`. This was an omission on the
original refactor to use the new endpoint, and wasn't an intentional
design.

Fixes #386.