### PR TITLE
Relax rest-client requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,10 @@ group :development do
   #
   #     https://github.com/travis-ci/travis-ci/issues/5145
   #
-  gem 'mime-types', '2.6.2'
-  gem 'rest-client', '1.8.0'
+  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+    gem 'mime-types', '2.6.2'
+    gem 'rest-client', '1.8.0'
+  end
 
   platforms :mri do
     # to avoid problems, bring Byebug in on just versions of Ruby under which

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://stripe.com/docs/api/ruby'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '>= 1.4', '< 3.0')
+  s.add_dependency('rest-client', '>= 1.4', '< 4.0')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
Our fairly old requirements for rest-client (and therefore mime-types)
are starting to cause some dependency hell problems for some customers.
Try relaxing these constraints and locking 1.9 specifically into
compatible versions.

Fixes #459.