### PR TITLE
Fix interpreter warnings

### DIFF
--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -723,7 +723,6 @@ module Stripe
       should 'retry failed network requests if specified and return successful response' do
         Stripe.expects(:sleep_time).at_least_once.returns(0)
         response = make_response({"id" => "myid"})
-        err = Errno::ECONNREFUSED.new
         @mock.expects(:post).times(2).with('https://api.stripe.com/v1/charges', nil, 'amount=50&currency=usd').
           raises(Errno::ECONNREFUSED.new).
           then.

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -7,7 +7,7 @@ module Stripe
       customer = Stripe::Customer.retrieve('c_test_customer')
 
       @mock.expects(:get).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions/s_test_subscription", nil, nil).returns(make_response(make_subscription(:id => 's_test_subscription')))
-      subscription = customer.subscriptions.retrieve('s_test_subscription')
+      _ = customer.subscriptions.retrieve('s_test_subscription')
     end
 
     should "subscriptions should be listable by customer" do
@@ -17,7 +17,7 @@ module Stripe
       @mock.expects(:get).once.with("#{Stripe.api_base}/v1/customers/c_test_customer/subscriptions", nil, nil).returns(make_response(make_customer_subscription_array('c_test_customer')))
       subs = customer.subscriptions.all()
 
-      assert subs.kind_of? (Stripe::ListObject)
+      assert subs.kind_of?(Stripe::ListObject)
       assert subs.data.kind_of?(Array)
       assert subs.data[0].kind_of? Stripe::Subscription
     end
@@ -51,7 +51,7 @@ module Stripe
       @mock.expects(:get).once.with("#{Stripe.api_base}/v1/subscriptions?customer=c_test_customer&limit=3&plan=gold", nil, nil).returns(make_response(make_subscription_array))
       subs = Stripe::Subscription.all(:customer => 'c_test_customer', :limit => 3, :plan => 'gold')
 
-      assert subs.kind_of? (Stripe::ListObject)
+      assert subs.kind_of?(Stripe::ListObject)
       assert subs.data.kind_of?(Array)
       assert subs.data[0].kind_of? Stripe::Subscription
     end


### PR DESCRIPTION
These aren't causing the build to fail or anything, but they do get
spewed out every time our test suite runs.