### PR TITLE
Remove respond_to? method for Ruby 1.9.2 or earlier

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -145,12 +145,6 @@ module Stripe
       construct_from(values, opts)
     end
 
-    if RUBY_VERSION < '1.9.2'
-      def respond_to?(symbol)
-        @values.has_key?(symbol) || super
-      end
-    end
-
     # Sets all keys within the StripeObject as unsaved so that they will be
     # included with an update when #serialize_params is called. This method is
     # also recursive, so any StripeObjects contained as values or which are


### PR DESCRIPTION
I remove `respond_to?` method because stripe-ruby requires Ruby 1.9.3 or above.
Thank you.
