### PR TITLE
Disallow TLS 1.0 using a cipher list

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -219,11 +219,11 @@ module Stripe
   def self.ciphers
     @ciphers ||= begin
       # This code has been duplicated from rest-client, which is the underlying
-      # library we're using to make HTTP requests. Ruby >= 2.0 is considered to
-      # have a pretty good cipher list, but older versions may have had a weak
-      # default cipher list, and we can't guarantee those aren't out of use
-      # yet. For now, look for one of those weak default lists and if found,
-      # replace it with a good one that's bundled within rest-client.
+      # library we're using to make HTTP requests. Ruby >= 2.1.4 is considered
+      # to have a pretty good cipher list, but older versions may have had a
+      # weak default cipher list, and we can't guarantee those aren't out of
+      # use yet. For now, look for one of those weak default lists and if
+      # found, replace it with a good one that's bundled within rest-client.
       #
       # All of this can be removed once this library is no longer compatible
       # with Ruby 1.9.

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -236,11 +236,9 @@ module Stripe
       # of TLS. We (the payments space) is a little ahead of the curve here in
       # that even though TLS 1.0/1.1 haven't been retired yet, we want to make
       # sure we deprecate them by June 2018 for reasons of PCI compliance.
-      ciphers = ciphers.split(":")
-      ciphers = ["!SSLv2", "!SSLv3", "!TLSv1"]
-      ciphers = ciphers.join(":")
-
-      ciphers
+      ciphers_list = ciphers.split(":")
+      ciphers_list += ["!SSLv2", "!SSLv3", "!TLSv1"]
+      ciphers_list.join(":")
     end
   end
 

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -50,7 +50,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   context ".ciphers" do
-    should "produce a cipher list disallowing TLS 1.2" do
+    should "produce a cipher list disallowing TLS 1.0" do
       assert_includes Stripe.ciphers.split(":"), "!TLSv1"
     end
 

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -54,7 +54,7 @@ class StripeTest < Test::Unit::TestCase
       assert_includes Stripe.ciphers.split(":"), "!TLSv1"
     end
 
-    should "produce a cipher list with sane length do" do
+    should "produce a cipher list with sane length" do
       # The list should be longer than the elements that we've added. This is
       # here to protect against a bug that I almost introduced one whereby I
       # set a new array instead of appending to the existing one.

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -48,4 +48,17 @@ class StripeTest < Test::Unit::TestCase
 
     Stripe.request(:post, '/v1/account', 'sk_live12334566')
   end
+
+  context ".ciphers" do
+    should "produce a cipher list disallowing TLS 1.2" do
+      assert_includes Stripe.ciphers.split(":"), "!TLSv1"
+    end
+
+    should "produce a cipher list with sane length do" do
+      # The list should be longer than the elements that we've added. This is
+      # here to protect against a bug that I almost introduced one whereby I
+      # set a new array instead of appending to the existing one.
+      assert(Stripe.ciphers.split(":").count > 3)
+    end
+  end
 end


### PR DESCRIPTION
Disallows TLS 1.0 and some older protocols through the use of an OpenSSL
cipher list. This is an alternative to #448 and I believe it to be
better because it allows for forward compatibility in that we keep our
`ssl_version` flexibile (for TLS 1.3 once we get there).

See the comments in the patch for details, but we re-use whatever cipher
list would have already been in use today, but pack in a few additional
rules that ban old secure protocols.

There's some details on cipher lists here:

https://wiki.openssl.org/index.php/Manual:Ciphers(1)#CIPHER_STRINGS

rest-client has some useful comments on cipher lists here:

https://github.com/rest-client/rest-client/blob/3a79728b332d316afa281d10022658735a6f72df/lib/restclient/request.rb#L55,L114

And Ruby's default cipher list is here (but of course this doesn't apply
to older versions of Ruby):

https://github.com/ruby/ruby/blob/ea31b6c0e47ebb40769abe835a15d5e436f841be/ext/openssl/lib/openssl/ssl.rb#L22,L56

Fixes #447.

r? @dpetrovics This one goes pretty deep, but if you get a chance, can you take a high-level pass on review of this one? Thanks!