### PR TITLE
Fix serialization of hashes passed to `#save`

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -152,6 +152,7 @@ module Stripe
         # the object has been reassigned
         # e.g. as object.key = {foo => bar}
         update = new_value
+        update = update.to_hash if update.is_a?(StripeObject)
         new_keys = update.keys.map(&:to_sym)
 
         # remove keys at the server, but not known locally

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -652,10 +652,10 @@ module Stripe
           :display_name => nil,
         })
 
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe').
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/accounts", nil, 'display_name=stripe&metadata[key]=value').
           returns(make_response({"id" => "charge_id"}))
 
-        account.save(:display_name => 'stripe')
+        account.save(:display_name => 'stripe', :metadata => {:key => 'value' })
       end
     end
 


### PR DESCRIPTION
Adds a basic fix for serialization of hashes passed to `#save`. Previously, these would produce non-sensical output that would be rejected by the API.

This fix is designed to help curb the pain of the current problem, but isn't 100%. Serialization will still be problematic for hashes that are found inside of an array.

Fixes #384.

/cc @francois2metz I pulled your patch in here. Thanks!