### PR TITLE
Use v1/subs endpoints for operations on subs and allow direct sub access

### DIFF
--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -1,15 +1,9 @@
 module Stripe
   class Subscription < APIResource
+    extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Update
     include Stripe::APIOperations::Delete
-
-    def resource_url
-      "#{Customer.resource_url}/#{CGI.escape(customer)}/subscriptions/#{CGI.escape(id)}"
-    end
-
-    def self.retrieve(id, opts=nil)
-      raise NotImplementedError.new("Subscriptions cannot be retrieved without a customer ID. Retrieve a subscription using customer.subscriptions.retrieve('subscription_id')")
-    end
+    extend Stripe::APIOperations::List
 
     def delete_discount
       response, opts = request(:delete, discount_url)

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -287,7 +287,7 @@ module Stripe
       {
         :data => [make_subscription, make_subscription, make_subscription],
         :object => 'list',
-        :resource_url => '/v1/customers/' + customer_id + '/subscriptions'
+        :resource_url => '/v1/subscriptions'
       }
     end
 

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -118,7 +118,7 @@ module Stripe
         :created => 1304114758,
         :sources => make_customer_card_array(id),
         :metadata => {},
-        :subscriptions => make_subscription_array(id)
+        :subscriptions => make_customer_subscription_array(id)
       }.merge(params)
     end
 
@@ -283,11 +283,19 @@ module Stripe
       }.merge(params)
     end
 
-    def make_subscription_array(customer_id)
+    def make_subscription_array
       {
         :data => [make_subscription, make_subscription, make_subscription],
         :object => 'list',
         :resource_url => '/v1/subscriptions'
+      }
+    end
+
+    def make_customer_subscription_array(customer_id)
+      {
+        :data => [make_subscription, make_subscription, make_subscription],
+        :object => 'list',
+        :resource_url => '/v1/customers/' + customer_id + '/subscriptions'
       }
     end
 


### PR DESCRIPTION
This PR:
Changes the v1/cus/cus_123/sub/* style URL to v1/sub/* so the Ruby bindings call the new API endpoints
Allows subscriptions to be retrieved, created, and listed directly
Continues support for update and deletion of subs
Updates the tests to use the methodology of the new docs and call the new endpoint

Not merging until data has been backfilled since this uses the new v1/subs API endpoints which rely on Subs data model.