### PR TITLE
Explicitly set TLS 1.2 for OpenSSL versions that support it

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -164,6 +164,18 @@ module Stripe
                         :method => method, :open_timeout => open_timeout,
                         :payload => payload, :url => url, :timeout => read_timeout)
 
+    # Explicitly set a TLS version to use now that we're starting to block 1.0
+    # and 1.1 requests.
+    #
+    # If users are on OpenSSL >= 1.0.1, we know that they support TLS 1.2, so
+    # set that explicitly because on some older Linux distros, clients may
+    # default to TLS 1.0 or 1.1 even when they have TLS 1.2 available.
+    #
+    # Note: The int on the right is pulled from the source of OpenSSL 1.0.1a.
+    if OpenSSL::OPENSSL_VERSION_NUMBER >= 0x1000100f
+      request_opts[:ssl_version] = :TLSv1_2
+    end
+
     response = execute_request_with_rescues(request_opts, api_base_url)
 
     [parse(response), api_key]


### PR DESCRIPTION
This mirrors what we did for stripe/stripe-php#277 in that we explicitly
set TLS 1.2 to use for connections when we know that the Ruby's OpenSSL
supports it (i.e. greater or equal to OpenSSL 1.0.1a).

I'm not going to bring this in quite yet because so far we only have a
single user experiencing a problem, and it doesn't seem like they should
necessarily be seeing it given that they're on quite a recent operating
system.

Fixes #447.