### PR TITLE
Refactor `serialize_params` under `StripeObject`

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -57,12 +57,11 @@ module Stripe
     end
 
     def serialize_params_account(obj, update_hash)
-      obj.instance_variable_get(:@values).each do |k, v|
-        k = k.to_sym
-        if k == :additional_owners && v.is_a?(Array)
-          update_hash[k] = serialize_additional_owners(obj, v)
-        elsif v.is_a?(StripeObject) && update_hash[k]
-          serialize_params_account(v, update_hash[k])
+      if entity = @values[:legal_entity]
+        if owners = entity[:additional_owners]
+          entity_update = update_hash[:legal_entity] ||= {}
+          entity_update[:additional_owners] =
+            serialize_additional_owners(entity, owners)
         end
       end
       update_hash
@@ -91,9 +90,9 @@ module Stripe
 
     private
 
-    def serialize_additional_owners(obj, value)
-      original_value = obj.instance_variable_get(:@original_values)[:additional_owners]
-      if original_value && original_value.length > value.length
+    def serialize_additional_owners(legal_entity, additional_owners)
+      original_value = legal_entity.instance_variable_get(:@original_values)[:additional_owners]
+      if original_value && original_value.length > additional_owners.length
         # url params provide no mechanism for deleting an item in an array,
         # just overwriting the whole array or adding new items. So let's not
         # allow deleting without a full overwrite until we have a solution.
@@ -103,7 +102,7 @@ module Stripe
       end
 
       update_hash = {}
-      value.each_with_index do |v, i|
+      additional_owners.each_with_index do |v, i|
         # We will almost always see a StripeObject except in the case of a Hash
         # that's been appended to an array of `additional_owners`. We may be
         # able to normalize that ugliness by using an array proxy object with
@@ -111,8 +110,9 @@ module Stripe
         # StripeObject.
         update = v.is_a?(StripeObject) ? v.serialize_params : v
 
-        if update != {} && (!original_value || update != obj.serialize_params_value(original_value[i], nil, false, true))
-          update_hash[i.to_s] = update
+        if update != {} && (!original_value ||
+          update != legal_entity.serialize_params_value(original_value[i], nil, false, true))
+            update_hash[i.to_s] = update
         end
       end
       update_hash

--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -25,7 +25,7 @@ module Stripe
         # Now remove any parameters that look like object attributes.
         params = params.reject { |k, _| respond_to?(k) }
 
-        values = self.class.serialize_params(self).merge(params)
+        values = self.serialize_params(self).merge(params)
 
         # note that id gets removed here our call to #url above has already
         # generated a uri for this object with an identifier baked in

--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -27,14 +27,13 @@ module Stripe
 
         values = self.class.serialize_params(self).merge(params)
 
-        if values.length > 0
-          # note that id gets removed here our call to #url above has already
-          # generated a uri for this object with an identifier baked in
-          values.delete(:id)
+        # note that id gets removed here our call to #url above has already
+        # generated a uri for this object with an identifier baked in
+        values.delete(:id)
 
-          response, opts = request(:post, req_url, values)
-          initialize_from(response, opts)
-        end
+        response, opts = request(:post, req_url, values)
+        initialize_from(response, opts)
+
         self
       end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -78,10 +78,10 @@ module Stripe
     #
     # * +:dirty+ Whether values should be initiated as "dirty" (unsaved).
     #   Defaults to true.
-    def update_attributes(values, opts = nil, options = {})
-      dirty = options[:dirty]
+    def update_attributes(values, opts = {}, method_options = {})
+      dirty = method_options[:dirty]
       values.each do |k, v|
-        @values[k] = Util.convert_to_stripe_object(v, opts || {})
+        @values[k] = Util.convert_to_stripe_object(v, opts)
         dirty_value!(@values[k]) unless dirty == false
         @unsaved_values.add(k)
       end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -161,7 +161,8 @@ module Stripe
       update_hash = {}
 
       @values.each do |k, v|
-        # There are two reasons we may want to add in a parameter for update:
+        # There are a few reasons that we may want to add in a parameter for
+        # update:
         #
         #   1. The `force` option has been set.
         #   2. We know that it was modified.

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -324,6 +324,11 @@ module Stripe
       when nil
         ''
 
+      # The logic here is that essentially any object embedded in another
+      # object that had a `type` is actually an API resource of a different
+      # type that's been included in the response. These other resources must
+      # be updated from their proper endpoints, and therefore they are not
+      # included when serializing even if they've been modified.
       when APIResource
         nil
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -365,7 +365,7 @@ module Stripe
 
         # If the entire object was replaced, then we need blank each field of
         # the old object that held a value. The new serialized values will
-        # override an of these empties.
+        # override any of these empty values.
         update = empty_values(original).merge(update) if original && unsaved
 
         update

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -182,8 +182,14 @@ module Stripe
       update_hash
     end
 
