### PR TITLE
Lock Byebug to just the MRI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,9 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
   - jruby-19mode
-
-gemfile:
-  - gemfiles/default-with-activesupport.gemfile
-  - gemfiles/yajl.gemfile
-
-matrix:
-  exclude:
-    - rvm: jruby-19mode
-      gemfile: gemfiles/yajl.gemfile
+  - jruby-head
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.0
   - jruby-19mode
-  - jruby-head
+  - jruby-9.0.5.0
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,20 @@
 source "https://rubygems.org"
+
 gemspec
+
+group :development do
+  gem 'mocha', '~> 0.13.2'
+  gem 'pry'
+  gem 'rake'
+  gem 'shoulda', '~> 3.4.0'
+  gem 'test-unit'
+
+  platforms :mri do
+    # to avoid problems, bring Byebug in on just versions of Ruby under which
+    # it's known to work well
+    if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+      gem 'byebug'
+      gem 'pry-byebug'
+    end
+  end
+end

--- a/gemfiles/default-with-activesupport.gemfile
+++ b/gemfiles/default-with-activesupport.gemfile
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec :path => File.join(File.dirname(__FILE__), "..")
-
-gem 'activesupport'

--- a/gemfiles/yajl.gemfile
+++ b/gemfiles/yajl.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-gemspec :path => File.join(File.dirname(__FILE__), "..")
-
-gem 'activesupport'
-gem 'yajl-ruby'

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -15,19 +15,6 @@ spec = Gem::Specification.new do |s|
 
   s.add_dependency('rest-client', '~> 1.4')
 
-  s.add_development_dependency('mocha', '~> 0.13.2')
-  s.add_development_dependency('shoulda', '~> 3.4.0')
-  s.add_development_dependency('test-unit')
-  s.add_development_dependency('rake')
-
-  # to avoid problems, bring Byebug in on just versions of Ruby under which
-  # it's known to work well
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
-    s.add_development_dependency("byebug")
-    s.add_development_dependency("pry")
-    s.add_development_dependency("pry-byebug")
-  end
-
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Here we predicate the installation of Byebug on being on the MRI. This
allows us to `bundle install` on alternate platforms like JRuby.