### PR TITLE
Add configurable HTTP client and make response objects available on API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gemspec
 
 group :development do
   gem 'mocha', '~> 0.13.2'
-  gem 'pry'
   gem 'rake'
   gem 'shoulda-context'
   gem 'test-unit'
@@ -15,6 +14,7 @@ group :development do
     # it's known to work well
     if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
       gem 'byebug'
+      gem 'pry'
       gem 'pry-byebug'
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ desc "update bundled certs"
 task :update_certs do
   require "restclient"
   File.open(File.join(File.dirname(__FILE__), 'lib', 'data', 'ca-certificates.crt'), 'w') do |file|
-    resp = RestClient.get "https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt"
+    resp = Faraday.get "https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt"
     abort("bad response when fetching bundle") unless resp.code == 200
     file.write(resp.to_str)
   end

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -76,7 +76,7 @@ module Stripe
   @max_network_retry_delay = 2
   @initial_network_retry_delay = 0.5
 
-  @ca_bundle_path  = DEFAULT_CA_BUNDLE_PATH
+  @ca_bundle_path = DEFAULT_CA_BUNDLE_PATH
   @ca_store = nil
   @verify_ssl_certs = true
 
@@ -88,10 +88,6 @@ module Stripe
                   :open_timeout, :read_timeout
 
     attr_reader :max_network_retry_delay, :initial_network_retry_delay
-  end
-
-  def self.api_url(url='', api_base_url=nil)
-    (api_base_url || @api_base) + url
   end
 
   # The location of a file containing a bundle of CA certificates. By default
@@ -125,91 +121,6 @@ module Stripe
     end
   end
 
-  # A default Faraday connection to be used when one isn't configured. This
-  # object should never be mutated, and instead instantiating your own
-  # connection and wrapping it in a StripeClient object should be preferred.
-  def self.default_conn
-    @default_conn ||= Faraday.new do |conn|
-      conn.use Faraday::Request::UrlEncoded
-      conn.use Faraday::Response::RaiseError
-      conn.adapter Faraday.default_adapter
-    end
-  end
-
-  # TODO: Fix parameters.
-  def self.request(conn, method, url, api_key, params, headers, api_base_url)
-    api_base_url = api_base_url || @api_base
-
-    unless api_key ||= @api_key
-      raise AuthenticationError.new('No API key provided. ' \
-        'Set your API key using "Stripe.api_key = <API-KEY>". ' \
-        'You can generate API keys from the Stripe web interface. ' \
-        'See https://stripe.com/api for details, or email support@stripe.com ' \
-        'if you have any questions.')
-    end
-
-    if api_key =~ /\s/
-      raise AuthenticationError.new('Your API key is invalid, as it contains ' \
-        'whitespace. (HINT: You can double-check your API key from the ' \
-        'Stripe web interface. See https://stripe.com/api for details, or ' \
-        'email support@stripe.com if you have any questions.)')
-    end
-
-    params = Util.objects_to_ids(params)
-    url = api_url(url, api_base_url)
-
-    case method.to_s.downcase.to_sym
-    when :get, :head, :delete
-      # Make params into GET parameters
-      url += "#{URI.parse(url).query ? '&' : '?'}#{Util.encode_parameters(params)}" if params && params.any?
-      payload = nil
-    else
-      if headers[:content_type] && headers[:content_type] == "multipart/form-data"
-        payload = params
-      else
-        payload = Util.encode_parameters(params)
-      end
-    end
-
-    if verify_ssl_certs
-      conn.ssl.verify = true
-      conn.ssl.cert_store = ca_store
-    else
-      conn.ssl.verify = false
-
-      unless @verify_ssl_warned
-        @verify_ssl_warned = true
-        $stderr.puts("WARNING: Running without SSL cert verification. " \
-          "You should never do this in production. " \
-          "Execute 'Stripe.verify_ssl_certs = true' to enable verification.")
-      end
-    end
-
-    http_resp = execute_request_with_rescues(api_base_url, 0) do
-      conn.run_request(
-        method,
-        url,
-        payload,
-        # TODO: Convert RestClient-style parameters.
-        request_headers(api_key, method).update(headers)
-      ) do |req|
-        req.options.open_timeout = open_timeout
-        req.options.timeout = read_timeout
-      end
-    end
-
-    begin
-      resp = StripeResponse.from_faraday_response(http_resp)
-    rescue JSON::ParserError
-      raise general_api_error(http_resp.code, http_resp.body)
-    end
-
-    # Allows StripeClient#request to return a response object to a caller.
-    StripeClient.set_last_response(resp)
-
-    [resp, api_key]
-  end
-
   def self.max_network_retries
     @max_network_retries
   end
@@ -220,210 +131,6 @@ module Stripe
 
   private
 
