### PR TITLE
Fix warnings emitted during tests

### DIFF
--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -3,7 +3,6 @@ module Stripe
     module List
       def list(filters={}, opts={})
         opts = Util.normalize_opts(opts)
-        opts = @opts.merge(opts) if @opts
 
         response, opts = request(:get, resource_url, filters, opts)
         obj = ListObject.construct_from(response, opts)

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -13,7 +13,7 @@ module Stripe
       # an `Array` and fall back to the old refund URL if necessary so as to
       # maintain internal compatibility.
       unless self.refunds.is_a?(Array)
-        refund = self.refunds.create(params, opts)
+        self.refunds.create(params, opts)
 
         # now that a refund has been created, we expect the state of this object
         # to change as well (i.e. `refunded` will now be `true`) so refresh it

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -32,7 +32,7 @@ module Stripe
     # considered to be equal if they have the same set of values and each one
     # of those values is the same.
     def ==(other)
-      @values == other.instance_variable_get(:@values)
+      other.is_a?(StripeObject) && @values == other.instance_variable_get(:@values)
     end
 
     # Indicates whether or not the resource has been deleted on the server.

--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -12,7 +12,7 @@ module Stripe
     end
 
     def delete_discount
-      response, opts = request(:delete, discount_url)
+      _, opts = request(:delete, discount_url)
       initialize_from({ :discount => nil }, opts, true)
     end
 

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -5,7 +5,7 @@ module Stripe
     include Stripe::APIOperations::Update
 
     def cancel
-      response, api_key = Stripe.request(:post, cancel_url, @api_key)
+      response, api_key = self.request(:post, cancel_url)
       initialize_from(response, api_key)
     end
 

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -120,7 +120,7 @@ module Stripe
 
       # do not sort the final output because arrays (and arrays of hashes
       # especially) can be order sensitive, but do sort incoming parameters
-      params.sort_by { |(k, v)| k.to_s }.each do |key, value|
+      params.sort_by { |(k, _)| k.to_s }.each do |key, value|
         calculated_key = parent_key ? "#{parent_key}[#{key}]" : "#{key}"
         if value.is_a?(Hash)
           result += flatten_params(value, calculated_key)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -445,7 +445,7 @@ module Stripe
           opts[:url] == "#{Stripe.api_base}/v1/customers/c_test_customer" &&
           opts[:headers][:stripe_account] == 'acct_abc'
         end.once.returns(make_response(make_customer))
-        c = Stripe::Customer.retrieve("c_test_customer", {:stripe_account => 'acct_abc'})
+        Stripe::Customer.retrieve("c_test_customer", {:stripe_account => 'acct_abc'})
       end
 
       should "passing in a stripe_account header should pass it through on save" do

--- a/test/stripe/bitcoin_receiver_test.rb
+++ b/test/stripe/bitcoin_receiver_test.rb
@@ -47,14 +47,14 @@ module Stripe
     should "delete a bitcoin receiver with no customer through top-level API" do
       @mock.expects(:delete).with("#{Stripe.api_base}/v1/bitcoin/receivers/btcrcv_test_receiver", nil, nil).once.returns(make_response({:deleted => true, :id => "btcrcv_test_receiver"}))
       receiver = Stripe::BitcoinReceiver.construct_from(make_bitcoin_receiver)
-      response = receiver.delete
+      receiver.delete
       assert(receiver.deleted)
     end
 
     should "delete a bitcoin receiver with a customer through customer's subresource API" do
       @mock.expects(:delete).with("#{Stripe.api_base}/v1/customers/customer_foo/sources/btcrcv_test_receiver", nil, nil).once.returns(make_response({:deleted => true, :id => "btcrcv_test_receiver"}))
       receiver = Stripe::BitcoinReceiver.construct_from(make_bitcoin_receiver(:customer => 'customer_foo'))
-      response = receiver.delete
+      receiver.delete
       assert(receiver.deleted)
     end
   end

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -283,7 +283,7 @@ module Stripe
       e = assert_raises ArgumentError do
         obj.foo = ""
       end
-      assert_match /\(object\).foo = nil/, e.message
+      assert_match %r{\(object\).foo = nil}, e.message
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,10 @@ module Stripe
     @mock_rest_client = mock_client
   end
 
+  class << self
+    remove_method :execute_request
+  end
+
   def self.execute_request(opts)
     get_params = (opts[:headers] || {})[:params]
     post_params = opts[:payload]


### PR DESCRIPTION
I'm not sure exactly what changed here (did we change the `$VERBOSE`
setting?), but I'm not seeing a whole lot of warnings when running the
test suites locally and in CI. For example:

```
Started
........................................./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
............../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
......../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
.../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
........./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
...
..../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
....../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
..../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
......./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
........./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
........../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
................./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
.../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
..../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
....../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
..........
........./home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
....../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
......../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
......../home/travis/build/stripe/stripe-ruby/lib/stripe/api_operations/list.rb:6: warning: instance variable @opts not initialized
............./home/travis/build/stripe/stripe-ruby/lib/stripe/stripe_object.rb:35: warning: instance variable @values not initialized
./home/travis/build/stripe/stripe-ruby/lib/stripe/stripe_object.rb:35: warning: instance variable @values not initialized
...................../home/travis/build/stripe/stripe-ruby/lib/stripe/transfer.rb:8: warning: instance variable @api_key not initialized
..............
..
Finished in 0.785621037 seconds.
```

Most of these are due to unused or uninitialized variables. This patch
fixes all warnings by fixing offending code.