### PR TITLE
Relax rest-client version requirements

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://stripe.com/docs/api/ruby'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '>= 1.4', '< 3.0')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
Hi!

rest-client version 2.0 was released last week: https://github.com/rest-client/rest-client/commit/3a79728b332d316afa281d10022658735a6f72df

Per the [upgrade notes](https://github.com/rest-client/rest-client/commit/3a79728b332d316afa281d10022658735a6f72df) and [history](https://github.com/rest-client/rest-client/blob/master/history.md#200), version 2.x is largely compatible API with version 1.x. I couldn't find this library using any deprecated features, tests passed for me locally (ruby 2.3.1), and I've been using this fork in production for about 24 hours without any problems so far.

Given this is the only dependency of the Stripe library, and the 2.x release of rest-client drops support for Ruby 1.9, I'd be happy to set up something like https://github.com/thoughtbot/appraisal to test against different versions of rest-client. Let me know what you think.