### PR TITLE
Colocate uname helpers + tests

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -218,18 +218,6 @@ module Stripe
 
   private
 
-  def self._uname_uname
-    (`uname -a 2>/dev/null` || '').strip
-  rescue Errno::ENOMEM # couldn't create subprocess
-    "uname lookup failed"
-  end
-
-  def self._uname_ver
-    (`ver` || '').strip
-  rescue Errno::ENOMEM # couldn't create subprocess
-    "uname lookup failed"
-  end
-
   def self.api_error(error, resp, error_obj)
     APIError.new(error[:message], resp.code, resp.body, error_obj, resp.headers)
   end
@@ -297,13 +285,29 @@ module Stripe
     else
       case RbConfig::CONFIG['host_os']
       when /linux|darwin|bsd|sunos|solaris|cygwin/i
-        _uname_uname
+        get_uname_from_system
       when /mswin|mingw/i
-        _uname_ver
+        get_uname_from_system_ver
       else
         "unknown platform"
       end
     end
+  end
+
+  def self.get_uname_from_system
+    (`uname -a 2>/dev/null` || '').strip
+  rescue Errno::ENOENT
+    "uname executable not found"
+  rescue Errno::ENOMEM # couldn't create subprocess
+    "uname lookup failed"
+  end
+
+  def self.get_uname_from_system_ver
+    (`ver` || '').strip
+  rescue Errno::ENOENT
+    "ver executable not found"
+  rescue Errno::ENOMEM # couldn't create subprocess
+    "uname lookup failed"
   end
 
   def self.handle_api_error(resp)

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -48,4 +48,27 @@ class StripeTest < Test::Unit::TestCase
 
     Stripe.request(:post, '/v1/account', 'sk_live12334566')
   end
+
+  context "#get_uname" do
+    should "run without failure" do
+      # Don't actually check the result because we try a variety of different
+      # strategies that will have different results depending on where this
+      # test and running. We're mostly making sure that no exception is thrown.
+      _ = Stripe.get_uname
+    end
+  end
+
+  context "#get_uname_from_system" do
+    should "run without failure" do
+      # as above, just verify that an exception is not thrown
+      _ = Stripe.get_uname_from_system
+    end
+  end
+
+  context "#get_uname_from_system_ver" do
+    should "run without failure" do
+      # as above, just verify that an exception is not thrown
+      _ = Stripe.get_uname_from_system_ver
+    end
+  end
 end


### PR DESCRIPTION
Colocates the helper methods for looking up a uname by renaming them to
have the same prefix as the base method (i.e. `get_uname`).

Also adds an additional rescue in case we try to run an executable on a
system but it wasn't founded (this should never happen).

Also adds some tests to make sure that each method gets at least a very
basic amount of exercise in the test suite.

Follows up minor improvements in #487 through #490.