### PR TITLE
Remove JRuby 1.9-compatibility mode from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
-  - jruby-19mode
   - jruby-9.0.5.0
 
 notifications:


### PR DESCRIPTION
Maintenance for all Ruby 1.9 versions ended in February 2015. It's not
the most unresonable thing to support the MRI version a bit longer
because it's not causing any major problems, but supporting 1.9 within
JRuby is legacy niche-within-a-niche.

I'm going to drop support for it for the time being. Let me know if
there any major concerns here. Thanks!