### PR TITLE
Remove check that prevents API resource subobjects from being serialized

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -329,14 +329,6 @@ module Stripe
       when nil
         ''
 
-      # The logic here is that essentially any object embedded in another
-      # object that had a `type` is actually an API resource of a different
-      # type that's been included in the response. These other resources must
-      # be updated from their proper endpoints, and therefore they are not
-      # included when serializing even if they've been modified.
-      when APIResource
-        nil
-
       when Array
         update = value.map { |v| serialize_params_value(v, nil, true, force) }
 

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -551,21 +551,6 @@ module Stripe
         acct.save
       end
 
-      should 'not save nested API resources' do
-        ch = Stripe::Charge.construct_from({
-          :id => 'charge_id',
-          :customer => {
-            :object => 'customer',
-            :id => 'customer_id'
-          }
-        })
-
-        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/charges/charge_id", nil, '').returns(make_response({"id" => "charge_id"}))
-
-        ch.customer.description = 'Bob'
-        ch.save
-      end
-
       should 'correctly handle replaced nested objects' do
         acct = Stripe::Account.construct_from({
           :id => 'myid',

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -240,15 +240,6 @@ module Stripe
       assert_equal([{ :foo => "bar" }], serialized[:metadata])
     end
 
-    should "#serialize_params and remove embedded APIResources" do
-      obj = Stripe::StripeObject.construct_from({
-        :customer => Customer.construct_from({})
-      })
-
-      serialized = obj.serialize_params
-      assert_equal({}, serialized)
-    end
-
     should "#serialize_params takes a force option" do
       obj = Stripe::StripeObject.construct_from({
         :id => 'id',


### PR DESCRIPTION
Prior to my last major serialization refactor, there was a check in the
code that would remove any subobjects from serialization that were of
their own proper resource type (for example, if a charge contained a
customer, that customer would be removed).

What I didn't realize at the time is that the old serialization code had
a bug/quirk that would allow *certain types* of subobjects that were API
resources to make it through unscathed.

In short, the behavior requirement here is *directly* contradictory.
There was a test in place that would make sure that `customer` was
removed from this hash:

``` ruby
{
  :id => 'ch_id',
  :object => 'charge',
  :customer => {
    :object => 'customer',
    :id => 'customer_id'
  }
}
```

But, as reported in #406, we expect, and indeed need, for `source` (a
card) to make it through to the API in this hash:

``` ruby
{
  :id => 'cus_id',
  :object => 'customer',
  :source => {
    :object => 'card',
    :id => 'card_id'
  }
}
```

My proposal here is to just remove the check on serializing API
resources. The normal code that only sends up keys/hashes that have
changed is still in place, so in the first example, `customer` still
isn't sent unless the user has directly manipulated a field on that
subobject. I propose that in those cases we allow the API itself to
reject the request rather than try to cut it off at the client level.

Unfortunately, there is some possibility that removing those API
resources is important for some reason, but of course there's no
documentation on it beyond the after-the-fact post-justification that I
wrote during my last refactor. I can't think of any reason that it would
be too destructive, but there is some level of risk.

Fixes #406.

/cc @mmcgrana Any thoughts on this one?

/cc @stripe/api-libraries