### PR TITLE
Workaround for mime-types related failures on 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,17 @@ group :development do
   gem 'shoulda-context'
   gem 'test-unit'
 
+  # mime-types has become only compatible with Ruby versions > 2 and we're
+  # still supporting 1.9 for the time being. Lock to old versions of
+  # mime-types and rest-client which are known to work in our Gemfile (it's
+  # fine to use newer versions in live environments so we don't have these in
+  # the gemspec).
+  #
+  #     https://github.com/travis-ci/travis-ci/issues/5145
+  #
+  gem 'mime-types', '2.6.2'
+  gem 'rest-client', '1.8.0'
+
   platforms :mri do
     # to avoid problems, bring Byebug in on just versions of Ruby under which
     # it's known to work well


### PR DESCRIPTION
This locks development (which will run in Travis) onto an older version of rest-client and mime-types. mime-types in particular has recently become only compatible with Ruby >= 2, and we're still trying to support 1.9.3. This has caused problems when relaxing the allowed versions of rest-client as seen in #439.

The change won't affect production (a much wider spread of versions is allowed by the gemspec).

Unblocks #439.