### PR TITLE
Fixed description about DELETE request retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ certificates.
 ### max_network_retries
 
 When `max_network_retries` is set to a positive integer, stripe will retry
-requests that fail on a network error. Idempotency keys will be added to post
-and get requests to ensure the safety of retrying. There will be a short delay
+requests that fail on a network error. Idempotency keys will be added to `POST`
+and `DELETE` requests to ensure the safety of retrying. There will be a short delay
 between each retry, with an exponential backoff algorithm used to determine the
 length of the delay. Default value is 0.
 


### PR DESCRIPTION
Previously it was wrongly saying about `GET` requests.
Vide https://github.com/stripe/stripe-ruby/blob/c131bcbcacc71ea9c8e331421b22f8ef3423e0e1/lib/stripe.rb#L327
[ci skip]