### PR TITLE
Rename error class to be singular "permissions"

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -67,7 +67,7 @@ require 'stripe/errors/api_connection_error'
 require 'stripe/errors/card_error'
 require 'stripe/errors/invalid_request_error'
 require 'stripe/errors/authentication_error'
-require 'stripe/errors/permissions_error'
+require 'stripe/errors/permission_error'
 require 'stripe/errors/rate_limit_error'
 
 module Stripe
@@ -380,7 +380,7 @@ module Stripe
     when 402
       raise card_error(error, resp, error_obj)
     when 403
-      raise permissions_error(error, resp, error_obj)
+      raise permission_error(error, resp, error_obj)
     when 429
       raise rate_limit_error(error, resp, error_obj)
     else
@@ -409,8 +409,8 @@ module Stripe
                   resp.code, resp.body, error_obj, resp.headers)
   end
 
-  def self.permissions_error(error, resp, error_obj)
-    PermissionsError.new(error[:message], resp.code, resp.body, error_obj, resp.headers)
+  def self.permission_error(error, resp, error_obj)
+    PermissionError.new(error[:message], resp.code, resp.body, error_obj, resp.headers)
   end
 
   def self.api_error(error, resp, error_obj)

--- a/lib/stripe/errors/permission_error.rb
+++ b/lib/stripe/errors/permission_error.rb
@@ -1,0 +1,4 @@
+module Stripe
+  class PermissionError < StripeError
+  end
+end

--- a/lib/stripe/errors/permissions_error.rb
+++ b/lib/stripe/errors/permissions_error.rb
@@ -1,4 +1,0 @@
-module Stripe
-  class PermissionsError < StripeError
-  end
-end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -300,12 +300,12 @@ module Stripe
         end
       end
 
-      should "a 403 should give a PermissionsError with http status, body, and JSON body" do
+      should "a 403 should give a PermissionError with http status, body, and JSON body" do
         response = make_response(make_missing_id_error, 403)
         @mock.expects(:get).once.raises(RestClient::ExceptionWithResponse.new(response, 403))
         begin
           Stripe::Customer.retrieve("foo")
-        rescue Stripe::PermissionsError => e
+        rescue Stripe::PermissionError => e
           assert_equal(403, e.http_status)
           assert_equal(true, !!e.http_body)
           assert_equal(true, e.json_body.kind_of?(Hash))


### PR DESCRIPTION
The addition of this class was unreleased so this is not a breaking
change.