### PR TITLE
Fix Gem builds in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   gem 'mocha', '~> 0.13.2'
   gem 'pry'
   gem 'rake'
-  gem 'shoulda', '~> 3.4.0'
+  gem 'shoulda-context'
   gem 'test-unit'
 
   platforms :mri do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require 'stripe'
 require 'test/unit'
 require 'mocha/setup'
 require 'stringio'
-require 'shoulda'
+require 'shoulda/context'
 require File.expand_path('../test_data', __FILE__)
 
 # monkeypatch request methods


### PR DESCRIPTION
CI is failing for a number of Ruby versions because shoulda is pulling
in should-matchers, which then pulls in activesupport. activesupport's
new 5.0.0 version is being picked up, and that requires at least Ruby
2.2.2.

Luckily the solution is easy, we're not using shoulda-matchers, only
shoulda-context, so just tighten up our dependencies a little and the
problem goes away.