### PR TITLE
Produce an error on bad array of maps

### DIFF
--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -138,7 +138,7 @@ module Stripe
         :amount => 100,
         :source => 'btcrcv_test_receiver',
         :currency => "usd",
-        :level3 => [{:red => 'firstred'}, {:one => 'fish', :red => 'another'}]
+        :level3 => [{:red => 'firstred'}, {:red => 'another', :one => 'fish'}]
       })
       assert c.paid
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -33,6 +33,19 @@ module Stripe
       expected = "All maps nested in an array should start with the same key " +
         "(expected starting key 'a', got 'c')"
       assert_equal expected, e.message
+
+      # Make sure the check is recursive by taking our original params and
+      # nesting it into yet another map and array. Should throw exactly the
+      # same error because it's still the in inner array of maps that's wrong.
+      params = {
+        :x => [
+          params
+        ]
+      }
+      e = assert_raises(ArgumentError) do
+        Stripe::Util.encode_parameters(params)
+      end
+      assert_equal expected, e.message
     end
 
     should "#url_encode should prepare strings for HTTP" do

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -20,6 +20,21 @@ module Stripe
       )
     end
 
+    should "#encode_params should throw an error an on array of maps that cannot be encoded" do
+      params = {
+        :a => [
+          { :a => 1, :b => 2 },
+          { :c => 3, :a => 4 },
+        ]
+      }
+      e = assert_raises(ArgumentError) do
+        Stripe::Util.encode_parameters(params)
+      end
+      expected = "All maps nested in an array should start with the same key " +
+        "(expected starting key 'a', got 'c')"
+      assert_equal expected, e.message
+    end
+
     should "#url_encode should prepare strings for HTTP" do
       assert_equal "foo",      Stripe::Util.url_encode("foo")
       assert_equal "foo",      Stripe::Util.url_encode(:foo)

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -20,7 +20,7 @@ module Stripe
       )
     end
 
-    should "#encode_params should throw an error an on array of maps that cannot be encoded" do
+    should "#encode_params should throw an error on an array of maps that cannot be encoded" do
       params = {
         :a => [
           { :a => 1, :b => 2 },


### PR DESCRIPTION
This produces an error when we detect an "array of maps" that cannot be
encoded with `application/x-www-form-urlencoded`; that is to say, one
that does not have each hash starting with a consistent key that will
allow a Rack-compliant server to recognize boundaries.

So for example, this is fine:

```
items: [
    { :type => 'sku', :parent => 'sku_94ZYSC0wppRTbk' },
    { :type => 'discount', :amount => -10000, :currency => 'cad', :description => 'potato' }
],
```

But this is _not_ okay:

```
items: [
    { :type => 'sku', :parent => 'sku_94ZYSC0wppRTbk' },
    { :amount => -10000, :currency => 'cad', :description => 'potato', :type => 'discount' }
],
```

(`type` should be moved to the beginning of the array.)

The purpose of this change is to give users better feedback when they
run into an encoding problem like this one. Currently, they just get
something confusing from the server, and someone on support usually
needs to examine a request log to figure out what happened.

CI will fail until the changes in #453 are brought in.

r? @dpetrovics Mind taking a shot at this one? Thanks!