### PR TITLE
Remove support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
   - 2.4.0
-  - jruby-19mode
   - jruby-9.0.5.0
 
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -8,19 +8,7 @@ group :development do
   gem 'rake'
   gem 'shoulda-context'
   gem 'test-unit'
-
-  # mime-types has become only compatible with Ruby versions > 2 and we're
-  # still supporting 1.9 for the time being. Lock to old versions of
-  # mime-types and rest-client which are known to work in our Gemfile (it's
-  # fine to use newer versions in live environments so we don't have these in
-  # the gemspec).
-  #
-  #     https://github.com/travis-ci/travis-ci/issues/5145
-  #
-  if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-    gem 'mime-types', '2.6.2'
-    gem 'rest-client', '1.8.0'
-  end
+  gem 'webmock'
 
   platforms :mri do
     # to avoid problems, bring Byebug in on just versions of Ruby under which

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ If you want to build the gem from source:
 
 ### Requirements
 
-* Ruby 1.9.3 or above.
-* rest-client
+* Ruby 2.0+.
 
 ### Bundler
 


### PR DESCRIPTION
This has been discussed, but we'll finally be doing it for the next
major version so that we can introduce a few features that depend on
gems that don't support 1.9.