-  def self.execute_request_with_rescues(api_base_url, retry_count, &block)
-    begin
-      resp = block.call
-
-    # We rescue all exceptions from a request so that we have an easy spot to
-    # implement our retry logic across the board. We'll re-raise if it's a type
-    # of exception that we didn't expect to handle.
-    rescue => e
-      if should_retry?(e, retry_count)
-        retry_count = retry_count + 1
-        sleep sleep_time(retry_count)
-        retry
-      end
-
-      case e
-      when Faraday::ClientError
-        if e.response
-          handle_api_error(e.response)
-        else
-          handle_network_error(e, retry_count, api_base_url)
-        end
-
-      # Only handle errors when we know we can do so, and re-raise otherwise.
-      # This should be pretty infrequent.
-      else
-        raise
-      end
-    end
-
-    resp
-  end
-
-  def self.general_api_error(status, body)
-    APIError.new("Invalid response object from API: #{body.inspect} " +
-                 "(HTTP response code was #{status})", status, body)
-  end
-
-  def self.get_uname
-    if File.exist?('/proc/version')
-      File.read('/proc/version').strip
-    else
-      case RbConfig::CONFIG['host_os']
-      when /linux|darwin|bsd|sunos|solaris|cygwin/i
-        get_uname_from_system
-      when /mswin|mingw/i
-        get_uname_from_system_ver
-      else
-        "unknown platform"
-      end
-    end
-  end
-
-  def self.get_uname_from_system
-    (`uname -a 2>/dev/null` || '').strip
-  rescue Errno::ENOENT
-    "uname executable not found"
-  rescue Errno::ENOMEM # couldn't create subprocess
-    "uname lookup failed"
-  end
-
-  def self.get_uname_from_system_ver
-    (`ver` || '').strip
-  rescue Errno::ENOENT
-    "ver executable not found"
-  rescue Errno::ENOMEM # couldn't create subprocess
-    "uname lookup failed"
-  end
-
-  def self.handle_api_error(http_resp)
-    begin
-      resp = StripeResponse.from_faraday_hash(http_resp)
-      error = resp.data[:error]
-      raise StripeError.new unless error && error.is_a?(Hash)
-
-    rescue JSON::ParserError, StripeError
-      raise general_api_error(http_resp[:status], http_resp[:body])
-    end
-
-    case resp.http_status
-    when 400, 404
-      error = InvalidRequestError.new(
-        error[:message], error[:param],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    when 401
-      error = AuthenticationError.new(
-        error[:message],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    when 402
-      error = CardError.new(
-        error[:message], error[:param], error[:code],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    when 403
-      error = PermissionError.new(
-        error[:message],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    when 429
-      error = RateLimitError.new(
-        error[:message],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    else
-      error = APIError.new(
-        error[:message],
-        resp.http_status, resp.http_body, resp.data, resp.http_headers)
-    end
-
-    error.response = resp
-    raise(error)
-  end
-
-  def self.handle_network_error(e, retry_count, api_base_url=nil)
-    case e
-    when Faraday::ConnectionFailed
-      message = "Unexpected error communicating when trying to connect to Stripe. " \
-        "You may be seeing this message because your DNS is not working. " \
-        "To check, try running 'host stripe.com' from the command line."
-
-    when Faraday::SSLError
-      message = "Could not establish a secure connection to Stripe, you may " \
-                "need to upgrade your OpenSSL version. To check, try running " \
-                "'openssl s_client -connect api.stripe.com:443' from the " \
-                "command line."
-
-    when Faraday::TimeoutError
-      api_base_url = @api_base unless api_base_url
-      message = "Could not connect to Stripe (#{api_base_url}). " \
-        "Please check your internet connection and try again. " \
-        "If this problem persists, you should check Stripe's service status at " \
-        "https://twitter.com/stripestatus, or let us know at support@stripe.com."
-
-    else
-      message = "Unexpected error communicating with Stripe. " \
-        "If this problem persists, let us know at support@stripe.com."
-
-    end
-
-    if retry_count > 0
-      message += " Request was retried #{retry_count} times."
-    end
-
-    raise APIConnectionError.new(message + "\n\n(Network error: #{e.message})")
-  end
-
-  def self.request_headers(api_key, method)
-    headers = {
-      'User-Agent' => "Stripe/v1 RubyBindings/#{Stripe::VERSION}",
-      'Authorization' => "Bearer #{api_key}",
-      'Content-Type' => 'application/x-www-form-urlencoded'
-    }
-
-    # It is only safe to retry network failures on post and delete
-    # requests if we add an Idempotency-Key header
-    if [:post, :delete].include?(method) && self.max_network_retries > 0
-      headers['Idempotency-Key'] ||= SecureRandom.uuid
-    end
-
-    headers['Stripe-Version'] = api_version if api_version
-    headers['Stripe-Account'] = stripe_account if stripe_account
-
-    begin
-      headers.update('X-Stripe-Client-User-Agent' => JSON.generate(user_agent))
-    rescue => e
-      headers.update('X-Stripe-Client-Raw-User-Agent' => user_agent.inspect,
-                     :error => "#{e} (#{e.class})")
-    end
-  end
-
-  # Checks if an error is a problem that we should retry on. This includes both
-  # socket errors that may represent an intermittent problem and some special
-  # HTTP statuses.
-  def self.should_retry?(e, retry_count)
-    return false if retry_count >= self.max_network_retries
-
-    # Retry on timeout-related problems (either on open or read).
-    return true if e.is_a?(Faraday::TimeoutError)
-
-    # Destination refused the connection, the connection was reset, or a
-    # variety of other connection failures. This could occur from a single
-    # saturated server, so retry in case it's intermittent.
-    return true if e.is_a?(Faraday::ConnectionFailed)
-
-    if e.is_a?(Faraday::ClientError) && e.response
-      # 409 conflict
-      return true if e.response[:status] == 409
-    end
-
-    false
-  end
-
-  def self.sleep_time(retry_count)
-    # Apply exponential backoff with initial_network_retry_delay on the number
-    # of attempts so far as inputs. Do not allow the number to exceed
-    # max_network_retry_delay.
-    sleep_seconds = [initial_network_retry_delay * (2 ** (retry_count - 1)), max_network_retry_delay].min
-
-    # Apply some jitter by randomizing the value in the range of (sleep_seconds
-    # / 2) to (sleep_seconds).
-    sleep_seconds = sleep_seconds * (0.5 * (1 + rand()))
-
-    # But never sleep less than the base sleep seconds.
-    sleep_seconds = [initial_network_retry_delay, sleep_seconds].max
-
-    sleep_seconds
-  end
-
   # DEPRECATED. Use `Util#encode_parameters` instead.
   def self.uri_encode(params)
     Util.encode_parameters(params)
@@ -431,22 +138,5 @@ module Stripe
   class << self
     extend Gem::Deprecate
     deprecate :uri_encode, "Stripe::Util#encode_parameters", 2016, 01
-  end
-
-  def self.user_agent
-    @uname ||= get_uname
-    lang_version = "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})"
-
-    {
-      :bindings_version => Stripe::VERSION,
-      :lang => 'ruby',
-      :lang_version => lang_version,
-      :platform => RUBY_PLATFORM,
-      :engine => defined?(RUBY_ENGINE) ? RUBY_ENGINE : '',
-      :publisher => 'stripe',
-      :uname => @uname,
-      :hostname => Socket.gethostname,
-    }
-
   end
 end

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -136,7 +136,7 @@ module Stripe
     end
   end
 
-  # TODO: 
+  # TODO: Fix parameters.
   def self.request(conn, method, url, api_key, params, headers, api_base_url)
     api_base_url = api_base_url || @api_base
 

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -37,8 +37,8 @@ module Stripe
 
     def reject(params={}, opts={})
       opts = Util.normalize_opts(opts)
-      response, opts = request(:post, resource_url + '/reject', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/reject', params, opts)
+      initialize_from(response.data, opts)
     end
 
     # Somewhat unfortunately, we attempt to do a special encoding trick when
@@ -93,9 +93,9 @@ module Stripe
 
     def deauthorize(client_id, opts={})
       opts = {:api_base => Stripe.connect_base}.merge(Util.normalize_opts(opts))
-      response, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
+      resp, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
       opts.delete(:api_base) # the api_base here is a one-off, don't persist it
-      Util.convert_to_stripe_object(response, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     ARGUMENT_NOT_PROVIDED = Object.new

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -37,8 +37,8 @@ module Stripe
 
     def reject(params={}, opts={})
       opts = Util.normalize_opts(opts)
-      self.response, opts = request(:post, resource_url + '/reject', params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, resource_url + '/reject', params, opts)
+      initialize_from(resp.data, opts)
     end
 
     # Somewhat unfortunately, we attempt to do a special encoding trick when
@@ -95,7 +95,7 @@ module Stripe
       opts = {:api_base => Stripe.connect_base}.merge(Util.normalize_opts(opts))
       resp, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
       opts.delete(:api_base) # the api_base here is a one-off, don't persist it
-      Util.convert_to_stripe_object(resp.data, opts, response: resp)
+      Util.convert_to_stripe_object(resp.data, opts)
     end
 
     ARGUMENT_NOT_PROVIDED = Object.new

--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -3,7 +3,7 @@ module Stripe
     module Create
       def create(params={}, opts={})
         resp, opts = request(:post, resource_url, params, opts)
-        Util.convert_to_stripe_object(resp.data, opts, response: resp)
+        Util.convert_to_stripe_object(resp.data, opts)
       end
     end
   end

--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -2,8 +2,8 @@ module Stripe
   module APIOperations
     module Create
       def create(params={}, opts={})
-        response, opts = request(:post, resource_url, params, opts)
-        Util.convert_to_stripe_object(response, opts)
+        resp, opts = request(:post, resource_url, params, opts)
+        Util.convert_to_stripe_object(resp.data, opts, response: resp)
       end
     end
   end

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -3,8 +3,8 @@ module Stripe
     module Delete
       def delete(params={}, opts={})
         opts = Util.normalize_opts(opts)
-        response, opts = request(:delete, resource_url, params, opts)
-        initialize_from(response, opts)
+        self.response, opts = request(:delete, resource_url, params, opts)
+        initialize_from(response.data, opts)
       end
     end
   end

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -3,8 +3,8 @@ module Stripe
     module Delete
       def delete(params={}, opts={})
         opts = Util.normalize_opts(opts)
-        self.response, opts = request(:delete, resource_url, params, opts)
-        initialize_from(response.data, opts)
+        resp, opts = request(:delete, resource_url, params, opts)
+        initialize_from(resp.data, opts)
       end
     end
   end

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -6,7 +6,6 @@ module Stripe
 
         resp, opts = request(:get, resource_url, filters, opts)
         obj = ListObject.construct_from(resp.data, opts)
-        obj.response = resp
 
         # set filters so that we can fetch the same limit, expansions, and
         # predicates when accessing the next and previous pages

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -4,8 +4,9 @@ module Stripe
       def list(filters={}, opts={})
         opts = Util.normalize_opts(opts)
 
-        response, opts = request(:get, resource_url, filters, opts)
-        obj = ListObject.construct_from(response, opts)
+        resp, opts = request(:get, resource_url, filters, opts)
+        obj = ListObject.construct_from(resp.data, opts)
+        obj.response = resp
 
         # set filters so that we can fetch the same limit, expansions, and
         # predicates when accessing the next and previous pages

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -15,7 +15,10 @@ module Stripe
           # Assume all remaining opts must be headers
 
           resp, opts[:api_key] = client.execute_request(
-            method, url, api_key, params, headers, api_base)
+            method, url,
+            api_base: api_base, api_key: api_key,
+            headers: headers, params: params
+          )
 
           # Hash#select returns an array before 1.9
           opts_to_persist = {}

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -2,17 +2,19 @@ module Stripe
   module APIOperations
     module Request
       module ClassMethods
-        OPTS_KEYS_TO_PERSIST = Set[:api_key, :api_base, :stripe_account, :stripe_version]
+        OPTS_KEYS_TO_PERSIST = Set[:api_key, :api_base, :conn, :stripe_account, :stripe_version]
 
         def request(method, url, params={}, opts={})
           opts = Util.normalize_opts(opts)
+          opts[:conn] ||= Stripe.default_conn
 
           headers = opts.clone
           api_key = headers.delete(:api_key)
           api_base = headers.delete(:api_base)
+          conn = headers.delete[:conn]
           # Assume all remaining opts must be headers
 
-          resp, opts[:api_key] = Stripe.request(method, url, api_key, params, headers, api_base)
+          resp, opts[:api_key] = Stripe.request(conn, method, url, api_key, params, headers, api_base)
 
           # Hash#select returns an array before 1.9
           opts_to_persist = {}

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -11,7 +11,7 @@ module Stripe
           headers = opts.clone
           api_key = headers.delete(:api_key)
           api_base = headers.delete(:api_base)
-          conn = headers.delete[:conn]
+          conn = headers.delete(:conn)
           # Assume all remaining opts must be headers
 
           resp, opts[:api_key] = Stripe.request(conn, method, url, api_key, params, headers, api_base)

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -2,19 +2,20 @@ module Stripe
   module APIOperations
     module Request
       module ClassMethods
-        OPTS_KEYS_TO_PERSIST = Set[:api_key, :api_base, :conn, :stripe_account, :stripe_version]
+        OPTS_KEYS_TO_PERSIST = Set[:api_key, :api_base, :client, :stripe_account, :stripe_version]
 
         def request(method, url, params={}, opts={})
           opts = Util.normalize_opts(opts)
-          opts[:conn] ||= Stripe.default_conn
+          opts[:client] ||= StripeClient.active_client
 
           headers = opts.clone
           api_key = headers.delete(:api_key)
           api_base = headers.delete(:api_base)
-          conn = headers.delete(:conn)
+          client = headers.delete(:client)
           # Assume all remaining opts must be headers
 
-          resp, opts[:api_key] = Stripe.request(conn, method, url, api_key, params, headers, api_base)
+          resp, opts[:api_key] = client.execute_request(
+            method, url, api_key, params, headers, api_base)
 
           # Hash#select returns an array before 1.9
           opts_to_persist = {}

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -12,7 +12,7 @@ module Stripe
           api_base = headers.delete(:api_base)
           # Assume all remaining opts must be headers
 
-          response, opts[:api_key] = Stripe.request(method, url, api_key, params, headers, api_base)
+          resp, opts[:api_key] = Stripe.request(method, url, api_key, params, headers, api_base)
 
           # Hash#select returns an array before 1.9
           opts_to_persist = {}
@@ -22,7 +22,7 @@ module Stripe
             end
           end
 
-          [response, opts_to_persist]
+          [resp, opts_to_persist]
         end
       end
 

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -22,7 +22,7 @@ module Stripe
           end
 
           resp, opts = request(:post, "#{resource_url}/#{id}", params, opts)
-          Util.convert_to_stripe_object(resp.data, opts, response: resp)
+          Util.convert_to_stripe_object(resp.data, opts)
         end
       end
 
@@ -57,8 +57,8 @@ module Stripe
         # generated a uri for this object with an identifier baked in
         values.delete(:id)
 
-        self.response, opts = request(:post, save_url, values, opts)
-        initialize_from(response.data, opts)
+        resp, opts = request(:post, save_url, values, opts)
+        initialize_from(resp.data, opts)
       end
 
       def self.included(base)

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -21,8 +21,8 @@ module Stripe
             end
           end
 
-          response, opts = request(:post, "#{resource_url}/#{id}", params, opts)
-          Util.convert_to_stripe_object(response, opts)
+          resp, opts = request(:post, "#{resource_url}/#{id}", params, opts)
+          Util.convert_to_stripe_object(resp.data, opts, response: resp)
         end
       end
 
@@ -57,10 +57,8 @@ module Stripe
         # generated a uri for this object with an identifier baked in
         values.delete(:id)
 
-        response, opts = request(:post, save_url, values, opts)
-        initialize_from(response, opts)
-
-        self
+        self.response, opts = request(:post, save_url, values, opts)
+        initialize_from(response.data, opts)
       end
 
       def self.included(base)

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -2,13 +2,6 @@ module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request
 
-    # Response contains a StripeResponse object that has some basic information
-    # about the response that conveyed the API resource.
-    #
-    # Note that this is only set on the top-level API resource returned by an
-    # API operation. It will hold a nil value on all others.
-    attr_accessor :response
-
     # A flag that can be set a behavior that will cause this resource to be
     # encoded and sent up along with an update of its parent resource. This is
     # usually not desirable because resources are updated individually on their
@@ -61,8 +54,8 @@ module Stripe
     end
 
     def refresh
-      self.response, opts = request(:get, resource_url, @retrieve_params)
-      initialize_from(response.data, opts)
+      resp, opts = request(:get, resource_url, @retrieve_params)
+      initialize_from(resp.data, opts)
     end
 
     def self.retrieve(id, opts={})

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -2,6 +2,13 @@ module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request
 
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the API resource.
+    #
+    # Note that this is only set on the top-level API resource returned by an
+    # API operation. It will hold a nil value on all others.
+    attr_accessor :response
+
     # A flag that can be set a behavior that will cause this resource to be
     # encoded and sent up along with an update of its parent resource. This is
     # usually not desirable because resources are updated individually on their
@@ -54,8 +61,8 @@ module Stripe
     end
 
     def refresh
-      response, opts = request(:get, resource_url, @retrieve_params)
-      initialize_from(response, opts)
+      self.response, opts = request(:get, resource_url, @retrieve_params)
+      initialize_from(response.data, opts)
     end
 
     def self.retrieve(id, opts={})

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -2,8 +2,8 @@ module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request
 
-    # Response contains a structure that has some basic information about the
-    # response that conveyed the API resource.
+    # Response contains a StripeResponse object that has some basic information
+    # about the response that conveyed the API resource.
     #
     # Note that this is only set on the top-level API resource returned by an
     # API operation. It will hold a nil value on all others.

--- a/lib/stripe/bank_account.rb
+++ b/lib/stripe/bank_account.rb
@@ -5,8 +5,8 @@ module Stripe
     extend Stripe::APIOperations::List
 
     def verify(params={}, opts={})
-      response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(response.data, opts)
     end
 
     def resource_url

--- a/lib/stripe/bank_account.rb
+++ b/lib/stripe/bank_account.rb
@@ -5,8 +5,8 @@ module Stripe
     extend Stripe::APIOperations::List
 
     def verify(params={}, opts={})
-      self.response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(resp.data, opts)
     end
 
     def resource_url

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -20,41 +20,41 @@ module Stripe
         # from the server
         self.refresh
       else
-        self.response, opts = request(:post, refund_url, params, opts)
-        initialize_from(response.data, opts)
+        resp, opts = request(:post, refund_url, params, opts)
+        initialize_from(resp.data, opts)
       end
     end
 
     def capture(params={}, opts={})
-      self.response, opts = request(:post, capture_url, params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, capture_url, params, opts)
+      initialize_from(resp.data, opts)
     end
 
     def update_dispute(params={}, opts={})
-      self.response, opts = request(:post, dispute_url, params, opts)
-      initialize_from({ :dispute => response.data }, opts, true)
+      resp, opts = request(:post, dispute_url, params, opts)
+      initialize_from({ :dispute => resp.data }, opts, true)
       dispute
     end
 
     def close_dispute(params={}, opts={})
-      self.response, opts = request(:post, close_dispute_url, params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, close_dispute_url, params, opts)
+      initialize_from(resp.data, opts)
     end
 
     def mark_as_fraudulent
       params = {
         :fraud_details => { :user_report => 'fraudulent' }
       }
-      self.response, opts = request(:post, resource_url, params)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, resource_url, params)
+      initialize_from(resp.data, opts)
     end
 
     def mark_as_safe
       params = {
         :fraud_details => { :user_report => 'safe' }
       }
-      self.response, opts = request(:post, resource_url, params)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, resource_url, params)
+      initialize_from(resp.data, opts)
     end
 
     private

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -20,41 +20,41 @@ module Stripe
         # from the server
         self.refresh
       else
-        response, opts = request(:post, refund_url, params, opts)
-        initialize_from(response, opts)
+        self.response, opts = request(:post, refund_url, params, opts)
+        initialize_from(response.data, opts)
       end
     end
 
     def capture(params={}, opts={})
-      response, opts = request(:post, capture_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, capture_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def update_dispute(params={}, opts={})
-      response, opts = request(:post, dispute_url, params, opts)
-      initialize_from({ :dispute => response }, opts, true)
+      self.response, opts = request(:post, dispute_url, params, opts)
+      initialize_from({ :dispute => response.data }, opts, true)
       dispute
     end
 
     def close_dispute(params={}, opts={})
-      response, opts = request(:post, close_dispute_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, close_dispute_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def mark_as_fraudulent
       params = {
         :fraud_details => { :user_report => 'fraudulent' }
       }
-      response, opts = request(:post, resource_url, params)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url, params)
+      initialize_from(response.data, opts)
     end
 
     def mark_as_safe
       params = {
         :fraud_details => { :user_report => 'safe' }
       }
-      response, opts = request(:post, resource_url, params)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url, params)
+      initialize_from(response.data, opts)
     end
 
     private

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -38,25 +38,25 @@ module Stripe
     end
 
     def cancel_subscription(params={}, opts={})
-      response, opts = request(:delete, subscription_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:delete, subscription_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def update_subscription(params={}, opts={})
-      response, opts = request(:post, subscription_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:post, subscription_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def create_subscription(params={}, opts={})
-      response, opts = request(:post, subscriptions_url, params, opts)
-      initialize_from({ :subscription => response }, opts, true)
+      self.response, opts = request(:post, subscriptions_url, params, opts)
+      initialize_from({ :subscription => response.data }, opts, true)
       subscription
     end
 
     def delete_discount
-      _, opts = request(:delete, discount_url)
+      self.response, opts = request(:delete, discount_url)
       initialize_from({ :discount => nil }, opts, true)
     end
 

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -56,7 +56,7 @@ module Stripe
     end
 
     def delete_discount
-      resp, opts = request(:delete, discount_url)
+      _, opts = request(:delete, discount_url)
       initialize_from({ :discount => nil }, opts, true)
     end
 

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -38,25 +38,25 @@ module Stripe
     end
 
     def cancel_subscription(params={}, opts={})
-      self.response, opts = request(:delete, subscription_url, params, opts)
-      initialize_from({ :subscription => response.data }, opts, true)
+      resp, opts = request(:delete, subscription_url, params, opts)
+      initialize_from({ :subscription => resp.data }, opts, true)
       subscription
     end
 
     def update_subscription(params={}, opts={})
-      self.response, opts = request(:post, subscription_url, params, opts)
-      initialize_from({ :subscription => response.data }, opts, true)
+      resp, opts = request(:post, subscription_url, params, opts)
+      initialize_from({ :subscription => resp.data }, opts, true)
       subscription
     end
 
     def create_subscription(params={}, opts={})
-      self.response, opts = request(:post, subscriptions_url, params, opts)
-      initialize_from({ :subscription => response.data }, opts, true)
+      resp, opts = request(:post, subscriptions_url, params, opts)
+      initialize_from({ :subscription => resp.data }, opts, true)
       subscription
     end
 
     def delete_discount
-      self.response, opts = request(:delete, discount_url)
+      resp, opts = request(:delete, discount_url)
       initialize_from({ :discount => nil }, opts, true)
     end
 

--- a/lib/stripe/dispute.rb
+++ b/lib/stripe/dispute.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def close(params={}, opts={})
-      response, opts = request(:post, close_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, close_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def close_url

--- a/lib/stripe/dispute.rb
+++ b/lib/stripe/dispute.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def close(params={}, opts={})
-      self.response, opts = request(:post, close_url, params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, close_url, params, opts)
+      initialize_from(resp.data, opts)
     end
 
     def close_url

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -17,12 +17,8 @@ module Stripe
     attr_reader :request_id
 
     # Initializes a StripeError.
-    #
-    # Note: We should try to move away from the very heavy constructors ordered
-    # parameters to each just setting accessor values directly or optional
-    # arguments.
-    def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil,
-                   http_headers=nil)
+    def initialize(message=nil, http_status: nil, http_body: nil, json_body: nil,
+                   http_headers: nil)
       @message = message
       @http_status = http_status
       @http_body = http_body
@@ -61,9 +57,10 @@ module Stripe
   class CardError < StripeError
     attr_reader :param, :code
 
-    def initialize(message, param, code, http_status=nil, http_body=nil, json_body=nil,
-                   http_headers=nil)
-      super(message, http_status, http_body, json_body, http_headers)
+    def initialize(message, param, code, http_status: nil, http_body: nil, json_body: nil,
+                   http_headers: nil)
+      super(message, http_status: http_status, http_body: http_body,
+        json_body: json_body, http_headers: http_headers)
       @param = param
       @code = code
     end
@@ -74,9 +71,10 @@ module Stripe
   class InvalidRequestError < StripeError
     attr_accessor :param
 
-    def initialize(message, param, http_status=nil, http_body=nil, json_body=nil,
-                   http_headers=nil)
-      super(message, http_status, http_body, json_body, http_headers)
+    def initialize(message, param, http_status: nil, http_body: nil, json_body: nil,
+                   http_headers: nil)
+      super(message, http_status: http_status, http_body: http_body,
+        json_body: json_body, http_headers: http_headers)
       @param = param
     end
   end

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -3,12 +3,24 @@ module Stripe
   # errors derive.
   class StripeError < StandardError
     attr_reader :message
-    attr_reader :http_status
+
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the error.
+    attr_accessor :response
+
+    # These fields are now available as part of #response and that usage should
+    # be preferred.
     attr_reader :http_body
     attr_reader :http_headers
+    attr_reader :http_status
+    attr_reader :json_body # equivalent to #data
     attr_reader :request_id
-    attr_reader :json_body
 
+    # Initializes a StripeError.
+    #
+    # Note: We should try to move away from the very heavy constructors ordered
+    # parameters to each just setting accessor values directly or optional
+    # arguments.
     def initialize(message=nil, http_status=nil, http_body=nil, json_body=nil,
                    http_headers=nil)
       @message = message

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -4,8 +4,8 @@ module Stripe
   class StripeError < StandardError
     attr_reader :message
 
-    # Response contains a structure that has some basic information about the
-    # response that conveyed the error.
+    # Response contains a StripeResponse object that has some basic information
+    # about the response that conveyed the error.
     attr_accessor :response
 
     # These fields are now available as part of #response and that usage should

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -5,13 +5,13 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     def self.upcoming(params, opts={})
-      response, opts = request(:get, upcoming_url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:get, upcoming_url, params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     def pay(opts={})
-      response, opts = request(:post, pay_url, {}, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, pay_url, {}, opts)
+      initialize_from(response.data, opts)
     end
 
     private

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -6,12 +6,12 @@ module Stripe
 
     def self.upcoming(params, opts={})
       resp, opts = request(:get, upcoming_url, params, opts)
-      Util.convert_to_stripe_object(resp.data, opts, response: resp)
+      Util.convert_to_stripe_object(resp.data, opts)
     end
 
     def pay(opts={})
-      self.response, opts = request(:post, pay_url, {}, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, pay_url, {}, opts)
+      initialize_from(resp.data, opts)
     end
 
     private

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -10,6 +10,10 @@ module Stripe
     # expansions, and predicates as a user pages through resources.
     attr_accessor :filters
 
+    # Response contains a structure that has some basic information about the
+    # response that conveyed the list resource.
+    attr_accessor :response
+
     # An empty list object. This is returned from +next+ when we know that
     # there isn't a next page in order to replicate the behavior of the API
     # when it attempts to return a page beyond the last.
@@ -64,8 +68,8 @@ module Stripe
 
     def retrieve(id, opts={})
       id, retrieve_params = Util.normalize_id(id)
-      response, opts = request(:get,"#{resource_url}/#{CGI.escape(id)}", retrieve_params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:get,"#{resource_url}/#{CGI.escape(id)}", retrieve_params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     # Fetches the next page in the resource list (if there is one).

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -10,10 +10,6 @@ module Stripe
     # expansions, and predicates as a user pages through resources.
     attr_accessor :filters
 
-    # Response contains a StripeResponse object that has some basic information
-    # about the response that conveyed the list resource.
-    attr_accessor :response
-
     # An empty list object. This is returned from +next+ when we know that
     # there isn't a next page in order to replicate the behavior of the API
     # when it attempts to return a page beyond the last.
@@ -69,7 +65,7 @@ module Stripe
     def retrieve(id, opts={})
       id, retrieve_params = Util.normalize_id(id)
       resp, opts = request(:get,"#{resource_url}/#{CGI.escape(id)}", retrieve_params, opts)
-      Util.convert_to_stripe_object(resp.data, opts, response: resp)
+      Util.convert_to_stripe_object(resp.data, opts)
     end
 
     # Fetches the next page in the resource list (if there is one).

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -10,8 +10,8 @@ module Stripe
     # expansions, and predicates as a user pages through resources.
     attr_accessor :filters
 
-    # Response contains a structure that has some basic information about the
-    # response that conveyed the list resource.
+    # Response contains a StripeResponse object that has some basic information
+    # about the response that conveyed the list resource.
     attr_accessor :response
 
     # An empty list object. This is returned from +next+ when we know that

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -5,13 +5,13 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def pay(params, opts={})
-      response, opts = request(:post, pay_url, params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, pay_url, params, opts)
+      initialize_from(response.data, opts)
     end
 
     def return_order(params, opts={})
-      response, opts = request(:post, returns_url, params, opts)
-      Util.convert_to_stripe_object(response, opts)
+      resp, opts = request(:post, returns_url, params, opts)
+      Util.convert_to_stripe_object(resp.data, opts, response: resp)
     end
 
     private

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -5,13 +5,13 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def pay(params, opts={})
-      self.response, opts = request(:post, pay_url, params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, pay_url, params, opts)
+      initialize_from(resp.data, opts)
     end
 
     def return_order(params, opts={})
       resp, opts = request(:post, returns_url, params, opts)
-      Util.convert_to_stripe_object(resp.data, opts, response: resp)
+      Util.convert_to_stripe_object(resp.data, opts)
     end
 
     private

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -4,8 +4,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def verify(params={}, opts={})
-      response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response, opts)
+      self.response, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(response.data, opts)
     end
   end
 end

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -4,8 +4,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def verify(params={}, opts={})
-      self.response, opts = request(:post, resource_url + '/verify', params, opts)
-      initialize_from(response.data, opts)
+      resp, opts = request(:post, resource_url + '/verify', params, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -24,7 +24,10 @@ module Stripe
     # object should never be mutated, and instead instantiating your own
     # connection and wrapping it in a StripeClient object should be preferred.
     def self.default_conn
-      @default_conn ||= begin
+      # We're going to keep connections around so that we can take advantage
+      # of connection re-use, so make sure that we have a separate connection
+      # object per thread.
+      Thread.current[:stripe_client_default_conn] ||= begin
         conn = Faraday.new do |conn|
           conn.use Faraday::Request::UrlEncoded
           conn.use Faraday::Response::RaiseError

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -1,30 +1,43 @@
 module Stripe
+  # StripeClient executes requests against the Stripe API and allows a user to
+  # recover both a resource a call returns as well as a response object that
+  # contains information on the HTTP call.
   class StripeClient
-    def initialize(conn)
-      self.conn = conn
+    attr_accessor :conn
+
+    # Initializes a new StripeClient. Expects a Faraday connection object, and
+    # uses a default connection unless one is passed.
+    def initialize(conn = nil)
+      self.conn = conn || Stripe.default_conn
     end
 
+    # Sets the last StripeResponse object to have come back from an API call.
+    # This is expected to be called by the Stripe module.
     def self.set_last_response(resp)
       if Thread.current[:stripe_client]
         Thread.current[:stripe_last_response] = resp
       end
     end
 
+    # Executes the API call within the given block. Usage looks like:
+    #
+    #     client = StripeClient.new
+    #     charge, resp = client.request { Charge.create }
+    #
     def request(&block)
       old_stripe_client = Thread.current[:stripe_client]
+      old_stripe_last_response = Thread.current[:stripe_last_response]
+
       Thread.current[:stripe_client] = self
+      Thread.current[:stripe_last_response] = nil
 
       begin
         res = block.call
         [res, Thread.current[:stripe_last_response]]
       ensure
         Thread.current[:stripe_client] = old_stripe_client
-        Thread.current[:stripe_last_response] = nil
+        Thread.current[:stripe_last_response] = old_stripe_last_response
       end
     end
-
-    private
-
-    attr_accessor :conn
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -8,14 +8,25 @@ module Stripe
     # Initializes a new StripeClient. Expects a Faraday connection object, and
     # uses a default connection unless one is passed.
     def initialize(conn = nil)
-      self.conn = conn || Stripe.default_conn
+      self.conn = conn || self.class.default_conn
     end
 
-    # Sets the last StripeResponse object to have come back from an API call.
-    # This is expected to be called by the Stripe module.
-    def self.set_last_response(resp)
-      if Thread.current[:stripe_client]
-        Thread.current[:stripe_last_response] = resp
+    def self.active_client
+      Thread.current[:stripe_client] || default_client
+    end
+
+    def self.default_client
+      @default_client ||= StripeClient.new(default_conn)
+    end
+
+    # A default Faraday connection to be used when one isn't configured. This
+    # object should never be mutated, and instead instantiating your own
+    # connection and wrapping it in a StripeClient object should be preferred.
+    def self.default_conn
+      @default_conn ||= Faraday.new do |conn|
+        conn.use Faraday::Request::UrlEncoded
+        conn.use Faraday::Response::RaiseError
+        conn.adapter Faraday.default_adapter
       end
     end
 
@@ -25,19 +36,315 @@ module Stripe
     #     charge, resp = client.request { Charge.create }
     #
     def request(&block)
+      @last_response = nil
       old_stripe_client = Thread.current[:stripe_client]
-      old_stripe_last_response = Thread.current[:stripe_last_response]
-
       Thread.current[:stripe_client] = self
-      Thread.current[:stripe_last_response] = nil
 
       begin
         res = block.call
-        [res, Thread.current[:stripe_last_response]]
+        [res, @last_response]
       ensure
         Thread.current[:stripe_client] = old_stripe_client
-        Thread.current[:stripe_last_response] = old_stripe_last_response
       end
+    end
+
+    # TODO: Fix parameters.
+    def execute_request(method, url, api_key, params, headers, api_base_url)
+      api_base_url = api_base_url || @api_base
+
+      unless api_key ||= Stripe.api_key
+        raise AuthenticationError.new('No API key provided. ' \
+          'Set your API key using "Stripe.api_key = <API-KEY>". ' \
+          'You can generate API keys from the Stripe web interface. ' \
+          'See https://stripe.com/api for details, or email support@stripe.com ' \
+          'if you have any questions.')
+      end
+
+      if api_key =~ /\s/
+        raise AuthenticationError.new('Your API key is invalid, as it contains ' \
+          'whitespace. (HINT: You can double-check your API key from the ' \
+          'Stripe web interface. See https://stripe.com/api for details, or ' \
+          'email support@stripe.com if you have any questions.)')
+      end
+
+      params = Util.objects_to_ids(params)
+      url = api_url(url, api_base_url)
+
+      case method.to_s.downcase.to_sym
+      when :get, :head, :delete
+        # Make params into GET parameters
+        url += "#{URI.parse(url).query ? '&' : '?'}#{Util.encode_parameters(params)}" if params && params.any?
+        payload = nil
+      else
+        if headers[:content_type] && headers[:content_type] == "multipart/form-data"
+          payload = params
+        else
+          payload = Util.encode_parameters(params)
+        end
+      end
+
+      if Stripe.verify_ssl_certs
+        conn.ssl.verify = true
+        conn.ssl.cert_store = Stripe.ca_store
+      else
+        conn.ssl.verify = false
+
+        unless @verify_ssl_warned
+          @verify_ssl_warned = true
+          $stderr.puts("WARNING: Running without SSL cert verification. " \
+            "You should never do this in production. " \
+            "Execute 'Stripe.verify_ssl_certs = true' to enable verification.")
+        end
+      end
+
+      http_resp = execute_request_with_rescues(api_base_url, 0) do
+        conn.run_request(
+          method,
+          url,
+          payload,
+          # TODO: Convert RestClient-style parameters.
+          request_headers(api_key, method).update(headers)
+        ) do |req|
+          req.options.open_timeout = Stripe.open_timeout
+          req.options.timeout = Stripe.read_timeout
+        end
+      end
+
+      begin
+        resp = StripeResponse.from_faraday_response(http_resp)
+      rescue JSON::ParserError
+        raise general_api_error(http_resp.code, http_resp.body)
+      end
+
+      # Allows StripeClient#request to return a response object to a caller.
+      @last_response = resp
+      [resp, api_key]
+    end
+
+    private
+
+    def api_url(url='', api_base_url=nil)
+      (api_base_url || Stripe.api_base) + url
+    end
+
+    def execute_request_with_rescues(api_base_url, retry_count, &block)
+      begin
+        resp = block.call
+
+      # We rescue all exceptions from a request so that we have an easy spot to
+      # implement our retry logic across the board. We'll re-raise if it's a type
+      # of exception that we didn't expect to handle.
+      rescue => e
+        if should_retry?(e, retry_count)
+          retry_count = retry_count + 1
+          sleep sleep_time(retry_count)
+          retry
+        end
+
+        case e
+        when Faraday::ClientError
+          if e.response
+            handle_api_error(e.response)
+          else
+            handle_network_error(e, retry_count, api_base_url)
+          end
+
+        # Only handle errors when we know we can do so, and re-raise otherwise.
+        # This should be pretty infrequent.
+        else
+          raise
+        end
+      end
+
+      resp
+    end
+
+    def general_api_error(status, body)
+      APIError.new("Invalid response object from API: #{body.inspect} " +
+                   "(HTTP response code was #{status})", status, body)
+    end
+
+    def get_uname
+      if File.exist?('/proc/version')
+        File.read('/proc/version').strip
+      else
+        case RbConfig::CONFIG['host_os']
+        when /linux|darwin|bsd|sunos|solaris|cygwin/i
+          get_uname_from_system
+        when /mswin|mingw/i
+          get_uname_from_system_ver
+        else
+          "unknown platform"
+        end
+      end
+    end
+
+    def get_uname_from_system
+      (`uname -a 2>/dev/null` || '').strip
+    rescue Errno::ENOENT
+      "uname executable not found"
+    rescue Errno::ENOMEM # couldn't create subprocess
+      "uname lookup failed"
+    end
+
+    def get_uname_from_system_ver
+      (`ver` || '').strip
+    rescue Errno::ENOENT
+      "ver executable not found"
+    rescue Errno::ENOMEM # couldn't create subprocess
+      "uname lookup failed"
+    end
+
+    def handle_api_error(http_resp)
+      begin
+        resp = StripeResponse.from_faraday_hash(http_resp)
+        error = resp.data[:error]
+        raise StripeError.new unless error && error.is_a?(Hash)
+
+      rescue JSON::ParserError, StripeError
+        raise general_api_error(http_resp[:status], http_resp[:body])
+      end
+
+      case resp.http_status
+      when 400, 404
+        error = InvalidRequestError.new(
+          error[:message], error[:param],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      when 401
+        error = AuthenticationError.new(
+          error[:message],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      when 402
+        error = CardError.new(
+          error[:message], error[:param], error[:code],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      when 403
+        error = PermissionError.new(
+          error[:message],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      when 429
+        error = RateLimitError.new(
+          error[:message],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      else
+        error = APIError.new(
+          error[:message],
+          resp.http_status, resp.http_body, resp.data, resp.http_headers)
+      end
+
+      error.response = resp
+      raise(error)
+    end
+
+    def handle_network_error(e, retry_count, api_base_url=nil)
+      case e
+      when Faraday::ConnectionFailed
+        message = "Unexpected error communicating when trying to connect to Stripe. " \
+          "You may be seeing this message because your DNS is not working. " \
+          "To check, try running 'host stripe.com' from the command line."
+
+      when Faraday::SSLError
+        message = "Could not establish a secure connection to Stripe, you may " \
+                  "need to upgrade your OpenSSL version. To check, try running " \
+                  "'openssl s_client -connect api.stripe.com:443' from the " \
+                  "command line."
+
+      when Faraday::TimeoutError
+        api_base_url = @api_base unless api_base_url
+        message = "Could not connect to Stripe (#{api_base_url}). " \
+          "Please check your internet connection and try again. " \
+          "If this problem persists, you should check Stripe's service status at " \
+          "https://twitter.com/stripestatus, or let us know at support@stripe.com."
+
+      else
+        message = "Unexpected error communicating with Stripe. " \
+          "If this problem persists, let us know at support@stripe.com."
+
+      end
+
+      if retry_count > 0
+        message += " Request was retried #{retry_count} times."
+      end
+
+      raise APIConnectionError.new(message + "\n\n(Network error: #{e.message})")
+    end
+
+    # Checks if an error is a problem that we should retry on. This includes both
+    # socket errors that may represent an intermittent problem and some special
+    # HTTP statuses.
+    def should_retry?(e, retry_count)
+      return false if retry_count >= Stripe.max_network_retries
+
+      # Retry on timeout-related problems (either on open or read).
+      return true if e.is_a?(Faraday::TimeoutError)
+
+      # Destination refused the connection, the connection was reset, or a
+      # variety of other connection failures. This could occur from a single
+      # saturated server, so retry in case it's intermittent.
+      return true if e.is_a?(Faraday::ConnectionFailed)
+
+      if e.is_a?(Faraday::ClientError) && e.response
+        # 409 conflict
+        return true if e.response[:status] == 409
+      end
+
+      false
+    end
+
+    def request_headers(api_key, method)
+      headers = {
+        'User-Agent' => "Stripe/v1 RubyBindings/#{Stripe::VERSION}",
+        'Authorization' => "Bearer #{api_key}",
+        'Content-Type' => 'application/x-www-form-urlencoded'
+      }
+
+      # It is only safe to retry network failures on post and delete
+      # requests if we add an Idempotency-Key header
+      if [:post, :delete].include?(method) && Stripe.max_network_retries > 0
+        headers['Idempotency-Key'] ||= SecureRandom.uuid
+      end
+
+      headers['Stripe-Version'] = Stripe.api_version if Stripe.api_version
+      headers['Stripe-Account'] = Stripe.stripe_account if Stripe.stripe_account
+
+      begin
+        headers.update('X-Stripe-Client-User-Agent' => JSON.generate(user_agent))
+      rescue => e
+        headers.update('X-Stripe-Client-Raw-User-Agent' => user_agent.inspect,
+                       :error => "#{e} (#{e.class})")
+      end
+    end
+
+    def sleep_time(retry_count)
+      # Apply exponential backoff with initial_network_retry_delay on the number
+      # of attempts so far as inputs. Do not allow the number to exceed
+      # max_network_retry_delay.
+      sleep_seconds = [Stripe.initial_network_retry_delay * (2 ** (retry_count - 1)), Stripe.max_network_retry_delay].min
+
+      # Apply some jitter by randomizing the value in the range of (sleep_seconds
+      # / 2) to (sleep_seconds).
+      sleep_seconds = sleep_seconds * (0.5 * (1 + rand()))
+
+      # But never sleep less than the base sleep seconds.
+      sleep_seconds = [Stripe.initial_network_retry_delay, sleep_seconds].max
+
+      sleep_seconds
+    end
+
+    def user_agent
+      @uname ||= get_uname
+      lang_version = "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})"
+
+      {
+        :bindings_version => Stripe::VERSION,
+        :lang => 'ruby',
+        :lang_version => lang_version,
+        :platform => RUBY_PLATFORM,
+        :engine => defined?(RUBY_ENGINE) ? RUBY_ENGINE : '',
+        :publisher => 'stripe',
+        :uname => @uname,
+        :hostname => Socket.gethostname,
+      }
     end
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -1,0 +1,20 @@
+module Stripe
+  class StripeClient
+    def initialize(conn)
+      self.conn = conn
+    end
+
+    def request(&block)
+      res = block.call
+      [res, Thread.local[:stripe_last_response]]
+    end
+
+    def set_last_response(resp)
+      Thread.local[:stripe_last_response] = resp
+    end
+
+    private
+
+    attr_accessor :conn
+  end
+end

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -1,0 +1,34 @@
+module Stripe
+  # StripeResponse encapsulates some vitals of a response that came back from
+  # the Stripe API.
+  class StripeResponse
+    # The data contained by the HTTP body of the response deserialized from
+    # JSON.
+    attr_accessor :data
+
+    # The raw HTTP body of the response.
+    attr_accessor :http_body
+
+    # A Hash of the HTTP headers of the response.
+    attr_accessor :http_headers
+
+    # The integer HTTP status code of the response.
+    attr_accessor :http_status
+
+    # The Stripe request ID of the response.
+    attr_accessor :request_id
+
+    # Initializes a StripeResponse object from a RestClient HTTP response
+    # object.
+    #
+    # This may throw JSON::ParserError if the response body is not valid JSON.
+    def self.from_rest_client_response(http_resp)
+      resp = StripeResponse.new
+      resp.data = JSON.parse(http_resp.body, symbolize_names: true)
+      resp.http_body = http_resp.body
+      resp.http_headers = http_resp.headers
+      resp.http_status = http_resp.code
+      resp
+    end
+  end
+end

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -28,6 +28,7 @@ module Stripe
       resp.http_body = http_resp.body
       resp.http_headers = http_resp.headers
       resp.http_status = http_resp.code
+      resp.request_id = http_resp.headers[:request_id]
       resp
     end
   end

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -18,6 +18,20 @@ module Stripe
     # The Stripe request ID of the response.
     attr_accessor :request_id
 
+    # Initializes a StripeResponse object from a Hash like the kind returned as
+    # part of a Faraday exception.
+    #
+    # This may throw JSON::ParserError if the response body is not valid JSON.
+    def self.from_faraday_hash(http_resp)
+      resp = StripeResponse.new
+      resp.data = JSON.parse(http_resp[:body], symbolize_names: true)
+      resp.http_body = http_resp[:body]
+      resp.http_headers = http_resp[:headers]
+      resp.http_status = http_resp[:status]
+      resp.request_id = http_resp[:headers]["Request-Id"]
+      resp
+    end
+
     # Initializes a StripeResponse object from a Faraday HTTP response object.
     #
     # This may throw JSON::ParserError if the response body is not valid JSON.

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -18,17 +18,16 @@ module Stripe
     # The Stripe request ID of the response.
     attr_accessor :request_id
 
-    # Initializes a StripeResponse object from a RestClient HTTP response
-    # object.
+    # Initializes a StripeResponse object from a Faraday HTTP response object.
     #
     # This may throw JSON::ParserError if the response body is not valid JSON.
-    def self.from_rest_client_response(http_resp)
+    def self.from_faraday_response(http_resp)
       resp = StripeResponse.new
       resp.data = JSON.parse(http_resp.body, symbolize_names: true)
       resp.http_body = http_resp.body
       resp.http_headers = http_resp.headers
-      resp.http_status = http_resp.code
-      resp.request_id = http_resp.headers[:request_id]
+      resp.http_status = http_resp.status
+      resp.request_id = http_resp.headers["Request-Id"]
       resp
     end
   end

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def cancel
-      self.response, api_key = self.request(:post, cancel_url)
-      initialize_from(response.data, api_key)
+      resp, api_key = self.request(:post, cancel_url)
+      initialize_from(resp.data, api_key)
     end
 
     def cancel_url

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -5,8 +5,8 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def cancel
-      response, api_key = self.request(:post, cancel_url)
-      initialize_from(response, api_key)
+      self.response, api_key = self.request(:post, cancel_url)
+      initialize_from(response.data, api_key)
     end
 
     def cancel_url

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -68,19 +68,28 @@ module Stripe
     #
     # ==== Attributes
     #
-    # * +resp+ - Hash of fields and values to be converted into a StripeObject.
+    # * +data+ - Hash of fields and values to be converted into a StripeObject.
     # * +opts+ - Options for +StripeObject+ like an API key that will be reused
     #   on subsequent API calls.
-    def self.convert_to_stripe_object(resp, opts)
-      case resp
+    # * +response+ - An object containing information about the API response
+    #   that produced the data which is hydrating the StripeObject.
+    def self.convert_to_stripe_object(data, opts, response: nil)
+      obj = case data
       when Array
-        resp.map { |i| convert_to_stripe_object(i, opts) }
+        data.map { |i| convert_to_stripe_object(i, opts) }
       when Hash
         # Try converting to a known object class.  If none available, fall back to generic StripeObject
-        object_classes.fetch(resp[:object], StripeObject).construct_from(resp, opts)
+        object_classes.fetch(data[:object], StripeObject).construct_from(data, opts)
       else
-        resp
+        data
       end
+
+      case obj
+      when APIResource, ListObject
+        obj.response = response
+      end
+
+      obj
     end
 
     def self.file_readable(file)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -71,10 +71,8 @@ module Stripe
     # * +data+ - Hash of fields and values to be converted into a StripeObject.
     # * +opts+ - Options for +StripeObject+ like an API key that will be reused
     #   on subsequent API calls.
-    # * +response+ - An object containing information about the API response
-    #   that produced the data which is hydrating the StripeObject.
-    def self.convert_to_stripe_object(data, opts, other_opts = {})
-      obj = case data
+    def self.convert_to_stripe_object(data, opts)
+      case data
       when Array
         data.map { |i| convert_to_stripe_object(i, opts) }
       when Hash
@@ -83,14 +81,6 @@ module Stripe
       else
         data
       end
-
-      case obj
-      when APIResource, ListObject
-        # Change this to an optional parameter when we drop 1.9 support.
-        obj.response = other_opts[:response]
-      end
-
-      obj
     end
 
     def self.file_readable(file)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -73,7 +73,7 @@ module Stripe
     #   on subsequent API calls.
     # * +response+ - An object containing information about the API response
     #   that produced the data which is hydrating the StripeObject.
-    def self.convert_to_stripe_object(data, opts, response: nil)
+    def self.convert_to_stripe_object(data, opts, other_opts = {})
       obj = case data
       when Array
         data.map { |i| convert_to_stripe_object(i, opts) }
@@ -86,7 +86,8 @@ module Stripe
 
       case obj
       when APIResource, ListObject
-        obj.response = response
+        # Change this to an optional parameter when we drop 1.9 support.
+        obj.response = other_opts[:response]
       end
 
       obj

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://stripe.com/docs/api/ruby'
   s.license = 'MIT'
 
-  s.add_dependency('rest-client', '>= 1.4', '< 4.0')
+  s.add_dependency('faraday', '~> 0')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -73,29 +73,6 @@ module Stripe
       end
     end
 
-    should "specifying invalid api credentials should raise an exception" do
-      Stripe.api_key = "invalid"
-      assert_raises Stripe::AuthenticationError do
-        stub_request(:get, "#{Stripe.api_base}/v1/customers/failing_customer").
-          to_return(body: JSON.generate(make_invalid_api_key_error), status: 401)
-        Stripe::Customer.retrieve("failing_customer")
-      end
-    end
-
-    should "AuthenticationErrors should have an http status, http body, and JSON body" do
-      Stripe.api_key = "invalid"
-      begin
-        stub_request(:get, "#{Stripe.api_base}/v1/customers/failing_customer").
-          to_return(body: JSON.generate(make_invalid_api_key_error), status: 401)
-        Stripe::Customer.retrieve("failing_customer")
-      rescue Stripe::AuthenticationError => e
-        assert_equal(401, e.http_status)
-        assert_equal(true, !!e.http_body)
-        assert_equal(true, !!e.json_body[:error][:message])
-        assert_equal(make_invalid_api_key_error[:error][:message], e.json_body[:error][:message])
-      end
-    end
-
     should "send expand on fetch properly" do
       stub_request(:get, "#{Stripe.api_base}/v1/charges/ch_test_charge").
         with(query: { "expand" => ["customer"] }).
@@ -123,53 +100,6 @@ module Stripe
 
       customer = Stripe::Customer.retrieve('c_test_customer')
       customer.sources.retrieve({:id => 'cc_test_card', :expand => [:customer]})
-    end
-
-    should "send stripe account as header when set" do
-      stripe_account = "acct_0000"
-      stub_request(:post, "#{Stripe.api_base}/v1/charges").
-        with(headers: {"Stripe-Account" => stripe_account}).
-        to_return(body: JSON.generate(make_customer))
-
-      Stripe::Charge.create({:card => {:number => '4242424242424242'}},
-                            {:stripe_account => stripe_account, :api_key => 'sk_test_local'})
-    end
-
-    should "not send stripe account as header when not set" do
-      stub_request(:post, "#{Stripe.api_base}/v1/charges").
-        with { |req|
-          req.headers["Stripe-Account"].nil?
-        }.to_return(body: JSON.generate(make_charge))
-
-      Stripe::Charge.create({:card => {:number => '4242424242424242'}},
-        'sk_test_local')
-    end
-
-    should "handle error response with empty body" do
-      stub_request(:post, "#{Stripe.api_base}/v1/charges").
-        to_return(body: '', status: 500)
-
-      e = assert_raises Stripe::APIError do
-        Stripe::Charge.create
-      end
-
-      assert_equal 'Invalid response object from API: "" (HTTP response code was 500)', e.message
-    end
-
-    should "handle error response with non-object error value" do
-      stub_request(:post, "#{Stripe.api_base}/v1/charges").
-        to_return(body: JSON.generate({ error: "foo" }), status: 500)
-
-      e = assert_raises Stripe::APIError do
-        Stripe::Charge.create
-      end
-
-      assert_equal 'Invalid response object from API: "{\"error\":\"foo\"}" (HTTP response code was 500)', e.message
-    end
-
-    should "have default open and read timeouts" do
-      assert_equal Stripe.open_timeout, 30
-      assert_equal Stripe.read_timeout, 80
     end
 
     context "when specifying per-object credentials" do
@@ -217,17 +147,6 @@ module Stripe
     end
 
     context "with valid credentials" do
-      should "send along the idempotency-key header" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          with(headers: {"Idempotency-Key" => "bar"}).
-          to_return(body: JSON.generate(make_charge))
-
-        Stripe::Charge.create({:card => {:number => '4242424242424242'}}, {
-          :idempotency_key => 'bar',
-          :api_key => 'local',
-        })
-      end
-
       should "urlencode values in GET params" do
         stub_request(:get, "#{Stripe.api_base}/v1/charges").
           with(query: { customer: "test customer" }).
@@ -247,78 +166,6 @@ module Stripe
           with(query: { customer: "test_customer", paid: "true" }).
           to_return(body: response)
         invoices.list(:paid => true)
-      end
-
-      should "a 400 should give an InvalidRequestError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_missing_id_error), status: 400)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::InvalidRequestError => e
-          assert_equal(400, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
-      end
-
-      should "a 401 should give an AuthenticationError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_missing_id_error), status: 401)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::AuthenticationError => e
-          assert_equal(401, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
-      end
-
-      should "a 402 should give a CardError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_missing_id_error), status: 402)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::CardError => e
-          assert_equal(402, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
-      end
-
-      should "a 403 should give a PermissionError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_missing_id_error), status: 403)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::PermissionError => e
-          assert_equal(403, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
-      end
-
-      should "a 404 should give an InvalidRequestError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_missing_id_error), status: 404)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::InvalidRequestError => e
-          assert_equal(404, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
-      end
-
-      should "a 429 should give a RateLimitError with http status, body, and JSON body" do
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return(body: JSON.generate(make_rate_limit_error), status: 429)
-        begin
-          Stripe::Charge.create
-        rescue Stripe::RateLimitError => e
-          assert_equal(429, e.http_status)
-          assert_equal(true, !!e.http_body)
-          assert_equal(true, e.json_body.kind_of?(Hash))
-        end
       end
 
       should "setting a nil value for a param should exclude that param from the request" do
@@ -404,15 +251,6 @@ module Stripe
         assert_equal false, c.livemode
       end
 
-      should "updating should send along the idempotency-key header" do
-        stub_request(:post, "#{Stripe.api_base}/v1/customers").
-          with(headers: {"Idempotency-Key" => "bar"}).
-          to_return(body: JSON.generate(make_customer))
-        c = Stripe::Customer.new
-        c.save({}, { :idempotency_key => 'bar' })
-        assert_equal false, c.livemode
-      end
-
       should "updating should fail if api_key is overwritten with nil" do
         c = Stripe::Customer.new
         assert_raises TypeError do
@@ -475,62 +313,6 @@ module Stripe
           to_return(body: JSON.generate(make_customer))
         c.description = 'FOO'
         c.save
-      end
-
-      context "error checking" do
-
-        should "404s should raise an InvalidRequestError" do
-          stub_request(:get, "#{Stripe.api_base}/v1/customers/test_customer").
-            to_return(body: JSON.generate(make_missing_id_error), status: 404)
-
-          rescued = false
-          begin
-            Stripe::Customer.new("test_customer").refresh
-            assert false #shouldn't get here either
-          rescue Stripe::InvalidRequestError => e # we don't use assert_raises because we want to examine e
-            rescued = true
-            assert e.kind_of? Stripe::InvalidRequestError
-            assert_equal "id", e.param
-            assert_equal "Missing id", e.message
-          end
-
-          assert_equal true, rescued
-        end
-
-        should "5XXs should raise an APIError" do
-          stub_request(:get, "#{Stripe.api_base}/v1/customers/test_customer").
-            to_return(body: JSON.generate(make_api_error), status: 500)
-
-          rescued = false
-          begin
-            Stripe::Customer.new("test_customer").refresh
-            assert false #shouldn't get here either
-          rescue Stripe::APIError => e # we don't use assert_raises because we want to examine e
-            rescued = true
-            assert e.kind_of? Stripe::APIError
-          end
-
-          assert_equal true, rescued
-        end
-
-        should "402s should raise a CardError" do
-          stub_request(:get, "#{Stripe.api_base}/v1/customers/test_customer").
-            to_return(body: JSON.generate(make_invalid_exp_year_error), status: 402)
-
-          rescued = false
-          begin
-            Stripe::Customer.new("test_customer").refresh
-            assert false #shouldn't get here either
-          rescue Stripe::CardError => e # we don't use assert_raises because we want to examine e
-            rescued = true
-            assert e.kind_of? Stripe::CardError
-            assert_equal "invalid_expiry_year", e.code
-            assert_equal "exp_year", e.param
-            assert_equal "Your card's expiration year is invalid", e.message
-          end
-
-          assert_equal true, rescued
-        end
       end
 
       should 'add key to nested objects' do
@@ -711,152 +493,6 @@ module Stripe
           to_return(body: JSON.generate({ "id" => "acct_123" }))
 
         account.save(:display_name => 'stripe', :metadata => {:key => 'value' })
-      end
-    end
-
-    context "with retries" do
-      setup do
-        Stripe.stubs(:max_network_retries).returns(2)
-      end
-
-      should 'retry failed network requests if specified and raise if error persists' do
-        Stripe.expects(:sleep_time).at_least_once.returns(0)
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_raise(Errno::ECONNREFUSED.new)
-
-        err = assert_raises Stripe::APIConnectionError do
-          Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-        end
-        assert_match(/Request was retried 2 times/, err.message)
-      end
-
-      should 'retry failed network requests if specified and return successful response' do
-        Stripe.expects(:sleep_time).at_least_once.returns(0)
-
-        i = 0
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          to_return { |_|
-            if i < 2
-              i += 1
-              raise Errno::ECONNREFUSED.new
-            else
-              { body: JSON.generate({"id" => "myid"}) }
-            end
-          }
-
-        result = Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-        assert_equal "myid", result.id
-      end
-
-      should 'not add an idempotency key to GET requests' do
-        SecureRandom.expects(:uuid).times(0)
-        stub_request(:get, "#{Stripe.api_base}/v1/charges").
-          with { |req|
-            req.headers['Idempotency-Key'].nil?
-          }.to_return(body: JSON.generate(make_charge_array))
-        Stripe::Charge.list
-      end
-
-      should 'ensure there is always an idempotency_key on POST requests' do
-        SecureRandom.expects(:uuid).at_least_once.returns("random_key")
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          with(headers: {"Idempotency-Key" => "random_key"}).
-          to_return(body: JSON.generate(make_charge))
-
-        Stripe::Charge.create(:amount => 50, :currency => 'usd', :card => { :number => nil })
-      end
-
-      should 'ensure there is always an idempotency_key on DELETE requests' do
-        SecureRandom.expects(:uuid).at_least_once.returns("random_key")
-
-        c = Stripe::Customer.construct_from(make_customer)
-        stub_request(:delete, "#{Stripe.api_base}/v1/customers/#{c.id}").
-          with(headers: {"Idempotency-Key" => "random_key"}).
-          to_return(body: JSON.generate(make_charge))
-
-        c.delete
-      end
-
-      should 'not override a provided idempotency_key' do
-        # Note that this expectation looks like `:idempotency_key` instead of
-        # the header `Idempotency-Key` because it's user provided as seen
-        # below. The ones injected by the library itself look like headers
-        # (`Idempotency-Key`), but rest-client does allow this symbol
-        # formatting and will properly override the system generated one as
-        # expected.
-        stub_request(:post, "#{Stripe.api_base}/v1/charges").
-          with(headers: {"Idempotency-Key" => "provided_key"}).
-          to_return(body: JSON.generate(make_charge))
-
-        Stripe::Charge.create({:amount => 50, :currency => 'usd', :card => { :number => nil }}, {:idempotency_key => 'provided_key'})
-      end
-
-    end
-
-    context ".should_retry?" do
-      setup do
-        Stripe.stubs(:max_network_retries).returns(2)
-      end
-
-      should 'retry on timeout' do
-        assert Stripe.should_retry?(Faraday::TimeoutError.new(""), 0)
-      end
-
-      should 'retry on a failed connection' do
-        assert Stripe.should_retry?(Faraday::ConnectionFailed.new(""), 0)
-      end
-
-      should 'retry on a conflict' do
-        error = make_rate_limit_error
-        e = Faraday::ClientError.new(error[:error][:message], { status: 409 })
-        assert Stripe.should_retry?(e, 0)
-      end
-
-      should 'not retry at maximum count' do
-        refute Stripe.should_retry?(RuntimeError.new, Stripe.max_network_retries)
-      end
-
-      should 'not retry on a certificate validation error' do
-        refute Stripe.should_retry?(Faraday::SSLError.new(""), 0)
-      end
-    end
-
-    context ".sleep_time" do
-      should "should grow exponentially" do
-        Stripe.stubs(:rand).returns(1)
-        Stripe.stubs(:max_network_retry_delay).returns(999)
-        assert_equal(Stripe.initial_network_retry_delay, Stripe.sleep_time(1))
-        assert_equal(Stripe.initial_network_retry_delay * 2, Stripe.sleep_time(2))
-        assert_equal(Stripe.initial_network_retry_delay * 4, Stripe.sleep_time(3))
-        assert_equal(Stripe.initial_network_retry_delay * 8, Stripe.sleep_time(4))
-      end
-
-      should "enforce the max_network_retry_delay" do
-        Stripe.stubs(:rand).returns(1)
-        Stripe.stubs(:initial_network_retry_delay).returns(1)
-        Stripe.stubs(:max_network_retry_delay).returns(2)
-        assert_equal(1, Stripe.sleep_time(1))
-        assert_equal(2, Stripe.sleep_time(2))
-        assert_equal(2, Stripe.sleep_time(3))
-        assert_equal(2, Stripe.sleep_time(4))
-      end
-
-      should "add some randomness" do
-        random_value = 0.8
-        Stripe.stubs(:rand).returns(random_value)
-        Stripe.stubs(:initial_network_retry_delay).returns(1)
-        Stripe.stubs(:max_network_retry_delay).returns(8)
-
-        base_value = Stripe.initial_network_retry_delay * (0.5 * (1 + random_value))
-
-        # the initial value cannot be smaller than the base,
-        # so the randomness is ignored
-        assert_equal(Stripe.initial_network_retry_delay, Stripe.sleep_time(1))
-
-        # after the first one, the randomness is applied
-        assert_equal(base_value * 2, Stripe.sleep_time(2))
-        assert_equal(base_value * 4, Stripe.sleep_time(3))
-        assert_equal(base_value * 8, Stripe.sleep_time(4))
       end
     end
   end

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -7,10 +7,10 @@ module Stripe
         e = StripeError.new("message")
         assert_equal "message", e.to_s
 
-        e = StripeError.new("message", 200)
+        e = StripeError.new("message", http_status: 200)
         assert_equal "(Status 200) message", e.to_s
 
-        e = StripeError.new("message", nil, nil, nil, { :request_id => "request-id" })
+        e = StripeError.new("message", http_status: nil, http_body: nil, json_body: nil, http_headers: { :request_id => "request-id" })
         assert_equal "(Request request-id) message", e.to_s
       end
     end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -25,6 +25,15 @@ module Stripe
       should "be a Faraday::Connection" do
         assert_kind_of Faraday::Connection, StripeClient.default_conn
       end
+
+      should "be a different connection on each thread" do
+        other_thread_conn = nil
+        thread = Thread.new do
+          other_thread_conn = StripeClient.default_conn
+        end
+        thread.join
+        refute_equal StripeClient.default_conn, other_thread_conn
+      end
     end
 
     context ".should_retry?" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -108,6 +108,30 @@ module Stripe
     end
 
     context "#execute_request" do
+      context "headers" do
+        should "support literal headers" do
+          stub_request(:post, "#{Stripe.api_base}/v1/account").
+            with(headers: { "Stripe-Account" => "bar" }).
+            to_return(body: JSON.generate(make_account))
+
+          client = StripeClient.new
+          client.execute_request(:post, '/v1/account',
+            headers: { "Stripe-Account" => "bar" }
+          )
+        end
+
+        should "support RestClient-style header keys" do
+          stub_request(:post, "#{Stripe.api_base}/v1/account").
+            with(headers: { "Stripe-Account" => "bar" }).
+            to_return(body: JSON.generate(make_account))
+
+          client = StripeClient.new
+          client.execute_request(:post, '/v1/account',
+            headers: { :stripe_account => "bar" }
+          )
+        end
+      end
+
       context "Stripe-Account header" do
         should "use a globally set header" do
           Stripe.stripe_account = 'acct_1234'

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1,0 +1,49 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class StripeClientTest < Test::Unit::TestCase
+    context "#initialize" do
+      should "set Stripe.default_conn" do
+        client = StripeClient.new
+        assert_equal Stripe.default_conn, client.conn
+      end
+
+      should "set a different connection if one was specified" do
+        conn = Faraday.new
+        client = StripeClient.new(conn)
+        assert_equal conn, client.conn
+      end
+    end
+
+    context "#request" do
+      should "return a result and response object" do
+        stub_request(:post, "#{Stripe.api_base}/v1/charges").
+          to_return(body: JSON.generate(make_charge))
+
+        client = StripeClient.new
+        charge, resp = client.request { Charge.create }
+
+        assert charge.is_a?(Charge)
+        assert resp.is_a?(StripeResponse)
+        assert_equal 200, resp.http_status
+      end
+
+      should "return the value of given block" do
+        client = StripeClient.new
+        ret, _ = client.request { 7 }
+        assert_equal 7, ret
+      end
+
+      should "reset local thread state after a call" do
+        Thread.current[:stripe_client] = :stripe_client
+        Thread.current[:stripe_last_response] = :stripe_last_response
+
+        client = StripeClient.new
+        client.request {}
+
+        assert_equal :stripe_client, Thread.current[:stripe_client]
+        assert_equal :stripe_last_response, Thread.current[:stripe_last_response]
+      end
+    end
+  end
+end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -2,16 +2,54 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class StripeClientTest < Test::Unit::TestCase
+    context ".active_client" do
+      should "be .default_client outside of #request" do
+        assert_equal StripeClient.default_client, StripeClient.active_client
+      end
+
+      should "be active client inside of #request" do
+        client = StripeClient.new
+        client.request do
+          assert_equal client, StripeClient.active_client
+        end
+      end
+    end
+
+    context ".default_client" do
+      should "be a StripeClient" do
+        assert_kind_of StripeClient, StripeClient.default_client
+      end
+    end
+
+    context ".default_conn" do
+      should "be a Faraday::Connection" do
+        assert_kind_of Faraday::Connection, StripeClient.default_conn
+      end
+    end
+
     context "#initialize" do
       should "set Stripe.default_conn" do
         client = StripeClient.new
-        assert_equal Stripe.default_conn, client.conn
+        assert_equal StripeClient.default_conn, client.conn
       end
 
       should "set a different connection if one was specified" do
         conn = Faraday.new
         client = StripeClient.new(conn)
         assert_equal conn, client.conn
+      end
+    end
+
+    context "#execute_request" do
+      should "makes requests with the Stripe-Account header" do
+        Stripe.stripe_account = 'acct_1234'
+
+        stub_request(:post, "#{Stripe.api_base}/v1/account").
+          with(headers: {"Stripe-Account" => Stripe.stripe_account}).
+          to_return(body: JSON.generate(make_account))
+
+        client = StripeClient.new
+        client.execute_request(:post, '/v1/account', 'sk_live12334566', {}, {}, nil)
       end
     end
 
@@ -35,14 +73,41 @@ module Stripe
       end
 
       should "reset local thread state after a call" do
-        Thread.current[:stripe_client] = :stripe_client
-        Thread.current[:stripe_last_response] = :stripe_last_response
+        begin
+          Thread.current[:stripe_client] = :stripe_client
 
-        client = StripeClient.new
-        client.request {}
+          client = StripeClient.new
+          client.request {}
 
-        assert_equal :stripe_client, Thread.current[:stripe_client]
-        assert_equal :stripe_last_response, Thread.current[:stripe_last_response]
+          assert_equal :stripe_client, Thread.current[:stripe_client]
+        ensure
+          Thread.current[:stripe_client] = nil
+        end
+      end
+    end
+  end
+
+  class SystemProfilerTest < Test::Unit::TestCase
+    context "#get_uname" do
+      should "run without failure" do
+        # Don't actually check the result because we try a variety of different
+        # strategies that will have different results depending on where this
+        # test and running. We're mostly making sure that no exception is thrown.
+        _ = StripeClient::SystemProfiler.get_uname
+      end
+    end
+
+    context "#get_uname_from_system" do
+      should "run without failure" do
+        # as above, just verify that an exception is not thrown
+        _ = StripeClient::SystemProfiler.get_uname_from_system
+      end
+    end
+
+    context "#get_uname_from_system_ver" do
+      should "run without failure" do
+        # as above, just verify that an exception is not thrown
+        _ = StripeClient::SystemProfiler.get_uname_from_system_ver
       end
     end
   end

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class StripeResponseTest < Test::Unit::TestCase
+    context ".from_rest_client_response" do
+      should "converts to StripeResponse" do
+        body = '{"foo": "bar"}'
+        headers = { :request_id => "request-id" }
+
+        http_resp = make_response(body, 200, headers: headers)
+        resp = StripeResponse.from_rest_client_response(http_resp)
+
+        assert_equal JSON.parse(body, symbolize_names: true), resp.data
+        assert_equal body, resp.http_body
+        assert_equal headers, resp.http_headers
+        assert_equal 200, resp.http_status
+        assert_equal "request-id", resp.request_id
+      end
+    end
+  end
+end

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -2,12 +2,36 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class StripeResponseTest < Test::Unit::TestCase
+    context ".from_faraday_hash" do
+      should "converts to StripeResponse" do
+        body = '{"foo": "bar"}'
+        headers = { "Request-Id" => "request-id" }
+
+        http_resp = {
+          body: body,
+          headers: headers,
+          status: 200,
+        }
+
+        resp = StripeResponse.from_faraday_hash(http_resp)
+
+        assert_equal JSON.parse(body, symbolize_names: true), resp.data
+        assert_equal body, resp.http_body
+        assert_equal headers, resp.http_headers
+        assert_equal 200, resp.http_status
+        assert_equal "request-id", resp.request_id
+      end
+    end
     context ".from_faraday_response" do
       should "converts to StripeResponse" do
         body = '{"foo": "bar"}'
-        headers = { :request_id => "request-id" }
+        headers = { "Request-Id" => "request-id" }
 
-        http_resp = make_response(body, 200, headers: headers)
+        env = Faraday::Env.from(
+          :status => 200, :body => body,
+          :response_headers => headers)
+        http_resp = Faraday::Response.new(env)
+
         resp = StripeResponse.from_faraday_response(http_resp)
 
         assert_equal JSON.parse(body, symbolize_names: true), resp.data

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -22,6 +22,7 @@ module Stripe
         assert_equal "request-id", resp.request_id
       end
     end
+
     context ".from_faraday_response" do
       should "converts to StripeResponse" do
         body = '{"foo": "bar"}'

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -2,13 +2,13 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class StripeResponseTest < Test::Unit::TestCase
-    context ".from_rest_client_response" do
+    context ".from_faraday_response" do
       should "converts to StripeResponse" do
         body = '{"foo": "bar"}'
         headers = { :request_id => "request-id" }
 
         http_resp = make_response(body, 200, headers: headers)
-        resp = StripeResponse.from_rest_client_response(http_resp)
+        resp = StripeResponse.from_faraday_response(http_resp)
 
         assert_equal JSON.parse(body, symbolize_names: true), resp.data
         assert_equal body, resp.http_body

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -142,6 +142,24 @@ module Stripe
       assert_equal [1, 2, 3], obj
     end
 
+    should "#convert_to_stripe_object should add a response to APIResource" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :object => "account" }, {}, response: resp)
+      assert_equal resp, obj.response
+    end
+
+    should "#convert_to_stripe_object should add a response to ListObject" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :object => "list" }, {}, response: resp)
+      assert_equal resp, obj.response
+    end
+
+    should "#convert_to_stripe_object should not add a response to other types" do
+      resp = StripeResponse.new
+      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {}, response: resp)
+      refute obj.respond_to?(:response)
+    end
+
     should "#array_to_hash should convert an array into a hash with integer keys" do
       assert_equal({"0" => 1, "1" => 2, "2" => 3}, Util.array_to_hash([1, 2, 3]))
     end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -142,24 +142,6 @@ module Stripe
       assert_equal [1, 2, 3], obj
     end
 
-    should "#convert_to_stripe_object should add a response to APIResource" do
-      resp = StripeResponse.new
-      obj = Util.convert_to_stripe_object({ :object => "account" }, {}, response: resp)
-      assert_equal resp, obj.response
-    end
-
-    should "#convert_to_stripe_object should add a response to ListObject" do
-      resp = StripeResponse.new
-      obj = Util.convert_to_stripe_object({ :object => "list" }, {}, response: resp)
-      assert_equal resp, obj.response
-    end
-
-    should "#convert_to_stripe_object should not add a response to other types" do
-      resp = StripeResponse.new
-      obj = Util.convert_to_stripe_object({ :foo => "bar" }, {}, response: resp)
-      refute obj.respond_to?(:response)
-    end
-
     should "#array_to_hash should convert an array into a hash with integer keys" do
       assert_equal({"0" => 1, "1" => 2, "2" => 3}, Util.array_to_hash([1, 2, 3]))
     end

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -33,37 +33,4 @@ class StripeTest < Test::Unit::TestCase
       Stripe.max_network_retries = old
     end
   end
-
-  should "makes requests with the Stripe-Account header" do
-    Stripe.stripe_account = 'acct_1234'
-
-    stub_request(:post, "#{Stripe.api_base}/v1/account").
-      with(headers: {"Stripe-Account" => Stripe.stripe_account}).
-      to_return(body: JSON.generate(make_account))
-
-    Stripe.request(Stripe.default_conn, :post, '/v1/account', 'sk_live12334566', {}, {}, nil)
-  end
-
-  context "#get_uname" do
-    should "run without failure" do
-      # Don't actually check the result because we try a variety of different
-      # strategies that will have different results depending on where this
-      # test and running. We're mostly making sure that no exception is thrown.
-      _ = Stripe.get_uname
-    end
-  end
-
-  context "#get_uname_from_system" do
-    should "run without failure" do
-      # as above, just verify that an exception is not thrown
-      _ = Stripe.get_uname_from_system
-    end
-  end
-
-  context "#get_uname_from_system_ver" do
-    should "run without failure" do
-      # as above, just verify that an exception is not thrown
-      _ = Stripe.get_uname_from_system_ver
-    end
-  end
 end

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -33,4 +33,9 @@ class StripeTest < Test::Unit::TestCase
       Stripe.max_network_retries = old
     end
   end
+
+  should "have default open and read timeouts" do
+    assert_equal Stripe.open_timeout, 30
+    assert_equal Stripe.read_timeout, 80
+  end
 end

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -41,7 +41,7 @@ class StripeTest < Test::Unit::TestCase
       with(headers: {"Stripe-Account" => Stripe.stripe_account}).
       to_return(body: JSON.generate(make_account))
 
-    Stripe.request(:post, '/v1/account', 'sk_live12334566')
+    Stripe.request(Stripe.default_conn, :post, '/v1/account', 'sk_live12334566', {}, {}, nil)
   end
 
   context "#get_uname" do

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -512,6 +512,15 @@ module Stripe
       }
     end
 
+    def make_error(type, message)
+      {
+        :error => {
+          :type => type,
+          :message => message,
+        }
+      }
+    end
+
     def make_invalid_api_key_error
       {
         :error => {


### PR DESCRIPTION
Replaces #492 in that this is largely a scheme to make response information available in HTTP calls (as requested in #484), but also opens up the project's guts and bolts on a configurable HTTP client (as requested in #313).

Rather than patching a response onto an API resource as see in #492, we instead use a slightly better approach by getting one through an invocation on a new class call `StripeClient`:

``` ruby
client = StripeClient.new
charge, resp = client.request { Charge.create }
resp.request_id # access request ID even on success!
```

`StripeClient` also provides the primitive that allows an HTTP client to be configured. Connection objects should always be a Faraday connection, but Faraday supports pretty much all the implementations that people will want to use. An example invocation:

``` ruby
conn = Faraday.new do |faraday|
  faraday.adapter :excon
end
client = StripeClient.new(conn)
charge, resp = client.request { Charge.create }
```

By default it uses `Net::HTTP` so that we still only need a single runtime dependency (i.e. now Faraday where it used to be RestClient).

This is probably not exactly the interface I would've used on a green field project, but I like the approach because it maintains 100% backwards compatibility, while also allowing us to move forward with a few new features. It also starts moving away from using globals all over the place, instead preferring instantiated HTTP clients.

Fixes #313.
Fixes #484.

---

~~This is mostly done interface-wise, but I'm still refactoring a bit because I think we can do a better job of the implementation by removing some of the poorly considered methods on `Stripe` and dependency on local thread storage.~~ It's done now.

~~Note that I'm currently targeting the branch in #496 because I needed to have Webmock into the test suite for any of it to work with Faraday.~~