### PR TITLE
Flag Account#external_account into save_with_parent system

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -110,6 +110,22 @@ module Stripe
 
     ARGUMENT_NOT_PROVIDED = Object.new
 
+    # Set or replace an account's bank account.
+    #
+    # This method is deprecated. Please use #external_account instead.
+    def bank_account=(value)
+      super
+      value = self.bank_account
+
+      if value.is_a?(APIResource)
+        value.save_with_parent = true
+      end
+
+      value
+    end
+    extend Gem::Deprecate
+    deprecate :bank_account=, "#external_account=", 2017, 8
+
     private
 
     def serialize_additional_owners(legal_entity, additional_owners)

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -28,6 +28,23 @@ module Stripe
       super(id, opts)
     end
 
+    # Set or replace an account's external account.
+    def external_account=(value)
+      super
+
+      # The parent setter will perform certain useful operations like
+      # converting to an APIResource if appropriate.
+      value = self.external_account
+
+      # Note that external_account may be a card, but could also be a tokenized
+      # card's ID (which is a string), and so we check its type here.
+      if value.is_a?(APIResource)
+        value.save_with_parent = true
+      end
+
+      value
+    end
+
     def reject(params={}, opts={})
       opts = Util.normalize_opts(opts)
       response, opts = request(:post, resource_url + '/reject', params, opts)

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -290,18 +290,62 @@ module Stripe
       assert_equal(expected, obj.serialize_params)
     end
 
-    should "can have a token source set" do
-      a = Stripe::Account.new("test_account")
-      a.external_account = "tok_123"
-      assert_equal "tok_123", a.external_account
+    context "#external_source=" do
+      should "can have a token source set" do
+        a = Stripe::Account.new("test_account")
+        a.external_account = "tok_123"
+        assert_equal "tok_123", a.external_account
+      end
+
+      should "set a flag if given an object source" do
+        a = Stripe::Account.new("test_account")
+        a.external_account = {
+          :object => 'card'
+        }
+        assert_equal true, a.external_account.save_with_parent
+      end
     end
 
-    should "set a flag if given an object source" do
-      a = Stripe::Account.new("test_account")
-      a.external_account = {
-        :object => 'card'
-      }
-      assert_equal true, a.external_account.save_with_parent
+    context "#bank_account=" do
+      should "can have a token source set" do
+        old_stderr = $stderr
+        $stderr = StringIO.new
+        begin
+          a = Stripe::Account.new("test_account")
+          a.bank_account = "tok_123"
+          assert_equal "tok_123", a.bank_account
+        ensure
+          $stderr = old_stderr
+        end
+      end
+
+      should "set a flag if given an object source" do
+        old_stderr = $stderr
+        $stderr = StringIO.new
+        begin
+          a = Stripe::Account.new("test_account")
+          a.bank_account = {
+            :object => 'bank_account'
+          }
+          assert_equal true, a.bank_account.save_with_parent
+        ensure
+          $stderr = old_stderr
+        end
+      end
+
+      should "warn that #bank_account= is deprecated" do
+        old_stderr = $stderr
+        $stderr = StringIO.new
+        begin
+          a = Stripe::Account.new("test_account")
+          a.bank_account = "tok_123"
+          message = "NOTE: Stripe::Account#bank_account= is " +
+            "deprecated; use #external_account= instead"
+          assert_match Regexp.new(message), $stderr.string
+        ensure
+          $stderr = old_stderr
+        end
+      end
     end
   end
 end

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -289,5 +289,19 @@ module Stripe
       }
       assert_equal(expected, obj.serialize_params)
     end
+
+    should "can have a token source set" do
+      a = Stripe::Account.new("test_account")
+      a.external_account = "tok_123"
+      assert_equal "tok_123", a.external_account
+    end
+
+    should "set a flag if given an object source" do
+      a = Stripe::Account.new("test_account")
+      a.external_account = {
+        :object => 'card'
+      }
+      assert_equal true, a.external_account.save_with_parent
+    end
   end
 end

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -290,7 +290,7 @@ module Stripe
       assert_equal(expected, obj.serialize_params)
     end
 
-    context "#external_source=" do
+    context "#external_account=" do
       should "can have a token source set" do
         a = Stripe::Account.new("test_account")
         a.external_account = "tok_123"


### PR DESCRIPTION
In #433, we built a framework under which subresources are usually not
persisted, but in certain cases they can be. At the time,
`Customer#source` was the only field that I knew about that had to be
flagged into it.

Issue #456 has raised that we also be doing `Account#external_account`.
This patch adds support for that.

Fixes #456.

r? @guillaumehenriot Does this look right to you? Thanks!