### PR TITLE
Ruby bindings for ApplePayDomain

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -57,6 +57,7 @@ require 'stripe/order_return'
 require 'stripe/alipay_account'
 require 'stripe/three_d_secure'
 require 'stripe/source'
+require 'stripe/apple_pay_domain'
 
 # Errors
 require 'stripe/errors/stripe_error'

--- a/lib/stripe/apple_pay_domain.rb
+++ b/lib/stripe/apple_pay_domain.rb
@@ -1,0 +1,14 @@
+module Stripe
+  module ApplePay
+    # Domains registered for Apple Pay on the Web
+    class Domain < APIResource
+      def self.resource_url
+        '/v1/apple_pay/domains'
+      end
+
+      extend Stripe::APIOperations::Create
+      include Stripe::APIOperations::Delete
+      extend Stripe::APIOperations::List
+    end
+  end
+end

--- a/lib/stripe/apple_pay_domain.rb
+++ b/lib/stripe/apple_pay_domain.rb
@@ -1,14 +1,12 @@
 module Stripe
-  module ApplePay
-    # Domains registered for Apple Pay on the Web
-    class Domain < APIResource
-      def self.resource_url
-        '/v1/apple_pay/domains'
-      end
-
-      extend Stripe::APIOperations::Create
-      include Stripe::APIOperations::Delete
-      extend Stripe::APIOperations::List
+  # Domains registered for Apple Pay on the Web
+  class ApplePayDomain < APIResource
+    def self.resource_url
+      '/v1/apple_pay/domains'
     end
+
+    extend Stripe::APIOperations::Create
+    include Stripe::APIOperations::Delete
+    extend Stripe::APIOperations::List
   end
 end

--- a/lib/stripe/apple_pay_domain.rb
+++ b/lib/stripe/apple_pay_domain.rb
@@ -1,12 +1,12 @@
 module Stripe
   # Domains registered for Apple Pay on the Web
   class ApplePayDomain < APIResource
-    def self.resource_url
-      '/v1/apple_pay/domains'
-    end
-
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
+
+    def self.resource_url
+      '/v1/apple_pay/domains'
+    end
   end
 end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -54,6 +54,7 @@ module Stripe
         'order' => Order,
         'order_return' => OrderReturn,
         'three_d_secure' => ThreeDSecure,
+        'apple_pay_domain' => ApplePay::Domain,
       }
     end
 

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -54,7 +54,7 @@ module Stripe
         'order' => Order,
         'order_return' => OrderReturn,
         'three_d_secure' => ThreeDSecure,
-        'apple_pay_domain' => ApplePay::Domain,
+        'apple_pay_domain' => ApplePayDomain,
       }
     end
 

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  module ApplePay
+    class DomainTest < Test::Unit::TestCase
+      should "create should return a new Apple Pay domain" do
+        @mock.expects(:post).once
+             .with('https://api.stripe.com/v1/apple_pay/domains', nil, '')
+             .returns(make_response(make_apple_pay_domain))
+        c = Stripe::ApplePay::Domain.create
+        assert_equal "apwc_test_domain", c.id
+      end
+
+      should "customer cards should be deletable" do
+        @mock.expects(:get).once
+             .with('https://api.stripe.com/v1/apple_pay/domains/apwc_test_domain', nil, nil)
+             .returns(make_response(make_apple_pay_domain))
+        @mock.expects(:delete).once.returns(make_response(make_apple_pay_domain(:deleted => true)))
+        domain = Stripe::ApplePay::Domain.retrieve('apwc_test_domain')
+        domain.delete
+        assert domain.deleted
+      end
+
+      should "domains should be listable" do
+        @mock.expects(:get).once.with('https://api.stripe.com/v1/apple_pay/domains', nil, nil)
+             .returns(make_response(make_apple_pay_domain_array))
+        domains = Stripe::ApplePay::Domain.list
+        assert domains.data.kind_of?(Array)
+        assert_equal 3, domains.data.length
+        domains.each do |domain|
+          assert domain.kind_of?(Stripe::ApplePay::Domain)
+        end
+      end
+    end
+  end
+end

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -1,35 +1,33 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
-  module ApplePay
-    class DomainTest < Test::Unit::TestCase
-      should "create should return a new Apple Pay domain" do
-        @mock.expects(:post).once
-             .with('https://api.stripe.com/v1/apple_pay/domains', nil, '')
-             .returns(make_response(make_apple_pay_domain))
-        d = Stripe::ApplePay::Domain.create
-        assert_equal "apwc_test_domain", d.id
-      end
+  class ApplePayDomainTest < Test::Unit::TestCase
+    should "create should return a new Apple Pay domain" do
+      @mock.expects(:post).once
+           .with('https://api.stripe.com/v1/apple_pay/domains', nil, '')
+           .returns(make_response(make_apple_pay_domain))
+      d = Stripe::ApplePayDomain.create
+      assert_equal "apwc_test_domain", d.id
+    end
 
