### PR TITLE
Allow `stripe_account` to be set globally:

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -82,7 +82,7 @@ module Stripe
   @read_timeout = 80
 
   class << self
-    attr_accessor :api_key, :api_base, :verify_ssl_certs, :api_version, :connect_base, :uploads_base,
+    attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs, :api_version, :connect_base, :uploads_base,
                   :open_timeout, :read_timeout
 
     attr_reader :max_network_retry_delay, :initial_network_retry_delay
@@ -278,10 +278,11 @@ module Stripe
     # It is only safe to retry network failures on post and delete
     # requests if we add an Idempotency-Key header
     if [:post, :delete].include?(method) && self.max_network_retries > 0
-      headers[:idempotency_key] ||= SecureRandom.uuid 
+      headers[:idempotency_key] ||= SecureRandom.uuid
     end
 
     headers[:stripe_version] = api_version if api_version
+    headers[:stripe_account] = stripe_account if stripe_account
 
     begin
       headers.update(:x_stripe_client_user_agent => JSON.generate(user_agent))

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -33,4 +33,19 @@ class StripeTest < Test::Unit::TestCase
       Stripe.max_network_retries = old
     end
   end
+
+  should "makes requests with the Stripe-Account header" do
+    response = make_account(
+      charges_enabled: false,
+      details_submitted: false,
+      email: "test+bindings@stripe.com"
+    )
+    Stripe.stripe_account = 'acct_1234'
+
+    Stripe.expects(:execute_request).with(
+      has_entry(:headers, has_entry(:stripe_account, 'acct_1234')),
+    ).returns(make_response(response))
+
+    Stripe.request(:post, '/v1/account', 'sk_live12334566')
+  end
 end


### PR DESCRIPTION
- When performing requests on the behalf of a managed account, `stripe_account` option must be passed everytime, this can become redundant
- Allowing to set the `stripe_account` globally makes thing easier for wrapping every request in a single method, the same way as it is when defining the `api_key` globally

@matthelm