### PR TITLE
Improve error message on setting empty strings

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -233,7 +233,7 @@ module Stripe
               raise ArgumentError.new(
                 "You cannot set #{k} to an empty string. " \
                 "We interpret empty strings as nil in requests. " \
-                "You may set #{self}.#{k} = nil to delete the property.")
+                "You may set (object).#{k} = nil to delete the property.")
             end
             @values[k] = Util.convert_to_stripe_object(v, @opts)
             dirty_value!(@values[k])

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -286,5 +286,13 @@ module Stripe
         $stderr = old_stderr
       end
     end
+
+    should "error on setting a property to an empty string" do
+      obj = Stripe::StripeObject.construct_from({ :foo => 'bar' })
+      e = assert_raises ArgumentError do
+        obj.foo = ""
+      end
+      assert_match /\(object\).foo = nil/, e.message
+    end
   end
 end


### PR DESCRIPTION
This improves the error message that a user sees when attempting to set
a property to an empty string.