### PR TITLE
Fix reference to URLs on ListObject

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -96,5 +96,10 @@ module Stripe
 
       list(params, opts)
     end
+
+    def resource_url
+      self.url ||
+        raise(ArgumentError, "List object does not contain a 'url' field.")
+    end
   end
 end

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -31,7 +31,11 @@ module Stripe
       ]
       expected = Util.convert_to_stripe_object(arr, {})
 
-      list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 1 }],
+        :has_more => true,
+        :url => "/things",
+      })
       @mock.expects(:get).once.with("#{Stripe.api_base}/things?starting_after=1", nil, nil).
         returns(make_response({ :data => [{ :id => 2 }, { :id => 3}], :has_more => false }))
 
@@ -46,7 +50,11 @@ module Stripe
       ]
       expected = Util.convert_to_stripe_object(arr, {})
 
-      list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 1 }],
+        :has_more => true,
+        :url => "/things",
+      })
       @mock.expects(:get).once.with("#{Stripe.api_base}/things?starting_after=1", nil, nil).
         returns(make_response({ :data => [{ :id => 2 }, { :id => 3}], :has_more => false }))
 
@@ -70,7 +78,11 @@ module Stripe
     #
 
     should "fetch a next page through #next_page" do
-      list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 1 }],
+        :has_more => true,
+        :url => "/things",
+      })
       @mock.expects(:get).once.with("#{Stripe.api_base}/things?starting_after=1", nil, nil).
         returns(make_response({ :data => [{ :id => 2 }], :has_more => false }))
       next_list = list.next_page
@@ -78,7 +90,11 @@ module Stripe
     end
 
     should "fetch a next page through #next_page and respect limit" do
-      list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => true })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 1 }],
+        :has_more => true,
+        :url => "/things",
+      })
       list.filters = { :expand => ['data.source'], :limit => 3 }
       @mock.expects(:get).with do |url, _, _|
         u = URI.parse(url)
@@ -94,7 +110,11 @@ module Stripe
     end
 
     should "fetch an empty page through #next_page" do
-      list = TestListObject.construct_from({ :data => [{ :id => 1 }], :has_more => false })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 1 }],
+        :has_more => false,
+        :url => "/things",
+      })
       next_list = list.next_page
       assert_equal Stripe::ListObject.empty_list, next_list
     end
@@ -104,7 +124,10 @@ module Stripe
     #
 
     should "fetch a next page through #previous_page" do
-      list = TestListObject.construct_from({ :data => [{ :id => 2 }] })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 2 }],
+        :url => "/things",
+      })
       @mock.expects(:get).once.with("#{Stripe.api_base}/things?ending_before=2", nil, nil).
         returns(make_response({ :data => [{ :id => 1 }] }))
       next_list = list.previous_page
@@ -112,7 +135,10 @@ module Stripe
     end
 
     should "fetch a next page through #previous_page and respect limit" do
-      list = TestListObject.construct_from({ :data => [{ :id => 2 }] })
+      list = TestListObject.construct_from({
+        :data => [{ :id => 2 }],
+        :url => "/things",
+      })
       list.filters = { :expand => ['data.source'], :limit => 3 }
       @mock.expects(:get).with do |url, _, _|
         # apparently URI.parse in 1.8.7 doesn't support query parameters ...
@@ -150,7 +176,4 @@ end
 
 # A helper class with a URL that allows us to try out pagination.
 class TestListObject < Stripe::ListObject
-  def resource_url
-    "/things"
-  end
 end


### PR DESCRIPTION
In #394 we renamed `url` to `resource_url` in order to prevent name
collisions in API resource that also have a `url` property.
Unfortunately, this didn't account for the fact that when making API
calls on a list object we rely on a returned `url` property to build a
request, and this had been renamed to `resource_url`. Tests should have
caught this, but they were written to work differently than how live
API calls actually function.

This patch repairs the problem by adding a `resource_url` to list
objects, and modifies test to be more accurate to reality so that
they'll catch this class of problem in the future.

Fixes #395.