-    def self.serialize_params(obj, options = {})
-      obj.serialize_params(options)
+    class << self
+      # This class method has been deprecated in favor of the instance method
+      # of the same name.
+      def serialize_params(obj, options = {})
+        obj.serialize_params(options)
+      end
+      extend Gem::Deprecate
+      deprecate :serialize_params, "#serialize_params", 2016, 9
     end
 
     protected

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -76,13 +76,17 @@ module Stripe
     #
     # ==== Options
     #
-    # * +:dirty+ Whether values should be initiated as "dirty" (unsaved).
-    #   Defaults to true.
+    # * +:dirty+ Whether values should be initiated as "dirty" (unsaved) and
+    #   which applies only to new StripeObjects being ininiated under this
+    #   StripeObject. Defaults to true.
     def update_attributes(values, opts = {}, method_options = {})
-      dirty = method_options[:dirty]
+      # Default to true. TODO: Convert to optional arguments after we're off
+      # 1.9 which will make this quite a bit more clear.
+      dirty = method_options.fetch(:dirty, true)
+
       values.each do |k, v|
         @values[k] = Util.convert_to_stripe_object(v, opts)
-        dirty_value!(@values[k]) unless dirty == false
+        dirty_value!(@values[k]) if dirty
         @unsaved_values.add(k)
       end
     end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -347,6 +347,11 @@ module Stripe
       # making sure any time one is set, we convert it to a StripeObject. This
       # will simplify our model by making data within an object more
       # consistent.
+      #
+      # For now, you can still run into a hash if someone appends one to an
+      # existing array being held by a StripeObject. This could happen for
+      # example by appending a new hash onto `additional_owners` for an
+      # account.
       when Hash
         Util.convert_to_stripe_object(value, @opts).serialize_params
 

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -155,8 +155,8 @@ module Stripe
     should "#serialize_params an a new additional_owners" do
       obj = Stripe::Util.convert_to_stripe_object({
         :object => "account",
-        :legal_entity => {
-        },
+        :legal_entity => Stripe::StripeObject.construct_from({
+        }),
       }, {})
       obj.legal_entity.additional_owners = [
         { :first_name => "Joe" },
@@ -171,7 +171,7 @@ module Stripe
           }
         }
       }
-      assert_equal(expected, obj.class.serialize_params(obj))
+      assert_equal(expected, obj.serialize_params)
     end
 
     should "#serialize_params on an partially changed additional_owners" do
@@ -197,7 +197,7 @@ module Stripe
           }
         }
       }
-      assert_equal(expected, obj.class.serialize_params(obj))
+      assert_equal(expected, obj.serialize_params)
     end
 
     should "#serialize_params on an unchanged additional_owners" do
@@ -220,7 +220,7 @@ module Stripe
           :additional_owners => {}
         }
       }
-      assert_equal(expected, obj.class.serialize_params(obj))
+      assert_equal(expected, obj.serialize_params)
     end
 
     # Note that the empty string that we send for this one has a special
@@ -246,7 +246,7 @@ module Stripe
           :additional_owners => ""
         }
       }
-      assert_equal(expected, obj.class.serialize_params(obj))
+      assert_equal(expected, obj.serialize_params)
     end
   end
 end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -121,20 +121,20 @@ module Stripe
 
     should "#serialize_params on an empty object" do
       obj = Stripe::StripeObject.construct_from({})
-      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+      assert_equal({}, obj.serialize_params)
     end
 
     should "#serialize_params on a new object with a subobject" do
       obj = Stripe::StripeObject.new
       obj.metadata = { :foo => "bar" }
       assert_equal({ :metadata => { :foo => "bar" } },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params on a basic object" do
       obj = Stripe::StripeObject.construct_from({ :foo => nil })
       obj.update_attributes(:foo => "bar")
-      assert_equal({ :foo => "bar" }, Stripe::StripeObject.serialize_params(obj))
+      assert_equal({ :foo => "bar" }, obj.serialize_params)
     end
 
     should "#serialize_params on a more complex object" do
@@ -146,7 +146,7 @@ module Stripe
       })
       obj.foo.bar = "newbar"
       assert_equal({ :foo => { :bar => "newbar" } },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params on an array" do
@@ -155,7 +155,7 @@ module Stripe
       })
       obj.foo = ["new-value"]
       assert_equal({ :foo => ["new-value"] },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params on an array that shortens" do
@@ -164,7 +164,7 @@ module Stripe
       })
       obj.foo = ["new-value"]
       assert_equal({ :foo => ["new-value"] },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params on an array that lengthens" do
@@ -173,7 +173,7 @@ module Stripe
       })
       obj.foo = ["new-value"] * 4
       assert_equal({ :foo => ["new-value"] * 4 },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params on an array of hashes" do
@@ -187,12 +187,12 @@ module Stripe
       ]
       obj.foo[0].bar = "baz"
       assert_equal({ :foo => [{ :bar => "baz" }] },
-        Stripe::StripeObject.serialize_params(obj))
+        obj.serialize_params)
     end
 
     should "#serialize_params doesn't include unchanged values" do
       obj = Stripe::StripeObject.construct_from({ :foo => nil })
