### PR TITLE
Add order returns

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -53,6 +53,7 @@ require 'stripe/dispute'
 require 'stripe/product'
 require 'stripe/sku'
 require 'stripe/order'
+require 'stripe/order_return'
 require 'stripe/alipay_account'
 
 # Errors

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -9,11 +9,19 @@ module Stripe
       initialize_from(response, opts)
     end
 
+    def return_order(params, opts={})
+      response, opts = request(:post, returns_url, params, opts)
+      initialize_from(response, opts)
+    end
+
     private
 
     def pay_url
-      resource_url + "/pay"
+      resource_url + '/pay'
     end
 
+    def returns_url
+      resource_url + '/returns'
+    end
   end
 end

--- a/lib/stripe/order_return.rb
+++ b/lib/stripe/order_return.rb
@@ -1,0 +1,9 @@
+module Stripe
+  class OrderReturn < APIResource
+    extend Stripe::APIOperations::List
+
+    def self.resource_url
+      "/v1/order_returns"
+    end
+  end
+end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -52,6 +52,7 @@ module Stripe
         'product' => Product,
         'sku' => SKU,
         'order' => Order,
+        'order_return' => OrderReturn,
       }
     end
 

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class OrderReturnTest < Test::Unit::TestCase
-    should "return_order should be listable" do
+    should "returns should be listable" do
       @mock.expects(:get).once.returns(make_response(make_order_return_array))
       returns = Stripe::OrderReturn.list
       assert returns.data.kind_of?(Array)
@@ -11,14 +11,15 @@ module Stripe
       end
     end
 
-    should "returns should not be updateable" do
-      assert_raises NoMethodError do
-        @mock.expects(:get).once.returns(make_response(make_order_return))
-        p = Stripe::OrderReturn.new("test_order")
-        p.refresh
-        p.items = []
-        p.save
-      end
+    should "returns should not be deletable" do
+      p = Stripe::OrderReturn.new("test_order")
+      assert_raises(NoMethodError) { p.delete }
+    end
+
+    should "returns should be immutable" do
+      p = Stripe::OrderReturn.new("test_order")
+      p.items = []
+      assert_raises(NoMethodError) { p.save }
     end
   end
 end

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class OrderReturnTest < Test::Unit::TestCase
+    should "return_order should be listable" do
+      @mock.expects(:get).once.returns(make_response(make_order_return_array))
+      returns = Stripe::OrderReturn.list
+      assert returns.data.kind_of?(Array)
+      returns.each do |ret|
+        assert ret.kind_of?(Stripe::OrderReturn)
+      end
+    end
+
+    should "returns should not be updateable" do
+      assert_raises NoMethodError do
+        @mock.expects(:get).once.returns(make_response(make_order_return))
+        p = Stripe::OrderReturn.new("test_order")
+        p.refresh
+        p.items = []
+        p.save
+      end
+    end
+  end
+end

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -48,5 +48,17 @@ module Stripe
       order.pay(:token => 'test_token')
       assert_equal "paid", order.status
     end
+
+    should "return an order" do
+      @mock.expects(:get).once.
+        returns(make_response(make_order(:id => 'or_test_order')))
+      order = Stripe::Order.retrieve('or_test_order')
+
+      @mock.expects(:post).once.
+        with('https://api.stripe.com/v1/orders/or_test_order/returns', nil, 'items[][parent]=sku_foo').
+        returns(make_response(make_paid_order))
+      order.return_order(:items => [{:parent => 'sku_foo'}])
+      assert_equal "paid", order.status
+    end
   end
 end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -686,6 +686,57 @@ module Stripe
       }).merge(params)
     end
 
+    def make_partially_returned_order(params={})
+      make_paid_order.merge({
+          :returns => make_order_return_array,
+        }).merge(params)
+    end
+
+    def make_order_return
+      {
+        :id => "orret_18CI1jDAu10Yox5R5kGPgbLN",
+        :object => "order_return",
+        :amount => 1220,
+        :created => 1463529303,
+        :currency => "usd",
+        :items => [
+          {
+            :object => "order_item",
+            :amount => 200,
+            :currency => "usd",
+            :description => "Just a SKU",
+            :parent => "sku_80NAUPJ9dpYtck",
+            :quantity => 2,
+            :type => "sku"
+          },
+          {
+            :object => "order_item",
+            :amount => 20,
+            :currency => "usd",
+            :description => "Fair enough",
+            :parent => nil,
+            :quantity => nil,
+            :type => "tax"
+          },
+        ],
+        :livemode => false,
+        :order => "or_189jaGDAu10Yox5R0F6LoH6K",
+        :refund => nil,
+      }
+    end
+
+    def make_order_return_array
+      {
+        :object => "list",
+        :resource_url => "/v1/order_returns",
+        :data => [
+          make_order_return,
+          make_order_return,
+          make_order_return,
+        ]
+      }
+    end
+
     def country_spec_array
       {
         :object => "list",


### PR DESCRIPTION
r? @stripe/api-libraries
cc @jimdanz 

There's a sad naming conflict here around `return` and since `returns` is already a property on the order this seemed like the third best choice. Very happy to rename though if anyone has any suggestions!