-      should "domains should be deletable" do
-        @mock.expects(:get).once
-             .with('https://api.stripe.com/v1/apple_pay/domains/apwc_test_domain', nil, nil)
-             .returns(make_response(make_apple_pay_domain))
-        @mock.expects(:delete).once.returns(make_response(make_apple_pay_domain(:deleted => true)))
-        domain = Stripe::ApplePay::Domain.retrieve('apwc_test_domain')
-        domain.delete
-        assert domain.deleted
-      end
+    should "domains should be deletable" do
+      @mock.expects(:get).once
+           .with('https://api.stripe.com/v1/apple_pay/domains/apwc_test_domain', nil, nil)
+           .returns(make_response(make_apple_pay_domain))
+      @mock.expects(:delete).once.returns(make_response(make_apple_pay_domain(:deleted => true)))
+      domain = Stripe::ApplePayDomain.retrieve('apwc_test_domain')
+      domain.delete
+      assert domain.deleted
+    end
 
-      should "domains should be listable" do
-        @mock.expects(:get).once.with('https://api.stripe.com/v1/apple_pay/domains', nil, nil)
-             .returns(make_response(make_apple_pay_domain_array))
-        domains = Stripe::ApplePay::Domain.list
-        assert domains.data.kind_of?(Array)
-        assert_equal 3, domains.data.length
-        domains.each do |domain|
-          assert domain.kind_of?(Stripe::ApplePay::Domain)
-        end
+    should "domains should be listable" do
+      @mock.expects(:get).once.with('https://api.stripe.com/v1/apple_pay/domains', nil, nil)
+           .returns(make_response(make_apple_pay_domain_array))
+      domains = Stripe::ApplePayDomain.list
+      assert domains.data.kind_of?(Array)
+      assert_equal 3, domains.data.length
+      domains.each do |domain|
+        assert domain.kind_of?(Stripe::ApplePayDomain)
       end
     end
   end

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -7,11 +7,11 @@ module Stripe
         @mock.expects(:post).once
              .with('https://api.stripe.com/v1/apple_pay/domains', nil, '')
              .returns(make_response(make_apple_pay_domain))
-        c = Stripe::ApplePay::Domain.create
-        assert_equal "apwc_test_domain", c.id
+        d = Stripe::ApplePay::Domain.create
+        assert_equal "apwc_test_domain", d.id
       end
 
-      should "customer cards should be deletable" do
+      should "domains should be deletable" do
         @mock.expects(:get).once
              .with('https://api.stripe.com/v1/apple_pay/domains/apwc_test_domain', nil, nil)
              .returns(make_response(make_apple_pay_domain))

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -848,5 +848,26 @@ module Stripe
         :status => 'succeeded',
       }.merge(params)
     end
+
+    def make_apple_pay_domain(params={})
+      {
+        :id => "apwc_test_domain",
+        :object => "apple_pay_domain",
+        :domain_name => "test.com",
+        :livemode => false
+      }.merge(params)
+    end
+
+    def make_apple_pay_domain_array
+      {
+        :object => "list",
+        :resource_url => "/v1/apple_pay/domains",
+        :data => [
+          make_apple_pay_domain,
+          make_apple_pay_domain,
+          make_apple_pay_domain
+        ]
+      }
+    end
   end
 end


### PR DESCRIPTION
Allows you to create a `Stripe::ApplePay::Domain` in Ruby