### PR TITLE
Initialize @max_network_retries

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -70,6 +70,7 @@ module Stripe
   @connect_base = 'https://connect.stripe.com'
   @uploads_base = 'https://uploads.stripe.com'
 
+  @max_network_retries = 0
   @max_network_retry_delay = 2
   @initial_network_retry_delay = 0.5
 
@@ -158,7 +159,7 @@ module Stripe
   end
 
   def self.max_network_retries
-    @max_network_retries || 0
+    @max_network_retries
   end
 
   def self.max_network_retries=(val)


### PR DESCRIPTION
Certain platforms will throw an error if this variable is accessed
without being initialized. Assign it a value instead of relying on the
OR operator to give it a default.