### PR TITLE
Move away from rest-client's "symbol header names"

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -303,24 +303,24 @@ module Stripe
 
   def self.request_headers(api_key, method)
     headers = {
-      :user_agent => "Stripe/v1 RubyBindings/#{Stripe::VERSION}",
-      :authorization => "Bearer #{api_key}",
-      :content_type => 'application/x-www-form-urlencoded'
+      'User-Agent' => "Stripe/v1 RubyBindings/#{Stripe::VERSION}",
+      'Authorization' => "Bearer #{api_key}",
+      'Content-Type' => 'application/x-www-form-urlencoded'
     }
 
     # It is only safe to retry network failures on post and delete
     # requests if we add an Idempotency-Key header
     if [:post, :delete].include?(method) && self.max_network_retries > 0
-      headers[:idempotency_key] ||= SecureRandom.uuid
+      headers['Idempotency-Key'] ||= SecureRandom.uuid
     end
 
-    headers[:stripe_version] = api_version if api_version
-    headers[:stripe_account] = stripe_account if stripe_account
+    headers['Stripe-Version'] = api_version if api_version
+    headers['Stripe-Account'] = stripe_account if stripe_account
 
     begin
-      headers.update(:x_stripe_client_user_agent => JSON.generate(user_agent))
+      headers.update('X-Stripe-Client-User-Agent' => JSON.generate(user_agent))
     rescue => e
-      headers.update(:x_stripe_client_raw_user_agent => user_agent.inspect,
+      headers.update('X-Stripe-Client-Raw-User-Agent' => user_agent.inspect,
                      :error => "#{e} (#{e.class})")
     end
   end

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -38,7 +38,7 @@ module Stripe
       Stripe.expects(:execute_request).with do |opts|
         opts[:url] == "#{Stripe.api_base}/v1/invoices/in_test_invoice/pay" &&
           opts[:method] == :post &&
-          opts[:headers][:authorization] == 'Bearer foobar'
+          opts[:headers]['Authorization'] == 'Bearer foobar'
       end.returns(make_response(make_paid_invoice))
 
       i.pay

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -43,7 +43,7 @@ class StripeTest < Test::Unit::TestCase
     Stripe.stripe_account = 'acct_1234'
 
     Stripe.expects(:execute_request).with(
-      has_entry(:headers, has_entry(:stripe_account, 'acct_1234')),
+      has_entry(:headers, has_entry('Stripe-Account', 'acct_1234')),
     ).returns(make_response(response))
 
     Stripe.request(:post, '/v1/account', 'sk_live12334566')


### PR DESCRIPTION
This moves away from rest-client's convention of using symbols as header
names so as to present less obfuscation as to how these are actually
named when they go over the wire.

Because headers can be injected via the bindings' API I was initially
worried that this change might break something, but upon inspection of
rest-client source, I can see now that headers take precedence as
assigned by their insertion order into the header hash, and are
"stringified" in that same loop [1]. This means that even if a user
injects a symbolized header name (`:idempotency_key`), it will still
correctly overwrite the one generated by stripe-ruby despite that using
the string format (`"Idempotency-Key"`).

r? @dpetrovics Mind taking a pass on this one too? Thanks!

[1] https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L603,L625