### PR TITLE
Remove hack to work around rest-client bug

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -226,15 +226,6 @@ module Stripe
       when SocketError
         response = handle_restclient_error(e, request_opts, retry_count, api_base_url)
 
-      when NoMethodError
-        # Work around RestClient bug
-        if e.message =~ /\WRequestFailed\W/
-          e = APIConnectionError.new('Unexpected HTTP response code')
-          response = handle_restclient_error(e, request_opts, retry_count, api_base_url)
-        else
-          raise
-        end
-
       when RestClient::ExceptionWithResponse
         if e.response
           handle_api_error(e.response)


### PR DESCRIPTION
This removes a hack in the code that's designed to work around a
rest-client bug which was added back in 2011. Unfortunately neither
comments nor commit messages bother to tell us what the nature of the
bug actually was, but based on what it's rescuing, it might be
rest-client/rest-client#58, which has been fixed for over five years
now.

Following up on the work done in #436, let's continue to try and simply
the error handling paths by taking this out.