-      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+      assert_equal({}, obj.serialize_params)
     end
 
     should "#serialize_params on an array that is unchanged" do
@@ -200,7 +200,7 @@ module Stripe
         :foo => ["0-index", "1-index", "2-index"],
       })
       obj.foo = ["0-index", "1-index", "2-index"]
-      assert_equal({}, Stripe::StripeObject.serialize_params(obj))
+      assert_equal({}, obj.serialize_params)
     end
 
     should "#serialize_params with a StripeObject" do
@@ -211,7 +211,7 @@ module Stripe
       obj.metadata =
         Stripe::StripeObject.construct_from({ :foo => 'bar' })
 
-      serialized = Stripe::StripeObject.serialize_params(obj)
+      serialized = obj.serialize_params
       assert_equal({ :foo => "bar" }, serialized[:metadata])
     end
 
@@ -226,7 +226,7 @@ module Stripe
       obj.metadata =
         Stripe::StripeObject.construct_from({ :baz => 'foo' })
 
-      serialized = Stripe::StripeObject.serialize_params(obj)
+      serialized = obj.serialize_params
       assert_equal({ :bar => "", :baz => 'foo' }, serialized[:metadata])
     end
 
@@ -236,7 +236,7 @@ module Stripe
         Stripe::StripeObject.construct_from({ :foo => 'bar' })
       ]
 
-      serialized = Stripe::StripeObject.serialize_params(obj)
+      serialized = obj.serialize_params
       assert_equal([{ :foo => "bar" }], serialized[:metadata])
     end
 
@@ -245,7 +245,7 @@ module Stripe
         :customer => Customer.construct_from({})
       })
 
-      serialized = Stripe::StripeObject.serialize_params(obj)
+      serialized = obj.serialize_params
       assert_equal({}, serialized)
     end
 
@@ -255,7 +255,7 @@ module Stripe
         :metadata => Stripe::StripeObject.construct_from({ :foo => 'bar' })
       })
 
-      serialized = Stripe::StripeObject.serialize_params(obj, :force => true)
+      serialized = obj.serialize_params(:force => true)
       assert_equal({ :id => 'id', :metadata => { :foo => 'bar' } }, serialized)
     end
 
@@ -269,7 +269,7 @@ module Stripe
       # functionally equivalent
       obj.dirty!
 
-      serialized = Stripe::StripeObject.serialize_params(obj)
+      serialized = obj.serialize_params
       assert_equal({ :id => 'id', :metadata => { :foo => 'bar' } }, serialized)
     end
   end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -258,5 +258,19 @@ module Stripe
       serialized = Stripe::StripeObject.serialize_params(obj, :force => true)
       assert_equal({ :id => 'id', :metadata => { :foo => 'bar' } }, serialized)
     end
+
+    should "#dirty! forces an object and its subobjects to be saved" do
+      obj = Stripe::StripeObject.construct_from({
+        :id => 'id',
+        :metadata => Stripe::StripeObject.construct_from({ :foo => 'bar' })
+      })
+
+      # note that `force` and `dirty!` are for different things, but are
+      # functionally equivalent
+      obj.dirty!
+
+      serialized = Stripe::StripeObject.serialize_params(obj)
+      assert_equal({ :id => 'id', :metadata => { :foo => 'bar' } }, serialized)
+    end
   end
 end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -272,5 +272,19 @@ module Stripe
       serialized = obj.serialize_params
       assert_equal({ :id => 'id', :metadata => { :foo => 'bar' } }, serialized)
     end
+
+    should "warn that .serialize_params is deprecated" do
+      old_stderr = $stderr
+      $stderr = StringIO.new
+      begin
+        obj = Stripe::StripeObject.construct_from({})
+        Stripe::StripeObject.serialize_params(obj)
+        message = "NOTE: Stripe::StripeObject.serialize_params is " +
+          "deprecated; use #serialize_params instead"
+        assert_match Regexp.new(message), $stderr.string
+      ensure
+        $stderr = old_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull does two major things:

1. Refactors `serialize_params` to be more concise and readable while still complying to our existing test suite. Unfortunately over time this method has become a ball of mud that's very difficult to reason about, as recently evidenced by #384.
2. Moves `serialize_params` from class method to instance method (while still keeping for old class method for backwards compatibility). This is to give it a more sane interface.

The test suite around serialization is fairly comprehensive so we can be reasonably sure that this will work as expected; although it wouldn't be too surprising to find yet another edge case caused by `additional_owners`.