### PR TITLE
Allow options (headers) to be passed into .save

### DIFF
--- a/lib/stripe/api_operations/update.rb
+++ b/lib/stripe/api_operations/update.rb
@@ -13,7 +13,11 @@ module Stripe
       #   and includes them in the create or update. If +:req_url:+ is included
       #   in the list, it overrides the update URL used for the create or
       #   update.
-      def save(params={})
+      # * +opts+ - A Hash of additional options (separate from the params /
+      #   object values) to be added to the request. E.g. to allow for an
+      #   idempotency_key to be passed in the request headers, or for the
+      #   api_key to be overwritten. See {APIOperations::Request.request}.
+      def save(params={}, opts={})
         # We started unintentionally (sort of) allowing attributes sent to
         # +save+ to override values used during the update. So as not to break
         # the API, this makes that official here.
@@ -28,7 +32,7 @@ module Stripe
         # generated a uri for this object with an identifier baked in
         values.delete(:id)
 
-        response, opts = request(:post, save_url, values)
+        response, opts = request(:post, save_url, values, opts)
         initialize_from(response, opts)
 
         self

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -387,6 +387,31 @@ module Stripe
         assert_equal false, c.livemode
       end
 
+      should "updating should send along the idempotency-key header" do
+        Stripe.expects(:execute_request).with do |opts|
+          opts[:headers][:idempotency_key] == 'bar'
+        end.returns(make_response(make_customer))
+        c = Stripe::Customer.new
+        c.save({}, { :idempotency_key => 'bar' })
+        assert_equal false, c.livemode
+      end
+
+      should "updating should fail if api_key is overwritten with nil" do
+        c = Stripe::Customer.new
+        assert_raises TypeError do
+          c.save({}, { :api_key => nil })
+        end
+      end
+
+      should "updating should use the supplied api_key" do
+        Stripe.expects(:execute_request).with do |opts|
+          opts[:headers][:authorization] == 'Bearer sk_test_local'
+        end.returns(make_response(make_customer))
+        c = Stripe::Customer.new
+        c.save({}, { :api_key => 'sk_test_local' })
+        assert_equal false, c.livemode
+      end
+
       should "deleting should send no props and result in an object that has no props other deleted" do
         @mock.expects(:get).never
         @mock.expects(:post).never


### PR DESCRIPTION
in the same manner as is already possible for .create.

Use-case / rationale:

For some operations, we don't care whether we are operating on a new or an existing object. For example, we'd do something like the below upon receiving a new card token. We may receive a card token either because a user just entered her payment information for the first time, or because she wants to update existing information. We'd like to handle both cases in a single endpoint.

```ruby
class User
  def stripe_customer
    @stripe_customer ||=
      if stripe_customer_id?
        Stripe::Customer.retrieve(stripe_customer_id)
      else
        Stripe::Customer.new.tap { |sc| sc.update_attributes(email: email) }
      end
  end

  def update_payment_info!(stripe_token)
    stripe_customer.source = stripe_token

    stripe_customer.save &&
    self.stripe_customer_id ||= stripe_customer.id &&
    save
  end
end
```

It would be great, if we could e.g. pass an idempotency_key into #save to ensure we don't create multiple customers when retrying the request.