### PR TITLE
add test for handling of charge.outcome subfield

### DIFF
--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -72,6 +72,12 @@ module Stripe
       assert c.card.kind_of?(Stripe::StripeObject) && c.card.object == 'card'
     end
 
+    should "charges should have Outcome objects associated with their outcome property" do
+      @mock.expects(:get).once.returns(make_response(make_charge))
+      c = Stripe::Charge.retrieve("test_charge")
+      assert c.outcome.kind_of?(Stripe::StripeObject) && c.outcome.type == 'authorized'
+    end
+
     should "execute should return a new, fully executed charge when passed correct `card` parameters" do
       @mock.expects(:post).with do |url, api_key, params|
         url == "#{Stripe.api_base}/v1/charges" && api_key.nil? && CGI.parse(params) == {

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -152,7 +152,13 @@ module Stripe
         :object => "charge",
         :created => 1304114826,
         :refunds => make_refund_array(id),
-        :metadata => {}
+        :metadata => {},
+        :outcome => {
+          type: 'authorized',
+          reason: nil,
+          seller_message: 'Payment complete.',
+          network_status: 'approved_by_network',
+        },
       }.merge(params)
     end
 


### PR DESCRIPTION
This PR adds a test to ensure that the forthcoming `outcome` nested subfield on the charge resource is rendered correctly by ruby bindings.

r? @brandur 

