### PR TITLE
Create accessor methods in update_attributes

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -84,8 +84,8 @@ module Stripe
       # Default to true. TODO: Convert to optional arguments after we're off
       # 1.9 which will make this quite a bit more clear.
       dirty = method_options.fetch(:dirty, true)
-
       values.each do |k, v|
+        add_accessors([k], values) unless metaclass.method_defined?(k.to_sym)
         @values[k] = Util.convert_to_stripe_object(v, opts)
         dirty_value!(@values[k]) if dirty
         @unsaved_values.add(k)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -90,6 +90,13 @@ module Stripe
       assert_equal Stripe::StripeObject, obj.metadata.class
     end
 
+    should "create accessors when #update_attributes is called" do
+      obj = Stripe::StripeObject.construct_from({})
+      assert_equal false, obj.send(:metaclass).method_defined?(:foo)
+      obj.update_attributes(:foo => 'bar')
+      assert_equal true, obj.send(:metaclass).method_defined?(:foo)
+    end
+    
     should "warn that #refresh_from is deprecated" do
       old_stderr = $stderr
       $stderr = StringIO.new


### PR DESCRIPTION
I tried upgrading the Stripe bindings and ran into an issue. Our code is doing this when it's trying to update the bank account information:
```ruby
response = Stripe::Account.new(account_token).save(request_params)
```
where request_params includes a bank_account: `btok_1234` entry. This is currently in production and works fine, but after we update the Ruby bindings, we get this error:
```ruby
NameError: method `bank_account=' not defined in #<Class:0x007f84d2c6b890>
```
We investigated and tracked it down to the Ruby bindings. It seems like Stripe::StripeObject#update_attributes should look something like this:
```ruby
def update_attributes(values, opts = {}, method_options = {})
  dirty = method_options.fetch(:dirty, true)
  values.each do |k, v|
    add_accessors([k], values) unless metaclass.method_defined?(k.to_sym)     # <---- This line added
    @values[k] = Util.convert_to_stripe_object(v, opts)
    dirty_value!(@values[k]) if dirty
    @unsaved_values.add(k)
  end
end
```
When we add the add_accessors line, it fixes the problem on our side. It doesn't seem like it'll cause any problems otherwise