### PR TITLE
Add basic test for errors

### DIFF
--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class StripeErrorTest < Test::Unit::TestCase
+    context "#to_s" do
+      should "convert to string" do
+        e = StripeError.new("message")
+        assert_equal "message", e.to_s
+
+        e = StripeError.new("message", 200)
+        assert_equal "(Status 200) message", e.to_s
+
+        e = StripeError.new("message", nil, nil, nil, { :request_id => "request-id" })
+        assert_equal "(Request request-id) message", e.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just adds a super simplistic test for the errors module. The win here is
to (hopefully) lower the friction a little bit the next time a feature
is introduced into errors because there's now suite where a new test can
be written.

Follows up #487 through #489 as very minor improvements.