### PR TITLE
Retry request on Stripe 409 response

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -205,10 +205,10 @@ module Stripe
         raise
       end
     rescue RestClient::ExceptionWithResponse => e
-      if e.response
-        handle_api_error(e.response)
-      else
+      if e.response.code == 409
         response = handle_restclient_error(e, request_opts, retry_count, api_base_url)
+      else
+        handle_api_error(e.response)
       end
     rescue RestClient::Exception, Errno::ECONNREFUSED, OpenSSL::SSL::SSLError => e
       response = handle_restclient_error(e, request_opts, retry_count, api_base_url)

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -523,6 +523,15 @@ module Stripe
       }
     end
 
+    def make_duplicate_idempotency_key_request_error
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "There is currently another in-progress request using this Idempotent Key (that probably means you submitted twice, and the other request is still going through): `request_id`. Please try again later."
+        }
+      }
+    end
+
     def make_invalid_exp_year_error
       {
         :error => {


### PR DESCRIPTION
**Issue**
The Stripe API returns 409 response when a request is retried with the same `Idempotency-Key` while the initial request is still being processed by Stripe. As of currently the Stripe gem bubbles up the `409` response as an exception on an API operation making outbound calls (ie on `Account.create`).

This is a possible solution to issue https://github.com/stripe/stripe-ruby/issues/431

**Solution**
Include a `409` response within the logic for retrying on a network failure. This means the following scenario will now occur:
- request has a network error, the Stripe gem retries the request
- retry receives a 409 response `There is currently another in-progress request using this Idempotent Key...`
- gem now retries (including further 409 responses) until `Stripe.max_network_retries`

**What could go wrong?**
The `else` case of `if e.response` actually does get called. After spending some time reading into `RestClient` (v1.8.0 used by Stripe v1.43) I couldn't find a situation where a `RestClient::ExceptionWithResponse` returns an exception without an associated `Response` object.

This PR passed the gem's test suite.