### PR TITLE
Rework HTTP retry path + retry 409s

### DIFF
--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -670,14 +670,14 @@ module Stripe
     end
 
     context "with retries" do
-
       setup do
         Stripe.stubs(:max_network_retries).returns(2)
       end
 
       should 'retry failed network requests if specified and raise if error persists' do
         Stripe.expects(:sleep_time).at_least_once.returns(0)
-        @mock.expects(:post).times(3).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').raises(Errno::ECONNREFUSED.new)
+        @mock.expects(:post).times(3).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').
+          raises(Errno::ECONNREFUSED.new)
 
         err = assert_raises Stripe::APIConnectionError do
           Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
@@ -689,32 +689,13 @@ module Stripe
         Stripe.expects(:sleep_time).at_least_once.returns(0)
         response = make_response({"id" => "myid"})
         err = Errno::ECONNREFUSED.new
-        @mock.expects(:post).times(2).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').raises(err).then.returns(response)
+        @mock.expects(:post).times(2).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').
+          raises(Errno::ECONNREFUSED.new).
+          then.
+          returns(response)
 
         result = Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
         assert_equal "myid", result.id
-      end
-
-      # We retry the request if we receive SSL errors, since these can be caused
-      # by transient network issues, in addition to compatibility issues between
-      # the client and server.
-      should 'retry failed network requests if they fail with OpenSSL::SSL::SSLError' do
-        Stripe.expects(:sleep_time).at_least_once.returns(0)
-        @mock.expects(:post).times(3).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').raises(OpenSSL::SSL::SSLError.new('message'))
-
-        err = assert_raises Stripe::APIConnectionError do
-          Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-        end
-        assert_match(/Request was retried 2 times/, err.message)
-      end
-
-      should 'not retry a SSLCertificateNotVerified error' do
-        @mock.expects(:post).times(1).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').raises(RestClient::SSLCertificateNotVerified.new('message'))
-
-        err = assert_raises Stripe::APIConnectionError do
-          Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-        end
-        assert_no_match(/retried/, err.message)
       end
 
       should 'not add an idempotency key to GET requests' do
@@ -755,8 +736,33 @@ module Stripe
 
     end
 
-    context "sleep_time" do
+    context ".should_retry?" do
+      setup do
+        Stripe.stubs(:max_network_retries).returns(2)
+      end
 
+      should 'retry on a low-level network error' do
+        assert Stripe.should_retry?(Errno::ECONNREFUSED.new, 0)
+      end
+
+      should 'retry on timeout' do
+        assert Stripe.should_retry?(RestClient::RequestTimeout.new, 0)
+      end
+
+      should 'retry on a conflict' do
+        assert Stripe.should_retry?(RestClient::Conflict.new, 0)
+      end
+
+      should 'not retry at maximum count' do
+        refute Stripe.should_retry?(RuntimeError.new, Stripe.max_network_retries)
+      end
+
+      should 'not retry on a certificate validation error' do
+        refute Stripe.should_retry?(RestClient::SSLCertificateNotVerified.new('message'), 0)
+      end
+    end
+
+    context ".sleep_time" do
       should "should grow exponentially" do
         Stripe.stubs(:rand).returns(1)
         Stripe.stubs(:max_network_retry_delay).returns(999)
@@ -793,7 +799,6 @@ module Stripe
         assert_equal(base_value * 4, Stripe.sleep_time(3))
         assert_equal(base_value * 8, Stripe.sleep_time(4))
       end
-
     end
   end
 end


### PR DESCRIPTION
Two changes:

1. The HTTP retry path has been refactored to make retries on errors
that are not RestClient exceptions possible by bringing the logic up a
level. This also has the effect of somewhat simplifying the exception
handling logic which can be somewhat difficult to reason about right
now.

2. Retry on `RestClient::Conflict` (a 409 from the API) as discussed in
issue #431.

Note that I also trimmed down the retry test cases a bit so as to replace some of the more verbose ones with simpler tests that are closer to the implementation (i.e. by testing `.should_retry?` instead of performing HTTP requests against a mock for every type of exception that we care about).

Fixes #431.