### PR TITLE
Whitelist request options (i.e. `opts`)

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -33,8 +33,17 @@ module Stripe
     end
 
     def self.retrieve(id, opts={})
+      # A note here because this is code is subtly complicated: due to some
+      # very bad legacy choices, both `id` and `opts` here can either be a
+      # string _or_ a Hash. To compensate for this, we normalize them as much
+      # as possible by passing them to some specialized utility methods.
+      #
+      # Parameters are always forwarded to the `StripeObject` constructor with
+      # `id` as a string and `opts` as a Hash.
+      id, params = Util.normalize_id(id)
       opts = Util.normalize_opts(opts)
-      instance = self.new(id, opts)
+
+      instance = self.new(id, params.merge(opts))
       instance.refresh
       instance
     end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -10,8 +10,18 @@ module Stripe
     end
 
     def initialize(id=nil, opts={})
-      id, @retrieve_params = Util.normalize_id(id)
-      @opts = Util.normalize_opts(opts)
+      # A note here because this is code is subtly complicated: due to some
+      # very bad legacy choices, both `id` and `opts` here can either be a
+      # string _or_ a Hash. To compensate for this, we normalize them as much
+      # as possible by passing them to some specialized utility methods.
+      #
+      # The result of these operations will leave `id` as a String, `@opts` as
+      # a Hash with only valid request options in it, and `@retrieve_params` as
+      # a Hash will all other miscellaneous keys that were passed in. This
+      # should be keys that are understood by the Stripe API like `expand`.
+      id, params = Util.normalize_id(id)
+      @opts, @retrieve_params = Util.extract_valid_opts(opts.merge(params))
+
       @original_values = {}
       @values = {}
       # This really belongs in APIResource, but not putting it there allows us

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -2,6 +2,24 @@ require "cgi"
 
 module Stripe
   module Util
+    # Request options that can be used between requests. This should also be a
+    # strict subset of VALID_OPTS.
+    PERSIST_OPTS = Set[
+      :api_key,
+      :api_base,
+      :stripe_account,
+      :stripe_version,
+    ].freeze
+
+    VALID_OPTS = Set[
+      :api_key,
+      :api_base,
+      :content_type,
+      :idempotency_key,
+      :stripe_account,
+      :stripe_version,
+    ].freeze
+
     def self.objects_to_ids(h)
       case h
       when APIResource
@@ -161,6 +179,15 @@ module Stripe
         end
       end
       result
+    end
+
+    # Given a Hash, extracts any keys that are known to be valid request
+    # options and returns them as a new Hash. All other keys are returned as a
+    # second Hash as well.
+    def self.extract_valid_opts(hash)
+      hash = Util.normalize_opts(hash)
+      opts, other = hash.partition { |k, _| Util::VALID_OPTS.include?(k) }
+      [Hash[opts], Hash[other]]
     end
 
     def self.normalize_id(id)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -84,6 +84,14 @@ module Stripe
       Stripe::Charge.retrieve({:id => 'ch_test_charge', :expand => [:customer]})
     end
 
+    should "send expand on fetch properly with more modern usage" do
+      @mock.expects(:get).once.
+        with("#{Stripe.api_base}/v1/charges/ch_test_charge?expand[]=customer", nil, nil).
+        returns(make_response(make_charge))
+
+      Stripe::Charge.retrieve('ch_test_charge', :api_key => "sk_test_xxx", :expand => [:customer])
+    end
+
     should "preserve expand across refreshes" do
       @mock.expects(:get).twice.
         with("#{Stripe.api_base}/v1/charges/ch_test_charge?expand[]=customer", nil, nil).

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -105,7 +105,7 @@ module Stripe
     end
 
     should "pass opts down to children when initializing" do
-      opts = { :custom => "opts" }
+      opts = { :api_key => "sk_test_xxx" }
 
       # customer comes with a `sources` list that makes a convenient object to
       # perform tests on

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -84,8 +84,8 @@ module Stripe
     end
 
     should "#normalize_opts should reject nil keys" do
-      assert_raise { Stripe::Util.normalize_opts(nil) }
-      assert_raise { Stripe::Util.normalize_opts(:api_key => nil) }
+      assert_raise(TypeError) { Stripe::Util.normalize_opts(nil) }
+      assert_raise(TypeError) { Stripe::Util.normalize_opts(:api_key => nil) }
     end
 
     should "#convert_to_stripe_object should pass through unknown types" do
@@ -112,6 +112,33 @@ module Stripe
     should "#convert_to_stripe_object should marshal arrays" do
       obj = Util.convert_to_stripe_object([1, 2, 3], {})
       assert_equal [1, 2, 3], obj
+    end
+
+    context ".extract_valid_opts" do
+      should "extract valid opts" do
+        opts, other = Util.extract_valid_opts({
+          :api_key => "sk_test_xxx",
+          :idempotency_key => "uuid",
+          :foo => "bar"
+        })
+        assert_equal({
+          :api_key => "sk_test_xxx",
+          :idempotency_key => "uuid"
+        }, opts)
+        assert_equal({ :foo => "bar" }, other)
+      end
+
+      should "handle no valid opts" do
+        opts, other = Util.extract_valid_opts({ :foo => "bar" })
+        assert_equal({}, opts)
+        assert_equal({ :foo => "bar" }, other)
+      end
+
+      should "handle all valid opts" do
+        opts, other = Util.extract_valid_opts({ :api_key => "sk_test_xxx" })
+        assert_equal({ :api_key => "sk_test_xxx" }, opts)
+        assert_equal({}, other)
+      end
     end
   end
 end


### PR DESCRIPTION
The aim of this patch is to get a start on normalizing and improving the
way that API resource methods are called. For example, it allows us to
change this pretty janky type of invocation:

``` ruby
Stripe::Charge.retrieve({:id => 'ch_test_charge', :expand => [:customer]}, { :api_key => "sk_test_xxx" })
```

To this:

``` ruby
Stripe::Charge.retrieve('ch_test_charge', :api_key => "sk_test_xxx", :expand => [:customer])
```

I'd like to eventually move to a world where all allowed request
parameters and options are prebaked into the bindings, preferrably as
optional keyword arguments where appropriate so that the code becomes
more self-documenting.

The downside is that `opts` must now fall into the whitelist defined by
`Util::VALID_KEYS`. This will prevent custom option keys from being
passed in and being inherited by other API resources. I'm honestly not
sure whether anyone currently needs/uses this functionality right or not
(hopefully _not_ because `@opts` is an internal instance variable).

This is mostly presented as a POC after examining the problem in #443.
I'm not sure whether I'll merge it in as of yet.
