### PR TITLE
Better tests for sources

### DIFF
--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -1,8 +1,7 @@
 module Stripe
   class Source < APIResource
-    include Stripe::APIOperations::Save
     extend Stripe::APIOperations::Create
-    extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     def verify(params={}, opts={})
       response, opts = request(:post, resource_url + '/verify', params, opts)

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -2,17 +2,82 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class SourceTest < Test::Unit::TestCase
+    should 'be creatable' do
+      @mock.expects(:post).once.returns(make_response(make_source_card))
+      src = Stripe::Source.create(
+        type: 'card',
+        token: 'tok_test',
+      )
+      assert_equal 'src_test_card', src.id
+    end
+
+    should 'be retrievable' do
+      @mock.expects(:get).once.returns(make_response(make_source_card))
+      src = Stripe::Source.retrieve('src_test_card')
+      assert_equal 'src_test_card', src.id
+    end
+
+    should 'be updatable' do
+      @mock.expects(:post).once
+        .with(
+          "#{Stripe.api_base}/v1/sources/src_test_card",
+          nil,
+          'metadata[foo]=bar'
+        )
+        .returns(make_response(make_source_card(metadata: {foo: 'bar'})))
+      src = Stripe::Source.update('src_test_card', metadata: {foo: 'bar'})
+      assert_equal 'bar', src.metadata['foo']
+    end
+
+    should 'be saveable' do
+      @mock.expects(:get).once.returns(make_response(make_source_card))
+      src = Stripe::Source.retrieve('src_test_card')
+
+      @mock.expects(:post).once
+        .with(
+          "#{Stripe.api_base}/v1/sources/src_test_card",
+          nil,
+          'metadata[foo]=bar'
+        )
+        .returns(make_response(make_source_card(metadata: {foo: 'bar'})))
+      src.metadata['foo'] = 'bar'
+      src.save
+      assert_equal 'bar', src.metadata['foo']
+    end
+
+    should 'not be deletable' do
+      @mock.expects(:get).once.returns(make_response(make_source_card))
+      src = Stripe::Source.retrieve('src_test_card')
+
+      assert_raises NoMethodError do
+        src.delete
+      end
+    end
+
+    should 'not be listable' do
+      assert_raises NoMethodError do
+        Stripe::Source.list
+      end
+    end
+
     should 'be verifiable' do
-      source = Stripe::Source.construct_from({
-        :id => 'ba_foo',
-      })
+      @mock.expects(:get).once.returns(make_response(make_source_ach_debit))
+      src = Stripe::Source.retrieve('src_test_ach_debit')
 
-      @mock.expects(:post).
-        once.
-        with('https://api.stripe.com/v1/sources/ba_foo/verify', nil, 'amounts[]=1&amounts[]=2').
-        returns(make_response(:status => 'verified'))
-
-      source.verify(:amounts => [1,2])
+      @mock.expects(:post).once
+        .with(
+          'https://api.stripe.com/v1/sources/src_test_ach_debit/verify',
+          nil,
+          'values[]=32&values[]=45'
+        )
+        .returns(make_response(make_source_ach_debit(
+          verification: {
+            attempts_remaining: 0,
+            status: 'succeeded',
+          }
+        )))
+      src.verify(values: [32, 45])
+      assert_equal 'succeeded', src.verification.status
     end
   end
 end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -895,5 +895,91 @@ module Stripe
         ]
       }
     end
+
+    def make_source_card(params={})
+      id = params[:id] || 'src_test_card'
+      {
+        :id => id,
+        :object => 'source',
+        :type => 'card',
+        :amount => nil,
+        :card => {
+          :address_line1_check => nil,
+          :address_zip_check => nil,
+          :brand => 'Visa',
+          :country => 'US',
+          :cvc_check => 'unchecked',
+          :description => nil,
+          :dynamic_last4 => nil,
+          :exp_month => 1,
+          :exp_year => 2020,
+          :fingerprint => 'NrVafqTONZfbLkQK',
+          :funding => 'credit',
+          :google_reference => nil,
+          :iin => nil,
+          :issuer => nil,
+          :last4 => '4242',
+          :three_d_secure => 'optional',
+          :tokenization_method => 'nil',
+        },
+        :client_secret => 'src_client_secret_test',
+        :created => 1484841032,
+        :currency => nil,
+        :flow => 'none',
+        :livemode => false,
+        :metadata => {},
+        :owner => {
+          :address => nil,
+          :email => nil,
+          :name => nil,
+          :phone => nil,
+          :verified_address => nil,
+          :verified_email => nil,
+          :verified_name => nil,
+          :verified_phone => nil,
+        },
+        :status => 'chargeable',
+        :usage => 'reusable',
+      }.merge(params)
+    end
+
+    def make_source_ach_debit(params={})
+      id = params[:id] || 'src_test_ach_debit'
+      {
+        :id => id,
+        :object => 'source',
+        :type => 'ach_debit',
+        :ach_debit => {
+          :country => 'US',
+          :fingerprint => 'yY5BWKwnW98uydOa',
+          :last4 => '6789',
+          :routing_number => '110000000',
+          :type => 'individual',
+        },
+        :amount => nil,
+        :client_secret => 'src_client_secret_test',
+        :created => 1484842122,
+        :currency => 'usd',
+        :flow => 'verification',
+        :livemode => false,
+        :metadata => {},
+        :owner => {
+          :address => nil,
+          :email => nil,
+          :name => 'Jenny Rosen',
+          :phone => nil,
+          :verified_address => nil,
+          :verified_email => nil,
+          :verified_name => nil,
+          :verified_phone => nil,
+        },
+        :status => 'pending',
+        :usage => 'reusable',
+        :verification => {
+          :attempts_remaining => 10,
+          :status => 'pending',
+        },
+      }.merge(params)
+    end
   end
 end


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @will-stripe

This PR:
- disables the "list" method for sources (the API does not support it)
- adds a bunch of tests for sources
