### PR TITLE
Create account.reject method.

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -28,6 +28,12 @@ module Stripe
       super(id, opts)
     end
 
+    def reject(params={}, opts={})
+      opts = Util.normalize_opts(opts)
+      response, opts = request(:post, resource_url + '/reject', params, opts)
+      initialize_from(response, opts)
+    end
+
     # Somewhat unfortunately, we attempt to do a special encoding trick when
     # serializing `additional_owners` under an account: when updating a value,
     # we actually send the update parameters up as an integer-indexed hash

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -52,6 +52,22 @@ module Stripe
       assert_equal 'secret-key', account.keys.secret
     end
 
+    should "be rejectable" do
+      account_data = {:id => 'acct_foo'}
+      @mock.expects(:get).
+        once.
+        with('https://api.stripe.com/v1/accounts/acct_foo', nil, nil).
+        returns(make_response(account_data))
+
+      @mock.expects(:post).
+        once.
+        with("https://api.stripe.com/v1/accounts/acct_foo/reject", nil, 'reason=fraud').
+        returns(make_response(account_data))
+
+      account = Stripe::Account.retrieve('acct_foo')
+      account.reject(:reason => 'fraud')
+    end
+
     should "be updatable" do
       resp = {
         :id => 'acct_foo',


### PR DESCRIPTION
Adds bindings for the [Account.reject](https://stripe.com/docs/api#reject_account) method.