### PR TITLE
Make request ID and response information available on all API calls

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -37,8 +37,8 @@ module Stripe
 
     def reject(params={}, opts={})
       opts = Util.normalize_opts(opts)
-      response, opts = request(:post, resource_url + '/reject', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/reject', params, opts)
+      initialize_from(response.data, opts)
     end
 
     # Somewhat unfortunately, we attempt to do a special encoding trick when
@@ -93,9 +93,9 @@ module Stripe
 
     def deauthorize(client_id, opts={})
       opts = {:api_base => Stripe.connect_base}.merge(Util.normalize_opts(opts))
-      response, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
+      resp, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
       opts.delete(:api_base) # the api_base here is a one-off, don't persist it
-      Util.convert_to_stripe_object(response, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     ARGUMENT_NOT_PROVIDED = Object.new

--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -2,8 +2,8 @@ module Stripe
   module APIOperations
     module Create
       def create(params={}, opts={})
-        response, opts = request(:post, resource_url, params, opts)
-        Util.convert_to_stripe_object(response, opts)
+        resp, opts = request(:post, resource_url, params, opts)
+        Util.convert_to_stripe_object(resp.data, opts, response: resp)
       end
     end
   end

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -3,8 +3,8 @@ module Stripe
     module Delete
       def delete(params={}, opts={})
         opts = Util.normalize_opts(opts)
-        response, opts = request(:delete, resource_url, params, opts)
-        initialize_from(response, opts)
+        self.response, opts = request(:delete, resource_url, params, opts)
+        initialize_from(response.data, opts)
       end
     end
   end

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -4,8 +4,9 @@ module Stripe
       def list(filters={}, opts={})
         opts = Util.normalize_opts(opts)
 
-        response, opts = request(:get, resource_url, filters, opts)
-        obj = ListObject.construct_from(response, opts)
+        resp, opts = request(:get, resource_url, filters, opts)
+        obj = ListObject.construct_from(resp.data, opts)
+        obj.response = resp
 
         # set filters so that we can fetch the same limit, expansions, and
         # predicates when accessing the next and previous pages

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -12,7 +12,7 @@ module Stripe
           api_base = headers.delete(:api_base)
           # Assume all remaining opts must be headers
 
-          response, opts[:api_key] = Stripe.request(method, url, api_key, params, headers, api_base)
+          resp, opts[:api_key] = Stripe.request(method, url, api_key, params, headers, api_base)
 
           # Hash#select returns an array before 1.9
           opts_to_persist = {}
@@ -22,7 +22,7 @@ module Stripe
             end
           end
 
-          [response, opts_to_persist]
+          [resp, opts_to_persist]
         end
       end
 

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -21,8 +21,8 @@ module Stripe
             end
           end
 
-          response, opts = request(:post, "#{resource_url}/#{id}", params, opts)
-          Util.convert_to_stripe_object(response, opts)
+          resp, opts = request(:post, "#{resource_url}/#{id}", params, opts)
+          Util.convert_to_stripe_object(resp.data, opts, response: resp)
         end
       end
 
@@ -57,10 +57,8 @@ module Stripe
         # generated a uri for this object with an identifier baked in
         values.delete(:id)
 
-        response, opts = request(:post, save_url, values, opts)
-        initialize_from(response, opts)
-
-        self
+        self.response, opts = request(:post, save_url, values, opts)
+        initialize_from(response.data, opts)
       end
 
       def self.included(base)

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -2,6 +2,13 @@ module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request
 
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the API resource.
+    #
+    # Note that this is only set on the top-level API resource returned by an
+    # API operation. It will hold a nil value on all others.
+    attr_accessor :response
+
     # A flag that can be set a behavior that will cause this resource to be
     # encoded and sent up along with an update of its parent resource. This is
     # usually not desirable because resources are updated individually on their
@@ -54,8 +61,8 @@ module Stripe
     end
 
     def refresh
-      response, opts = request(:get, resource_url, @retrieve_params)
-      initialize_from(response, opts)
+      self.response, opts = request(:get, resource_url, @retrieve_params)
+      initialize_from(response.data, opts)
     end
 
     def self.retrieve(id, opts={})

--- a/lib/stripe/bank_account.rb
+++ b/lib/stripe/bank_account.rb
@@ -5,8 +5,8 @@ module Stripe
     extend Stripe::APIOperations::List
 
     def verify(params={}, opts={})
-      response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(response.data, opts)
     end
 
     def resource_url

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -20,41 +20,41 @@ module Stripe
         # from the server
         self.refresh
       else
-        response, opts = request(:post, refund_url, params, opts)
-        initialize_from(response, opts)
+        self.response, opts = request(:post, refund_url, params, opts)
+        initialize_from(response.data, opts)
       end
     end
 
     def capture(params={}, opts={})
-      response, opts = request(:post, capture_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, capture_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def update_dispute(params={}, opts={})
-      response, opts = request(:post, dispute_url, params, opts)
-      initialize_from({ :dispute => response }, opts, true)
+      self.response, opts = request(:post, dispute_url, params, opts)
+      initialize_from({ :dispute => response.data }, opts, true)
       dispute
     end
 
     def close_dispute(params={}, opts={})
-      response, opts = request(:post, close_dispute_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, close_dispute_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def mark_as_fraudulent
       params = {
         :fraud_details => { :user_report => 'fraudulent' }
       }
-      response, opts = request(:post, resource_url, params)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url, params)
+      initialize_from(response.data, opts)
     end
 
     def mark_as_safe
       params = {
         :fraud_details => { :user_report => 'safe' }
       }
-      response, opts = request(:post, resource_url, params)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url, params)
+      initialize_from(response.data, opts)
     end
 
     private

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -38,25 +38,25 @@ module Stripe
     end
 
     def cancel_subscription(params={}, opts={})
-      response, opts = request(:delete, subscription_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:delete, subscription_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def update_subscription(params={}, opts={})
-      response, opts = request(:post, subscription_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:post, subscription_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def create_subscription(params={}, opts={})
-      response, opts = request(:post, subscriptions_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:post, subscriptions_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def delete_discount
-      _, opts = request(:delete, discount_url)
+      self.response, opts = request(:delete, discount_url)
       initialize_from({ :discount => nil }, opts, true)
     end
 

--- a/lib/stripe/dispute.rb
+++ b/lib/stripe/dispute.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def close(params={}, opts={})
-      response, opts = request(:post, close_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, close_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def close_url

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -3,12 +3,24 @@ module Stripe
   # errors derive.
   class StripeError < StandardError
     attr_reader :message
-    attr_reader :http_status
+
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the error.
+    attr_accessor :response
+
+    # These fields are now available as part of #response and that usage should
+    # be preferred.
     attr_reader :http_body
     attr_reader :http_headers
+    attr_reader :http_status
+    attr_reader :json_body # equivalent to #data
     attr_reader :request_id
-    attr_reader :json_body
 
+    # Initializes a StripeError.
+    #
+    # Note: We should try to move away from the very heavy constructors ordered
+    # parameters to each just setting accessor values directly or optional
+    # arguments.
     def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil,
                    http_headers=nil)
       @message = message

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -5,13 +5,13 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     def self.upcoming(params, opts={})
-      response, opts = request(:get, upcoming_url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:get, upcoming_url, params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     def pay(opts={})
-      response, opts = request(:post, pay_url, {}, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, pay_url, {}, opts)
+      initialize_from(response.data, opts)
     end
 
     private

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -10,6 +10,10 @@ module Stripe
     # expansions, and predicates as a user pages through resources.
     attr_accessor :filters
 
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the list resource.
+    attr_accessor :response
+
     # An empty list object. This is returned from +next+ when we know that
     # there isn't a next page in order to replicate the behavior of the API
     # when it attempts to return a page beyond the last.
@@ -64,8 +68,8 @@ module Stripe
 
     def retrieve(id, opts={})
       id, retrieve_params = Util.normalize_id(id)
-      response, opts = request(:get,"#{resource_url}/#{CGI.escape(id)}", retrieve_params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:get,"#{resource_url}/#{CGI.escape(id)}", retrieve_params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     # Fetches the next page in the resource list (if there is one).

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -5,13 +5,13 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def pay(params, opts={})
-      response, opts = request(:post, pay_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, pay_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def return_order(params, opts={})
-      response, opts = request(:post, returns_url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:post, returns_url, params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     private

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -5,8 +5,8 @@ module Stripe
     extend Stripe::APIOperations::List
 
     def verify(params={}, opts={})
-      response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(response.data, opts)
     end
   end
 end

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -1,0 +1,34 @@
+module Stripe
+  # StripeResponse encapsulates some vitals of a response that came back from
+  # the Stripe API.
+  class StripeResponse
+    # The data contained by the HTTP body of the response deserialized from
+    # JSON.
+    attr_accessor :data
+
+    # The raw HTTP body of the response.
+    attr_accessor :http_body
+
+    # A Hash of the HTTP headers of the response.
+    attr_accessor :http_headers
+
+    # The integer HTTP status code of the response.
+    attr_accessor :http_status
+
+    # The Stripe request ID of the response.
+    attr_accessor :request_id
+
+    # Initializes a StripeResponse object from a RestClient HTTP response
+    # object.
+    #
+    # This may throw JSON::ParserError if the response body is not valid JSON.
+    def self.from_rest_client_response(http_resp)
+      resp = StripeResponse.new
+      resp.data = JSON.parse(http_resp.body, symbolize_names: true)
+      resp.http_body = http_resp.body
+      resp.http_headers = http_resp.headers
+      resp.http_status = http_resp.code
+      resp
+    end
+  end
+end

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -28,6 +28,7 @@ module Stripe
       resp.http_body = http_resp.body
       resp.http_headers = http_resp.headers
       resp.http_status = http_resp.code
+      resp.request_id = http_resp.headers[:request_id]
       resp
     end
   end

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def cancel
-      response, api_key = self.request(:post, cancel_url)
-      initialize_from(response, api_key)
+      self.response, api_key = self.request(:post, cancel_url)
+      initialize_from(response.data, api_key)
     end
 
     def cancel_url

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -68,19 +68,28 @@ module Stripe
     #
     # ==== Attributes
     #
-    # * +resp+ - Hash of fields and values to be converted into a StripeObject.
+    # * +data+ - Hash of fields and values to be converted into a StripeObject.
     # * +opts+ - Options for +StripeObject+ like an API key that will be reused
     #   on subsequent API calls.
-    def self.convert_to_stripe_object(resp, opts)
-      case resp
+    # * +response+ - An object containing information about the API response
+    #   that produced the data which is hydrating the StripeObject.
+    def self.convert_to_stripe_object(data, opts, response: nil)
+      obj = case data
       when Array
-        resp.map { |i| convert_to_stripe_object(i, opts) }
+        data.map { |i| convert_to_stripe_object(i, opts) }
       when Hash
         # Try converting to a known object class.  If none available, fall back to generic StripeObject
-        object_classes.fetch(resp[:object], StripeObject).construct_from(resp, opts)
+        object_classes.fetch(data[:object], StripeObject).construct_from(data, opts)
       else
-        resp
+        data
       end
+
+      case obj
+      when APIResource, ListObject
+        obj.response = response
+      end
+
+      obj
     end
 
     def self.file_readable(file)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -73,7 +73,7 @@ module Stripe
     #   on subsequent API calls.
     # * +response+ - An object containing information about the API response
     #   that produced the data which is hydrating the StripeObject.
-    def self.convert_to_stripe_object(data, opts, response: nil)
+    def self.convert_to_stripe_object(data, opts, other_opts = {})
       obj = case data
       when Array
         data.map { |i| convert_to_stripe_object(i, opts) }
@@ -86,7 +86,8 @@ module Stripe
 
       case obj
       when APIResource, ListObject
-        obj.response = response
+        # Change this to an optional parameter when we drop 1.9 support.
+        obj.response = other_opts[:response]
       end
 
       obj

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -167,6 +167,17 @@ module Stripe
       assert_equal 'Invalid response object from API: "{\"error\": \"foo\"}" (HTTP response code was 500)', e.message
     end
 
+    should "set response on error" do
+      response = make_response('{"error": { "message": "foo"}}', 500)
+      @mock.expects(:post).once.raises(RestClient::ExceptionWithResponse.new(response, 500))
+
+      e = assert_raises Stripe::APIError do
+        Stripe::Charge.create
+      end
+
+      assert_equal 500, e.response.http_status
+    end
+
     should "have default open and read timeouts" do
       assert_equal Stripe.open_timeout, 30
       assert_equal Stripe.read_timeout, 80
@@ -384,6 +395,12 @@ module Stripe
         @mock.expects(:get).once.returns(make_response(make_customer))
         c = Stripe::Customer.new("test_customer")
         c.refresh
+      end
+
+      should "set response on success" do
+        @mock.expects(:post).once.returns(make_response(make_charge, 200))
+        charge = Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
+        assert_equal 200, charge.response.http_status
       end
 
       should "using array accessors should be the same as the method interface" do

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class StripeResponseTest < Test::Unit::TestCase
+    context ".from_rest_client_response" do
+      should "converts to StripeResponse" do
+        body = '{"foo": "bar"}'
+        headers = { :request_id => "request-id" }
+
+        http_resp = make_response(body, 200, headers: headers)
+        resp = StripeResponse.from_rest_client_response(http_resp)
+
+        assert_equal JSON.parse(body, symbolize_names: true), resp.data
+        assert_equal body, resp.http_body
+        assert_equal headers, resp.http_headers
+        assert_equal 200, resp.http_status
+        assert_equal "request-id", resp.request_id
+      end
+    end
+  end
+end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -142,6 +142,24 @@ module Stripe
       assert_equal [1, 2, 3], obj
     end
 
+    should "#convert_to_stripe_object should add a response to APIResource" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :object => "account" }, {}, response: resp)
+      assert_equal resp, obj.response
+    end
+
+    should "#convert_to_stripe_object should add a response to ListObject" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :object => "list" }, {}, response: resp)
+      assert_equal resp, obj.response
+    end
+
+    should "#convert_to_stripe_object should not add a response to other types" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {}, response: resp)
+      refute obj.respond_to?(:response)
+    end
+
     should "#array_to_hash should convert an array into a hash with integer keys" do
       assert_equal({"0" => 1, "1" => 2, "2" => 3}, Util.array_to_hash([1, 2, 3]))
     end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,6 +1,8 @@
 module Stripe
   module TestData
-    def make_response(body, code=200)
+    def make_response(body, code=200, headers: nil)
+      headers = {} if headers.nil?
+
       # When an exception is raised, restclient clobbers method_missing.  Hence we
       # can't just use the stubs interface.
       body = JSON.generate(body) if !(body.kind_of? String)
@@ -8,7 +10,7 @@ module Stripe
       m.instance_variable_set('@stripe_values', {
         :body => body,
         :code => code,
-        :headers => {},
+        :headers => headers,
       })
       def m.body; @stripe_values[:body]; end
       def m.code; @stripe_values[:code]; end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,7 +1,8 @@
 module Stripe
   module TestData
-    def make_response(body, code=200, headers: nil)
-      headers = {} if headers.nil?
+    def make_response(body, code = 200, opts = {})
+      # Change this to an optional parameter when we drop 1.9 support.
+      headers = opts[:headers] || {}
 
       # When an exception is raised, restclient clobbers method_missing.  Hence we
       # can't just use the stubs interface.


### PR DESCRIPTION
It's currently possible to access a Stripe request ID value from a `StripeError` object, but it's also quite useful to be able to access one from any API call for logging and other purposes. This patch adds a `response` access to `APIResource`, `ListObject`, and `StripeError` which includes response information including the request ID.

So for any API call it's now possible to do this:

``` ruby
charge = Charge.create(...)
puts "request ID = #{charge.response.request_id}"

charges = Charge.list
puts "request ID = #{charges.response.request_id}"
```

Or on error, the recommended approach is to now access `#request_id` in the same way:

``` ruby
begin
  charge = Charge.create(...)
rescue Stripe::StripeError => e
  puts "request ID = #{e.response.request_id}"
end
```

Only top level resources are given a `response` value, so we get a `nil` back for this operation:

``` ruby
charge = Charge.create(...)
charge.customer.response.request_id # nil
```

Fixes #484.

r? @dpetrovics-stripe This one is pretty big, but would you mind reviewing? We could also kick it to someone else on the team if you're pretty swamped right now. Thanks!