### PR TITLE
Allow to_s to also pretty_generate embedded StripeObjects

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -43,7 +43,7 @@ module Stripe
     end
 
     def to_s(*args)
-      JSON.pretty_generate(@values)
+      JSON.pretty_generate(to_hash)
     end
 
     def inspect


### PR DESCRIPTION
When using the `to_s` method to print out the values it now prints the embedded objects as a string, which makes it look bad.

The solution I'm proposing is to use a copy object that will contain a hash for all values. It will use `to_hash` for any embedded stripe objects.

This should allow us to print all of the StripeObjects within a stripe object.

This may not be exactly right, but the test if nothing else should show the issue.

@brandur 