### PR TITLE
Retry on stripe outages

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -435,7 +435,10 @@ module Stripe
 
   def self.should_retry?(e, retry_count)
     retry_count < self.max_network_retries &&
-      RETRY_EXCEPTIONS.any? { |klass| e.is_a?(klass) }
+      (
+        RETRY_EXCEPTIONS.any? { |klass| e.is_a?(klass) } ||
+        (e.is_a?(RestClient::ExceptionWithResponse) && e.response.include?('Error while communicating with one of our backends.'))
+      )
   end
 
   def self.sleep_time(retry_count)


### PR DESCRIPTION
Hello! I'm running into a situation where iterating over all large numbers of transactions is causing the following error:

```
Error while communicating with one of our backends.  Sorry about that!  We have been notified of the problem.  If you have any questions, we can help at https://support.stripe.com/. (Stripe::APIError)
```

I'm using `auto_paging_each`, when this error occurs during the paging loop my paging position is lost and I need to completely re-run the operation. 

What do you think about auto-retrying on Stripe API outages? This PR is a quick-and-dirty example of how this could be handled.