### PR TITLE
Convert return_order response to OrderReturn.

### DIFF
--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -11,7 +11,7 @@ module Stripe
 
     def return_order(params, opts={})
       response, opts = request(:post, returns_url, params, opts)
-      initialize_from(response, opts)
+      Util.convert_to_stripe_object(response, opts)
     end
 
     private

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -56,9 +56,9 @@ module Stripe
 
       @mock.expects(:post).once.
         with('https://api.stripe.com/v1/orders/or_test_order/returns', nil, 'items[][parent]=sku_foo').
-        returns(make_response(make_paid_order))
-      order.return_order(:items => [{:parent => 'sku_foo'}])
-      assert_equal "paid", order.status
+        returns(make_response(make_order_return({:order => order.id})))
+      order_return = order.return_order(:items => [{:parent => 'sku_foo'}])
+      assert_equal order.id, order_return.order
     end
   end
 end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -692,7 +692,7 @@ module Stripe
         }).merge(params)
     end
 
-    def make_order_return
+    def make_order_return(params={})
       {
         :id => "orret_18CI1jDAu10Yox5R5kGPgbLN",
         :object => "order_return",
@@ -722,7 +722,7 @@ module Stripe
         :livemode => false,
         :order => "or_189jaGDAu10Yox5R0F6LoH6K",
         :refund => nil,
-      }
+      }.merge(params)
     end
 
     def make_order_return_array


### PR DESCRIPTION
r? @stripe/api-libraries 
cc @jimdanz 

The object we get from `/v1/orders/:id/returns` is an `OrderReturn` and not an `Order`. We want to use `Util.convert_to_stripe_object` to deserialize instead of `initialize_from`. 