### PR TITLE
Properly encode file uploads

### DIFF
--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -15,6 +15,13 @@ module Stripe
     end
 
     def self.create(params={}, opts={})
+      # rest-client would accept a vanilla `File` for upload, but Faraday does
+      # not. Support the old API by wrapping a `File` with an `UploadIO` object
+      # if we're given one.
+      if params[:file] && params[:file].is_a?(File)
+        params[:file] = Faraday::UploadIO.new(params[:file], nil)
+      end
+
       opts = {
         :content_type => 'multipart/form-data',
       }.merge(Util.normalize_opts(opts))

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -29,6 +29,7 @@ module Stripe
       # object per thread.
       Thread.current[:stripe_client_default_conn] ||= begin
         conn = Faraday.new do |c|
+          c.use Faraday::Request::Multipart
           c.use Faraday::Request::UrlEncoded
           c.use Faraday::Response::RaiseError
           c.adapter Faraday.default_adapter

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -35,11 +35,30 @@ module Stripe
 
     should "be creatable" do
       stub_request(:post, "#{Stripe.uploads_base}/v1/files").
-        to_return(body: JSON.generate(FIXTURE))
+        with(:headers => {
+          "Content-Type" => %r|\A#{Faraday::Request::Multipart.mime_type}|
+        }) { |request|
+          request.body =~ /FileUploadTest/
+        }.to_return(body: JSON.generate(FIXTURE))
 
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
         file: File.new(__FILE__),
+      )
+      assert file.kind_of?(Stripe::FileUpload)
+    end
+
+    should "be creatable with Faraday::UploadIO" do
+      stub_request(:post, "#{Stripe.uploads_base}/v1/files").
+        with(:headers => {
+          "Content-Type" => %r|\A#{Faraday::Request::Multipart.mime_type}|
+        }) { |request|
+          request.body =~ /FileUploadTest/
+        }.to_return(body: JSON.generate(FIXTURE))
+
+      file = Stripe::FileUpload.create(
+        purpose: "dispute_evidence",
+        file: Faraday::UploadIO.new(File.new(__FILE__), nil),
       )
       assert file.kind_of?(Stripe::FileUpload)
     end


### PR DESCRIPTION
As described in #506, file uploads were broken on the way over to
Faraday and unfortunately I didn't catch it because the file upload
creation test wasn't using a matcher that was strict enough to really
catch anything.

Here we add the multipart middleware to our Faraday connection, add a
compatibility layer to `FileUpload` so that we can support `File` like
the rest-client based version always did (Faraday generally expects an
`UploadIO` object), and then tighten up our tests so that we'd be able
to catch future regressions.

Fixes #506.

r? @ob-stripe Mind taking a look at this one? Thanks!