### PR TITLE
Go back to not saving subresources, but exclude `Customer#source=`

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -2,6 +2,13 @@ module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request
 
+    # A flag that can be set a behavior that will cause this resource to be
+    # encoded and sent up along with an update of its parent resource. This is
+    # usually not desirable because resources are updated individually on their
+    # own endpoints, but there are certain cases, changing a customer's default
+    # source for example, where this is allowed.
+    attr_accessor :save_with_parent
+
     def self.class_name
       self.name.split('::')[-1]
     end

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -5,8 +5,8 @@ module Stripe
     # A flag that can be set a behavior that will cause this resource to be
     # encoded and sent up along with an update of its parent resource. This is
     # usually not desirable because resources are updated individually on their
-    # own endpoints, but there are certain cases, changing a customer's default
-    # source for example, where this is allowed.
+    # own endpoints, but there are certain cases, replacing a customer's source
+    # for example, where this is allowed.
     attr_accessor :save_with_parent
 
     def self.class_name

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -5,6 +5,20 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
 
+    def source=(value)
+      super
+
+      # The parent setter will perform certain useful operations like
+      # converting to an APIResource if appropriate.
+      value = self.source
+
+      if value.is_a?(APIResource)
+        value.save_with_parent = true
+      end
+
+      value
+    end
+
     def add_invoice_item(params, opts={})
       opts = @opts.merge(Util.normalize_opts(opts))
       InvoiceItem.create(params.merge(:customer => id), opts)

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -5,6 +5,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
 
+    # Set or replace a customer's default source.
     def source=(value)
       super
 
@@ -12,6 +13,8 @@ module Stripe
       # converting to an APIResource if appropriate.
       value = self.source
 
+      # Note that source may be a card, but could also be a tokenized card's ID
+      # (which is a string), and so we check its type here.
       if value.is_a?(APIResource)
         value.save_with_parent = true
       end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -330,6 +330,14 @@ module Stripe
       when nil
         ''
 
+      # The logic here is that essentially any object embedded in another
+      # object that had a `type` is actually an API resource of a different
+      # type that's been included in the response. These other resources must
+      # be updated from their proper endpoints, and therefore they are not
+      # included when serializing even if they've been modified.
+      when APIResource
+        nil
+
       when Array
         update = value.map { |v| serialize_params_value(v, nil, true, force) }
 

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -551,6 +551,21 @@ module Stripe
         acct.save
       end
 
+      should 'not save nested API resources' do
+        ch = Stripe::Charge.construct_from({
+          :id => 'charge_id',
+          :customer => {
+            :object => 'customer',
+            :id => 'customer_id'
+          }
+        })
+
+        @mock.expects(:post).once.with("#{Stripe.api_base}/v1/charges/charge_id", nil, '').returns(make_response({"id" => "charge_id"}))
+
+        ch.customer.description = 'Bob'
+        ch.save
+      end
+
       should 'correctly handle replaced nested objects' do
         acct = Stripe::Account.construct_from({
           :id => 'myid',

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -92,5 +92,20 @@ module Stripe
       c.delete_discount
       assert_equal nil, c.discount
     end
+
+    should "can have a token source set" do
+      c = Stripe::Customer.new("test_customer")
+      c.source = "tok_123"
+      assert_equal "tok_123", c.source
+    end
+
+    should "set a flag if given an object source" do
+      c = Stripe::Customer.new("test_customer")
+      c.source = {
+        :object => 'card'
+      }
+      assert_equal true, c.source.save_with_parent
+    end
   end
 end
+

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -249,6 +249,18 @@ module Stripe
       assert_equal({}, serialized)
     end
 
+    should "#serialize_params and remove embedded APIResources unless flagged with save_with_parent" do
+      c = Customer.construct_from({})
+      c.save_with_parent = true
+
+      obj = Stripe::StripeObject.construct_from({
+        :customer => c,
+      })
+
+      serialized = obj.serialize_params
+      assert_equal({ :customer => {} }, serialized)
+    end
+
     should "#serialize_params takes a force option" do
       obj = Stripe::StripeObject.construct_from({
         :id => 'id',

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -240,6 +240,15 @@ module Stripe
       assert_equal([{ :foo => "bar" }], serialized[:metadata])
     end
 
+    should "#serialize_params and remove embedded APIResources" do
+      obj = Stripe::StripeObject.construct_from({
+        :customer => Customer.construct_from({})
+      })
+
+      serialized = obj.serialize_params
+      assert_equal({}, serialized)
+    end
+
     should "#serialize_params takes a force option" do
       obj = Stripe::StripeObject.construct_from({
         :id => 'id',


### PR DESCRIPTION
This one is a bit of a story, but to put this as succinctly as possible, this patch makes the following changes:

1. Reverts the behavior introduced #407. This means that subresources go back to not being serialized when a parent is saved by default.
2. Introduce a new flag on `APIResource` called `#save_with_parent` that allows this behavior to be overridden.
3. Apply behavior override to `Customer#source=`.

And now for some more detailed history: in #406 it was brought to my attention that a change had broken the ability to replace a source on a customer with a nnew card _object_ (note that this is a slightly unusual thing to do as you would normally want to replace it with a token):

``` ruby
customer = Customer.retrieve(...)
customer.source = {
  object: 'card',
  number: '4012888888881881',
  exp_year: 2018,
  exp_month: 12,
  cvc: 666
}
customer.save
```

This had worked previously to my change mostly out of pure luck -- most of the time a resource being saved never saves any of its subresources, but a quirk in the parameter encoding code had allowed an exception in some cases. This behavior was both untested and unknown.

To fix the problem, I introduced #407, which just removed the check on subresources when saving a parent. So if a "dirty" (i.e. updated) child resource was detected, it would be sent up along with a change every time. However, as explained in #429, this change can also lead to some unusual and unwanted behavior of its own.

In an attempt to find a happy compromise for both problems, this patch essentially special cases setting a new source on a customer, which is so far the only case we know of where sending a child resource would ever be desirable. The mechanism for doing this is the addition of a new `#save_with_parent` attribute on `APIResource` which is respected as any `StripeObject` is being encoded.

Unfortunately, I don't think there's really anybody out there who is fully qualified to review this change (including myself), but I wouldn't mind any feedback/insight that @kyleconroy and @remistr might be able to offer. Thanks guys :$

/cc @stripe/api-libraries

Fixes #429.