### PR TITLE
Bump OpenAPI spec to latest

### DIFF
--- a/spec/fixtures.json
+++ b/spec/fixtures.json
@@ -19,7 +19,7 @@
     "default_currency": "usd",
     "details_submitted": false,
     "display_name": "",
-    "email": "foo+bnklon35vv@example.com",
+    "email": "foo+hfdp1ea29h@example.com",
     "external_accounts": {
       "data": [
 
@@ -27,10 +27,10 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/accounts/acct_19mq3gAXZ0PAB0qu/external_accounts"
+      "url": "/v1/accounts/acct_19qYWjAmUcJIthQ8/external_accounts"
     },
     "fake_account": false,
-    "id": "acct_19mq3gAXZ0PAB0qu",
+    "id": "acct_19qYWjAmUcJIthQ8",
     "legal_entity": {
       "additional_owners": null,
       "address": {
@@ -138,11 +138,11 @@
     "default_currency": "usd",
     "details_submitted": false,
     "display_name": "",
-    "email": "foo+bnklon35vv@example.com",
+    "email": "foo+hfdp1ea29h@example.com",
     "external_accounts": {
     },
     "fake_account": false,
-    "id": "acct_19mq3gAXZ0PAB0qu",
+    "id": "acct_19qYWjAmUcJIthQ8",
     "keys": {
     },
     "legal_entity": {
@@ -177,8 +177,8 @@
   "alipay_account": {
     "created": 1234567890,
     "customer": "",
-    "fingerprint": "b6kmmo2KDWmL6NnE",
-    "id": "aliacc_19mq3pAXZ0PAB0qutSJIFvG1",
+    "fingerprint": "wEUjqjvF4BeRenzq",
+    "id": "aliacc_19qYWoAmUcJIthQ86rdK7f78",
     "livemode": false,
     "metadata": {
     },
@@ -192,7 +192,7 @@
   "apple_pay_domain": {
     "created": 1234567890,
     "domain_name": "example.com",
-    "id": "apwc_19mq3lAXZ0PAB0qutk0Bbilz",
+    "id": "apwc_19qYWoAmUcJIthQ8aaWwMxUd",
     "livemode": true,
     "object": "apple_pay_domain"
   },
@@ -233,14 +233,42 @@
     "fee_details": [
 
     ],
-    "id": "txn_19mq3mAXZ0PAB0quuB601NdX",
+    "id": "txn_19qYWoAmUcJIthQ8nkS84OrS",
     "net": 100,
     "object": "balance_transaction",
-    "source": "ch_19mq3mAXZ0PAB0quafODEaTb",
+    "source": "ch_19qYWoAmUcJIthQ8bXdOlg7i",
     "sourced_transfers": {
     },
     "status": "pending",
     "type": "charge"
+  },
+  "bank_account": {
+    "account": "acct_19qYWjAmUcJIthQ8",
+    "account_holder_name": "Jane Austen",
+    "account_holder_type": "individual",
+    "address_city": "",
+    "address_line1": "",
+    "address_line2": "",
+    "address_state": "",
+    "address_zip": "",
+    "allows_debits": false,
+    "bank_name": "STRIPE TEST BANK",
+    "bank_phone_number": "",
+    "country": "US",
+    "currency": "usd",
+    "customer": "",
+    "customer_reference": "",
+    "default_for_currency": false,
+    "fingerprint": "Uv372FI5KdaHdZhl",
+    "id": "ba_19qYWoAmUcJIthQ8yfohLr7y",
+    "last4": "6789",
+    "metadata": {
+    },
+    "object": "bank_account",
+    "reusable": false,
+    "routing_number": "110000000",
+    "status": "new",
+    "used": false
   },
   "bitcoin_receiver": {
     "active": false,
@@ -255,7 +283,7 @@
     "description": "Receiver for John Doe",
     "email": "test@example.com",
     "filled": false,
-    "id": "btcrcv_19mq3pAXZ0PAB0quysC4SOJn",
+    "id": "btcrcv_19qYWoAmUcJIthQ8GNgZ61HT",
     "inbound_address": "test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1",
     "livemode": false,
     "metadata": {
@@ -273,9 +301,52 @@
     "bitcoin_amount": 1757908,
     "created": 1234567890,
     "currency": "usd",
-    "id": "btctxn_19mq3pAXZ0PAB0quo4NMSQ1P",
+    "id": "btctxn_19qYWoAmUcJIthQ85oxOPgem",
     "object": "bitcoin_transaction",
-    "receiver": "btcrcv_19mq3pBFZK1NInhS7HqQ8daC"
+    "receiver": "btcrcv_19qYWoBKPgWF2WHuRAP2vIic"
+  },
+  "card": {
+    "3d_secure": {
+    },
+    "account": "",
+    "address_city": "",
+    "address_country": "",
+    "address_line1": "",
+    "address_line1_check": "",
+    "address_line2": "",
+    "address_state": "",
+    "address_zip": "",
+    "address_zip_check": "",
+    "available_payout_methods": [
+
+    ],
+    "brand": "Visa",
+    "country": "",
+    "currency": "",
+    "customer": "",
+    "cvc_check": "",
+    "default_for_currency": false,
+    "description": "",
+    "dynamic_last4": "",
+    "emv_auth_data": "",
+    "estimated_availability": "",
+    "exp_month": 8,
+    "exp_year": 2018,
+    "fingerprint": "",
+    "funding": "unknown",
+    "google_reference": "",
+    "id": "card_19qYWoAmUcJIthQ8t6Dm5Ol6",
+    "iin": "",
+    "issuer": "",
+    "last4": "4242",
+    "metadata": {
+    },
+    "name": "",
+    "object": "card",
+    "recipient": "",
+    "three_d_secure": {
+    },
+    "tokenization_method": ""
   },
   "charge": {
     "alternate_statement_descriptors": {
@@ -288,7 +359,7 @@
     "application_fee": "",
     "application_fees_refunded": 0,
     "authorization_code": "",
-    "balance_transaction": "txn_19mq3mAXZ0PAB0quuB601NdX",
+    "balance_transaction": "txn_19qYWoAmUcJIthQ8nkS84OrS",
     "captured": true,
     "card": {
     },
@@ -304,7 +375,7 @@
     },
     "fraud_details": {
     },
-    "id": "ch_19mq3mAXZ0PAB0quafODEaTb",
+    "id": "ch_19qYWoAmUcJIthQ8bXdOlg7i",
     "invoice": "",
     "level3": {
     },
@@ -327,7 +398,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/charges/ch_19mq3mAXZ0PAB0quafODEaTb/refunds"
+      "url": "/v1/charges/ch_19qYWoAmUcJIthQ8bXdOlg7i/refunds"
     },
     "review": "",
     "shipping": {
@@ -349,7 +420,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19mq3lAXZ0PAB0quo1Fi4kuG",
+      "id": "card_19qYWoAmUcJIthQ8t6Dm5Ol6",
       "last4": "4242",
       "metadata": {
       },
@@ -443,7 +514,7 @@
     "discount": {
     },
     "email": "",
-    "id": "cus_A74CGlAc6Xc9o8",
+    "id": "cus_AAuLxPuOFN7Ull",
     "livemode": false,
     "metadata": {
     },
@@ -457,24 +528,18 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/customers/cus_A74CGlAc6Xc9o8/sources"
+      "url": "/v1/customers/cus_AAuLxPuOFN7Ull/sources"
     },
     "subscription": {
     },
     "subscriptions": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/customers/cus_A74CGlAc6Xc9o8/subscriptions"
     },
     "trust": {
     }
   },
   "customer_source": {
-    "id": "ba_19mq3pAXZ0PAB0que2xYqubF",
+    "customer": "",
+    "id": "ba_19qYWoAmUcJIthQ8yfohLr7y",
     "metadata": {
     },
     "object": "bank_account"
@@ -482,7 +547,7 @@
   "discount": {
     "coupon": {
       "amount_off": null,
-      "created": 1487016273,
+      "created": 1487902190,
       "currency": "usd",
       "duration": "repeating",
       "duration_in_months": 3,
@@ -497,7 +562,7 @@
       "times_redeemed": 0,
       "valid": true
     },
-    "customer": "cus_A74CGlAc6Xc9o8",
+    "customer": "cus_AAuLxPuOFN7Ull",
     "end": 1234567890,
     "object": "discount",
     "start": 1234567890,
@@ -510,7 +575,7 @@
     "balance_transactions": [
 
     ],
-    "charge": "ch_19mq3mAXZ0PAB0quafODEaTb",
+    "charge": "ch_19qYWoAmUcJIthQ8bXdOlg7i",
     "closed_at": 1234567890,
     "created": 1234567890,
     "currency": "usd",
@@ -545,7 +610,7 @@
       "uncategorized_text": null
     },
     "evidence_details": {
-      "due_by": 1488671999,
+      "due_by": 1489622399,
       "has_evidence": false,
       "past_due": false,
       "submission_count": 0
@@ -553,7 +618,7 @@
     "evidence_submitted_at": [
 
     ],
-    "id": "dp_19mq3nAXZ0PAB0quWfu875gB",
+    "id": "dp_19qYWoAmUcJIthQ8hiQKRidU",
     "is_charge_refundable": false,
     "is_protected": false,
     "livemode": false,
@@ -571,7 +636,7 @@
     "data": {
       "object": {
         "amount": 2000,
-        "created": 1487016273,
+        "created": 1487902190,
         "currency": "usd",
         "id": "gold",
         "interval": "month",
@@ -585,7 +650,7 @@
         "trial_period_days": null
       }
     },
-    "id": "evt_19mq3pAXZ0PAB0qutMlKV6c3",
+    "id": "evt_19qYWpAmUcJIthQ8flpeC3A6",
     "livemode": false,
     "object": "event",
     "pending_webhooks": 0,
@@ -594,7 +659,7 @@
     "type": "plan.created"
   },
   "external_account_source": {
-    "account": "acct_19mq3gAXZ0PAB0qu",
+    "account": "acct_19qYWjAmUcJIthQ8",
     "address_city": "",
     "address_line1": "",
     "address_line2": "",
@@ -602,9 +667,10 @@
     "address_zip": "",
     "country": "US",
     "currency": "usd",
+    "customer": "",
     "default_for_currency": false,
-    "fingerprint": "d23J1TFOicgP64nb",
-    "id": "ba_19mq3pAXZ0PAB0que2xYqubF",
+    "fingerprint": "Uv372FI5KdaHdZhl",
+    "id": "ba_19qYWoAmUcJIthQ8yfohLr7y",
     "last4": "6789",
     "metadata": {
     },
@@ -615,8 +681,8 @@
     "balance_transaction": "",
     "created": 1234567890,
     "currency": "usd",
-    "fee": "fee_19mq3pAXZ0PAB0quKLPknTXJ",
-    "id": "fr_A74Ce1Bh7Kr6UC",
+    "fee": "fee_19qYWoAmUcJIthQ81JzKWcmc",
+    "id": "fr_AAuLnHfz4zsfMV",
     "metadata": {
     },
     "object": "fee_refund"
@@ -630,7 +696,7 @@
     "charge": "",
     "closed": false,
     "currency": "usd",
-    "customer": "cus_A74CGlAc6Xc9o8",
+    "customer": "cus_AAuLxPuOFN7Ull",
     "date": 1234567890,
     "description": "",
     "discount": {
@@ -638,7 +704,7 @@
     "due_date": 1234567890,
     "ending_balance": 0,
     "forgiven": false,
-    "id": "in_19mq3pAXZ0PAB0qupydNkllt",
+    "id": "in_19qYWoAmUcJIthQ8mMavVKyP",
     "lines": {
       "data": [
         {
@@ -646,18 +712,18 @@
           "currency": "usd",
           "description": null,
           "discountable": true,
-          "id": "sub_A74CDfuKRtyn06",
+          "id": "sub_AAuLAT8thsFpDe",
           "livemode": true,
           "metadata": {
           },
           "object": "line_item",
           "period": {
-            "end": 1492113872,
-            "start": 1489435472
+            "end": 1492999790,
+            "start": 1490321390
           },
           "plan": {
             "amount": 2000,
-            "created": 1487016273,
+            "created": 1487902190,
             "currency": "usd",
             "id": "gold",
             "interval": "month",
@@ -673,13 +739,13 @@
           "proration": false,
           "quantity": 1,
           "subscription": null,
-          "subscription_item": "si_19mq3oBFZK1NInhSuSpw3kRl",
+          "subscription_item": "si_19qYWoBKPgWF2WHuVSwKNUvS",
           "type": "subscription"
         }
       ],
       "object": "list",
       "total_count": 1,
-      "url": "/v1/invoices/in_19mq3pAXZ0PAB0qupydNkllt/lines"
+      "url": "/v1/invoices/in_19qYWoAmUcJIthQ8mMavVKyP/lines"
     },
     "livemode": false,
     "metadata": {
@@ -704,19 +770,19 @@
   "invoice_item": {
     "amount": 1000,
     "currency": "usd",
-    "customer": "cus_A74CGlAc6Xc9o8",
+    "customer": "cus_AAuLxPuOFN7Ull",
     "date": 1234567890,
     "description": "My First Invoice Item (created for API docs)",
     "discountable": true,
-    "id": "ii_19mq3pAXZ0PAB0quXd6LJkwP",
+    "id": "ii_19qYWoAmUcJIthQ8V8c0aOsd",
     "invoice": "",
     "livemode": false,
     "metadata": {
     },
     "object": "invoiceitem",
     "period": {
-      "end": 1487016273,
-      "start": 1487016273
+      "end": 1487902190,
+      "start": 1487902190
     },
     "plan": {
     },
@@ -730,14 +796,14 @@
     "currency": "usd",
     "description": "My First Invoice Item (created for API docs)",
     "discountable": true,
-    "id": "ii_19mq3pAXZ0PAB0quXd6LJkwP",
+    "id": "ii_19qYWoAmUcJIthQ8V8c0aOsd",
     "livemode": false,
     "metadata": {
     },
     "object": "line_item",
     "period": {
-      "end": 1487016273,
-      "start": 1487016273
+      "end": 1487902190,
+      "start": 1487902190
     },
     "plan": {
     },
@@ -762,18 +828,18 @@
     "date": 1234567890,
     "delay_reason": "",
     "description": "Transfer to test@example.com",
-    "destination": "ba_19mq3pAXZ0PAB0qurDV9Avlb",
+    "destination": "ba_19qYWoAmUcJIthQ8qTr0A9Em",
     "destination_payment": "",
     "failure_code": "",
     "failure_message": "",
-    "id": "tr_19mq3pAXZ0PAB0qubIKTrixZ",
+    "id": "tr_19qYWoAmUcJIthQ88M6TcLVT",
     "legacy_date": 1234567890,
     "livemode": false,
     "metadata": {
     },
     "method": "standard",
     "object": "transfer",
-    "recipient": "rp_19mq3pAXZ0PAB0quySWBNl2v",
+    "recipient": "",
     "reversals": {
       "data": [
 
@@ -781,7 +847,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/transfers/tr_19mq3pAXZ0PAB0qubIKTrixZ/reversals"
+      "url": "/v1/transfers/tr_19qYWoAmUcJIthQ88M6TcLVT/reversals"
     },
     "reversed": false,
     "source_transaction": "",
@@ -806,14 +872,14 @@
     "external_sku_ids": [
 
     ],
-    "id": "or_19mq3qAXZ0PAB0qua7xjbAdc",
+    "id": "or_19qYWpAmUcJIthQ8qyjYeMOA",
     "items": [
       {
         "amount": 1500,
         "currency": "usd",
         "description": "T-shirt",
         "object": "order_item",
-        "parent": "sk_19mq3qAXZ0PAB0quLkoPCkNK",
+        "parent": "sk_19qYWpAmUcJIthQ81nFJf7oq",
         "quantity": null,
         "type": "sku"
       }
@@ -829,7 +895,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/order_returns?order=or_19mq3qAXZ0PAB0qua7xjbAdc"
+      "url": "/v1/order_returns?order=or_19qYWpAmUcJIthQ8qyjYeMOA"
     },
     "selected_shipping_method": "",
     "shipping": {
@@ -859,82 +925,22 @@
     "amount": 1500,
     "created": 1234567890,
     "currency": "usd",
-    "id": "orret_19mq3qAXZ0PAB0qu32DCGDSQ",
+    "id": "orret_19qYWpAmUcJIthQ87Z2XSNB7",
     "items": [
       {
         "amount": 1500,
         "currency": "usd",
         "description": "T-shirt",
         "object": "order_item",
-        "parent": "sk_19mq3qAXZ0PAB0quLkoPCkNK",
+        "parent": "sk_19qYWpAmUcJIthQ81nFJf7oq",
         "quantity": null,
         "type": "sku"
       }
     ],
     "livemode": false,
     "object": "order_return",
-    "order": "or_19mq3qAXZ0PAB0qu1Sr0vNrE",
-    "refund": "re_19mq3qAXZ0PAB0qu9txUplQ2"
-  },
-  "payment_bank_account": {
-    "account_holder_name": "Jane Austen",
-    "account_holder_type": "individual",
-    "address_city": "",
-    "address_line1": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "bank_name": "STRIPE TEST BANK",
-    "bank_phone_number": "",
-    "country": "US",
-    "currency": "usd",
-    "customer": "",
-    "customer_reference": "",
-    "fingerprint": "d23J1TFOicgP64nb",
-    "id": "ba_19mq3pAXZ0PAB0que2xYqubF",
-    "last4": "6789",
-    "metadata": {
-    },
-    "object": "bank_account",
-    "reusable": false,
-    "routing_number": "110000000",
-    "status": "new",
-    "used": false
-  },
-  "payment_card": {
-    "3d_secure": {
-    },
-    "address_city": "",
-    "address_country": "",
-    "address_line1": "",
-    "address_line1_check": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "address_zip_check": "",
-    "brand": "",
-    "country": "",
-    "customer": "",
-    "cvc_check": "",
-    "description": "",
-    "dynamic_last4": "",
-    "emv_auth_data": "",
-    "exp_month": 0,
-    "exp_year": 0,
-    "fingerprint": "",
-    "funding": "",
-    "google_reference": "",
-    "id": "tok_19mq3pAXZ0PAB0qucG7ckr0s",
-    "iin": "",
-    "issuer": "",
-    "last4": "",
-    "metadata": {
-    },
-    "name": "",
-    "object": "token",
-    "three_d_secure": {
-    },
-    "tokenization_method": ""
+    "order": "or_19qYWpAmUcJIthQ8UTxcPzrC",
+    "refund": "re_19qYWpAmUcJIthQ8zCfRSInM"
   },
   "plan": {
     "amount": 2000,
@@ -952,15 +958,15 @@
     "trial_period_days": 0
   },
   "platform_earning": {
-    "account": "acct_19mq3gAXZ0PAB0qu",
+    "account": "acct_19qYWjAmUcJIthQ8",
     "amount": 100,
     "amount_refunded": 0,
-    "application": "ca_A74Cy7ZahkUTCBUvdzDMqtBz3n9zWjJw",
-    "balance_transaction": "txn_19mq3mAXZ0PAB0quuB601NdX",
-    "charge": "ch_19mq3mAXZ0PAB0quafODEaTb",
+    "application": "ca_AAuLq9yGtXXwqlznUKq6kGjBvQpnZj1R",
+    "balance_transaction": "txn_19qYWoAmUcJIthQ8nkS84OrS",
+    "charge": "ch_19qYWoAmUcJIthQ8bXdOlg7i",
     "created": 1234567890,
     "currency": "usd",
-    "id": "fee_19mq3pAXZ0PAB0quKLPknTXJ",
+    "id": "fee_19qYWoAmUcJIthQ81JzKWcmc",
     "livemode": false,
     "object": "application_fee",
     "originating_transaction": "",
@@ -972,7 +978,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/application_fees/fee_19mq3pAXZ0PAB0quKLPknTXJ/refunds"
+      "url": "/v1/application_fees/fee_19qYWoAmUcJIthQ81JzKWcmc/refunds"
     }
   },
   "product": {
@@ -988,7 +994,7 @@
     ],
     "description": "Comfortable gray cotton t-shirts",
     "donation": false,
-    "id": "prod_A74CjbvJG198EF",
+    "id": "prod_AAuLwRhYxnv0sx",
     "images": [
 
     ],
@@ -1008,55 +1014,22 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/skus?product=prod_A74CjbvJG198EF\u0026active=true"
+      "url": "/v1/skus?product=prod_AAuLwRhYxnv0sx\u0026active=true"
     },
     "tweetable_url": "",
     "updated": 1234567890,
     "url": ""
   },
-  "recipient_payout_card": {
-    "address_city": "",
-    "address_country": "",
-    "address_line1": "",
-    "address_line1_check": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "address_zip_check": "",
-    "brand": "",
-    "country": "",
-    "cvc_check": "",
-    "description": "",
-    "dynamic_last4": "",
-    "estimated_availability": "",
-    "exp_month": 0,
-    "exp_year": 0,
-    "fingerprint": "",
-    "funding": "",
-    "google_reference": "",
-    "id": "tok_19mq3pAXZ0PAB0qucG7ckr0s",
-    "iin": "",
-    "issuer": "",
-    "last4": "",
-    "metadata": {
-    },
-    "name": "",
-    "object": "token",
-    "recipient": "",
-    "three_d_secure": {
-    },
-    "tokenization_method": ""
-  },
   "refund": {
     "amount": 100,
     "balance_transaction": "",
-    "charge": "ch_19mq3mAXZ0PAB0quafODEaTb",
+    "charge": "ch_19qYWoAmUcJIthQ8bXdOlg7i",
     "created": 1234567890,
     "currency": "usd",
     "description": "",
     "fee_balance_transactions": {
     },
-    "id": "re_19mq3nAXZ0PAB0quqH5KQOit",
+    "id": "re_19qYWoAmUcJIthQ8cKkdY9yt",
     "metadata": {
     },
     "object": "refund",
@@ -1073,7 +1046,7 @@
     },
     "created": 1234567890,
     "currency": "usd",
-    "id": "sku_A74CaPnn1qmjb1",
+    "id": "sku_AAuLi9h04wg7cg",
     "image": "",
     "inventory": {
       "quantity": 50,
@@ -1087,7 +1060,7 @@
     "package_dimensions": {
     },
     "price": 1500,
-    "product": "prod_A74CjbvJG198EF",
+    "product": "prod_AAuLwRhYxnv0sx",
     "updated": 1234567890
   },
   "source": {
@@ -1099,7 +1072,7 @@
     "currency": "",
     "customer": "",
     "flow": "",
-    "id": "card_19mq3pAXZ0PAB0quryDGMYFl",
+    "id": "card_19qYWoAmUcJIthQ8t6Dm5Ol6",
     "livemode": false,
     "metadata": {
     },
@@ -1124,21 +1097,21 @@
     "created": 1234567890,
     "current_period_end": 1234567890,
     "current_period_start": 1234567890,
-    "customer": "cus_A74CD39bY4X367",
+    "customer": "cus_AAuLOB7WALx4Zo",
     "days_until_due": 0,
     "discount": {
     },
     "ended_at": 1234567890,
-    "id": "sub_A74CDfuKRtyn06",
+    "id": "sub_AAuLAT8thsFpDe",
     "items": {
       "data": [
         {
-          "created": 1487016273,
-          "id": "si_19mq3oBFZK1NInhSuSpw3kRl",
+          "created": 1487902191,
+          "id": "si_19qYWoBKPgWF2WHuVSwKNUvS",
           "object": "subscription_item",
           "plan": {
             "amount": 2000,
-            "created": 1487016272,
+            "created": 1487902190,
             "currency": "usd",
             "id": "gold",
             "interval": "month",
@@ -1157,7 +1130,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 1,
-      "url": "/v1/subscription_items?subscription=sub_A74CDfuKRtyn06"
+      "url": "/v1/subscription_items?subscription=sub_AAuLAT8thsFpDe"
     },
     "livemode": false,
     "max_occurrences": 0,
@@ -1166,7 +1139,7 @@
     "object": "subscription",
     "plan": {
       "amount": 2000,
-      "created": 1487016272,
+      "created": 1487902190,
       "currency": "usd",
       "id": "gold",
       "interval": "month",
@@ -1188,12 +1161,12 @@
     "trial_start": 1234567890
   },
   "subscription_item": {
-    "created": 1487016273,
-    "id": "si_19mq3oBFZK1NInhS3ZhhdFF8",
+    "created": 1487902191,
+    "id": "si_19qYWoBKPgWF2WHuFvY9YdCi",
     "object": "subscription_item",
     "plan": {
       "amount": 2000,
-      "created": 1487016272,
+      "created": 1487902190,
       "currency": "usd",
       "id": "gold",
       "interval": "month",
@@ -1228,7 +1201,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19mq3pAXZ0PAB0quryDGMYFl",
+      "id": "card_19qYWoAmUcJIthQ8yFmDKOnd",
       "last4": "4242",
       "metadata": {
       },
@@ -1238,10 +1211,10 @@
     },
     "created": 1234567890,
     "currency": "usd",
-    "id": "tdsrc_A74Cn8dTJLosfe",
+    "id": "tdsrc_AAuLnCzSLJVLB4",
     "livemode": false,
     "object": "three_d_secure",
-    "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_A74Cn8dTJLosfe",
+    "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AAuLnCzSLJVLB4",
     "status": "redirect_pending"
   },
   "token": {
@@ -1267,7 +1240,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19mq3pAXZ0PAB0quryDGMYFl",
+      "id": "card_19qYWoAmUcJIthQ8yFmDKOnd",
       "last4": "4242",
       "metadata": {
       },
@@ -1279,7 +1252,7 @@
     "created": 1234567890,
     "description": "",
     "email": "",
-    "id": "tok_19mq3pAXZ0PAB0qucG7ckr0s",
+    "id": "tok_19qYWoAmUcJIthQ8xAwoDoXA",
     "livemode": false,
     "object": "token",
     "type": "card",
@@ -1289,12 +1262,12 @@
   "transfer": {
     "amount": 1100,
     "amount_reversed": 0,
-    "balance_transaction": "txn_19mq3mAXZ0PAB0quuB601NdX",
+    "balance_transaction": "txn_19qYWoAmUcJIthQ8nkS84OrS",
     "created": 1234567890,
     "currency": "usd",
-    "destination": "ba_19mq3pAXZ0PAB0qurDV9Avlb",
+    "destination": "ba_19qYWoAmUcJIthQ8qTr0A9Em",
     "destination_payment": "",
-    "id": "tr_19mq3pAXZ0PAB0qubIKTrixZ",
+    "id": "tr_19qYWoAmUcJIthQ88M6TcLVT",
     "livemode": false,
     "metadata": {
     },
@@ -1306,7 +1279,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/transfers/tr_19mq3pAXZ0PAB0qubIKTrixZ/reversals"
+      "url": "/v1/transfers/tr_19qYWoAmUcJIthQ88M6TcLVT/reversals"
     },
     "reversed": false,
     "transfer_group": ""
@@ -1327,7 +1300,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/recipients/rp_19mq3pAXZ0PAB0quySWBNl2v/cards"
+      "url": "/v1/recipients/rp_19qYWoAmUcJIthQ8Xx4vHz7G/cards"
     },
     "country": "",
     "created": 1234567890,
@@ -1337,7 +1310,7 @@
     "dob_month": "",
     "dob_year": "",
     "email": "test@example.com",
-    "id": "rp_19mq3pAXZ0PAB0quySWBNl2v",
+    "id": "rp_19qYWoAmUcJIthQ8Xx4vHz7G",
     "livemode": false,
     "metadata": {
     },
@@ -1354,11 +1327,11 @@
     "balance_transaction": "",
     "created": 1234567890,
     "currency": "usd",
-    "id": "trr_19mq3pAXZ0PAB0quDwZdcrSt",
+    "id": "trr_19qYWoAmUcJIthQ8aCB1cCjt",
     "metadata": {
     },
     "object": "transfer_reversal",
-    "transfer": "tr_19mq3pAXZ0PAB0qubIKTrixZ"
+    "transfer": "tr_19qYWoAmUcJIthQ88M6TcLVT"
   },
   "upcoming_invoice": {
     "amount_due": 0,
@@ -1369,7 +1342,7 @@
     "charge": "",
     "closed": false,
     "currency": "usd",
-    "customer": "cus_A74CGlAc6Xc9o8",
+    "customer": "cus_AAuLxPuOFN7Ull",
     "date": 1234567890,
     "description": "",
     "discount": {
@@ -1384,7 +1357,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/invoices/in_19mq3pAXZ0PAB0qupydNkllt/lines"
+      "url": "/v1/invoices/in_19qYWoAmUcJIthQ8mMavVKyP/lines"
     },
     "livemode": false,
     "metadata": {

--- a/spec/fixtures.yaml
+++ b/spec/fixtures.yaml
@@ -15,15 +15,15 @@ account:
   default_currency: usd
   details_submitted: false
   display_name: ''
-  email: foo+bnklon35vv@example.com
+  email: foo+hfdp1ea29h@example.com
   external_accounts:
     data: []
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/accounts/acct_19mq3gAXZ0PAB0qu/external_accounts"
+    url: "/v1/accounts/acct_19qYWjAmUcJIthQ8/external_accounts"
   fake_account: false
-  id: acct_19mq3gAXZ0PAB0qu
+  id: acct_19qYWjAmUcJIthQ8
   legal_entity:
     additional_owners: 
     address:
@@ -113,10 +113,10 @@ account_with_keys:
   default_currency: usd
   details_submitted: false
   display_name: ''
-  email: foo+bnklon35vv@example.com
+  email: foo+hfdp1ea29h@example.com
   external_accounts: {}
   fake_account: false
-  id: acct_19mq3gAXZ0PAB0qu
+  id: acct_19qYWjAmUcJIthQ8
   keys: {}
   legal_entity: {}
   light: false
@@ -141,8 +141,8 @@ account_with_keys:
 alipay_account:
   created: 1234567890
   customer: ''
-  fingerprint: b6kmmo2KDWmL6NnE
-  id: aliacc_19mq3pAXZ0PAB0qutSJIFvG1
+  fingerprint: wEUjqjvF4BeRenzq
+  id: aliacc_19qYWoAmUcJIthQ86rdK7f78
   livemode: false
   metadata: {}
   object: alipay_account
@@ -154,7 +154,7 @@ alipay_account:
 apple_pay_domain:
   created: 1234567890
   domain_name: example.com
-  id: apwc_19mq3lAXZ0PAB0qutk0Bbilz
+  id: apwc_19qYWoAmUcJIthQ8aaWwMxUd
   livemode: true
   object: apple_pay_domain
 balance:
@@ -180,13 +180,39 @@ balance_transaction:
   description: ''
   fee: 0
   fee_details: []
-  id: txn_19mq3mAXZ0PAB0quuB601NdX
+  id: txn_19qYWoAmUcJIthQ8nkS84OrS
   net: 100
   object: balance_transaction
-  source: ch_19mq3mAXZ0PAB0quafODEaTb
+  source: ch_19qYWoAmUcJIthQ8bXdOlg7i
   sourced_transfers: {}
   status: pending
   type: charge
+bank_account:
+  account: acct_19qYWjAmUcJIthQ8
+  account_holder_name: Jane Austen
+  account_holder_type: individual
+  address_city: ''
+  address_line1: ''
+  address_line2: ''
+  address_state: ''
+  address_zip: ''
+  allows_debits: false
+  bank_name: STRIPE TEST BANK
+  bank_phone_number: ''
+  country: US
+  currency: usd
+  customer: ''
+  customer_reference: ''
+  default_for_currency: false
+  fingerprint: Uv372FI5KdaHdZhl
+  id: ba_19qYWoAmUcJIthQ8yfohLr7y
+  last4: '6789'
+  metadata: {}
+  object: bank_account
+  reusable: false
+  routing_number: '110000000'
+  status: new
+  used: false
 bitcoin_receiver:
   active: false
   amount: 100
@@ -200,7 +226,7 @@ bitcoin_receiver:
   description: Receiver for John Doe
   email: test@example.com
   filled: false
-  id: btcrcv_19mq3pAXZ0PAB0quysC4SOJn
+  id: btcrcv_19qYWoAmUcJIthQ8GNgZ61HT
   inbound_address: test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1
   livemode: false
   metadata: {}
@@ -215,9 +241,46 @@ bitcoin_transaction:
   bitcoin_amount: 1757908
   created: 1234567890
   currency: usd
-  id: btctxn_19mq3pAXZ0PAB0quo4NMSQ1P
+  id: btctxn_19qYWoAmUcJIthQ85oxOPgem
   object: bitcoin_transaction
-  receiver: btcrcv_19mq3pBFZK1NInhS7HqQ8daC
+  receiver: btcrcv_19qYWoBKPgWF2WHuRAP2vIic
+card:
+  3d_secure: {}
+  account: ''
+  address_city: ''
+  address_country: ''
+  address_line1: ''
+  address_line1_check: ''
+  address_line2: ''
+  address_state: ''
+  address_zip: ''
+  address_zip_check: ''
+  available_payout_methods: []
+  brand: Visa
+  country: ''
+  currency: ''
+  customer: ''
+  cvc_check: ''
+  default_for_currency: false
+  description: ''
+  dynamic_last4: ''
+  emv_auth_data: ''
+  estimated_availability: ''
+  exp_month: 8
+  exp_year: 2018
+  fingerprint: ''
+  funding: unknown
+  google_reference: ''
+  id: card_19qYWoAmUcJIthQ8t6Dm5Ol6
+  iin: ''
+  issuer: ''
+  last4: '4242'
+  metadata: {}
+  name: ''
+  object: card
+  recipient: ''
+  three_d_secure: {}
+  tokenization_method: ''
 charge:
   alternate_statement_descriptors: {}
   amount: 100
@@ -228,7 +291,7 @@ charge:
   application_fee: ''
   application_fees_refunded: 0
   authorization_code: ''
-  balance_transaction: txn_19mq3mAXZ0PAB0quuB601NdX
+  balance_transaction: txn_19qYWoAmUcJIthQ8nkS84OrS
   captured: true
   card: {}
   created: 1234567890
@@ -241,7 +304,7 @@ charge:
   failure_message: ''
   fee_balance_transactions: {}
   fraud_details: {}
-  id: ch_19mq3mAXZ0PAB0quafODEaTb
+  id: ch_19qYWoAmUcJIthQ8bXdOlg7i
   invoice: ''
   level3: {}
   livemode: false
@@ -259,7 +322,7 @@ charge:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/charges/ch_19mq3mAXZ0PAB0quafODEaTb/refunds"
+    url: "/v1/charges/ch_19qYWoAmUcJIthQ8bXdOlg7i/refunds"
   review: ''
   shipping: {}
   source:
@@ -279,7 +342,7 @@ charge:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19mq3lAXZ0PAB0quo1Fi4kuG
+    id: card_19qYWoAmUcJIthQ8t6Dm5Ol6
     last4: '4242'
     metadata: {}
     name: 
@@ -346,7 +409,7 @@ customer:
   description: ''
   discount: {}
   email: ''
-  id: cus_A74CGlAc6Xc9o8
+  id: cus_AAuLxPuOFN7Ull
   livemode: false
   metadata: {}
   object: customer
@@ -356,23 +419,19 @@ customer:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/customers/cus_A74CGlAc6Xc9o8/sources"
+    url: "/v1/customers/cus_AAuLxPuOFN7Ull/sources"
   subscription: {}
-  subscriptions:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/customers/cus_A74CGlAc6Xc9o8/subscriptions"
+  subscriptions: {}
   trust: {}
 customer_source:
-  id: ba_19mq3pAXZ0PAB0que2xYqubF
+  customer: ''
+  id: ba_19qYWoAmUcJIthQ8yfohLr7y
   metadata: {}
   object: bank_account
 discount:
   coupon:
     amount_off: 
-    created: 1487016273
+    created: 1487902190
     currency: usd
     duration: repeating
     duration_in_months: 3
@@ -385,7 +444,7 @@ discount:
     redeem_by: 
     times_redeemed: 0
     valid: true
-  customer: cus_A74CGlAc6Xc9o8
+  customer: cus_AAuLxPuOFN7Ull
   end: 1234567890
   object: discount
   start: 1234567890
@@ -395,7 +454,7 @@ dispute:
   amount: 1000
   balance_transaction: ''
   balance_transactions: []
-  charge: ch_19mq3mAXZ0PAB0quafODEaTb
+  charge: ch_19qYWoAmUcJIthQ8bXdOlg7i
   closed_at: 1234567890
   created: 1234567890
   currency: usd
@@ -429,12 +488,12 @@ dispute:
     uncategorized_file: 
     uncategorized_text: 
   evidence_details:
-    due_by: 1488671999
+    due_by: 1489622399
     has_evidence: false
     past_due: false
     submission_count: 0
   evidence_submitted_at: []
-  id: dp_19mq3nAXZ0PAB0quWfu875gB
+  id: dp_19qYWoAmUcJIthQ8hiQKRidU
   is_charge_refundable: false
   is_protected: false
   livemode: false
@@ -450,7 +509,7 @@ event:
   data:
     object:
       amount: 2000
-      created: 1487016273
+      created: 1487902190
       currency: usd
       id: gold
       interval: month
@@ -461,7 +520,7 @@ event:
       object: plan
       statement_descriptor: 
       trial_period_days: 
-  id: evt_19mq3pAXZ0PAB0qutMlKV6c3
+  id: evt_19qYWpAmUcJIthQ8flpeC3A6
   livemode: false
   object: event
   pending_webhooks: 0
@@ -469,7 +528,7 @@ event:
   request: ''
   type: plan.created
 external_account_source:
-  account: acct_19mq3gAXZ0PAB0qu
+  account: acct_19qYWjAmUcJIthQ8
   address_city: ''
   address_line1: ''
   address_line2: ''
@@ -477,9 +536,10 @@ external_account_source:
   address_zip: ''
   country: US
   currency: usd
+  customer: ''
   default_for_currency: false
-  fingerprint: d23J1TFOicgP64nb
-  id: ba_19mq3pAXZ0PAB0que2xYqubF
+  fingerprint: Uv372FI5KdaHdZhl
+  id: ba_19qYWoAmUcJIthQ8yfohLr7y
   last4: '6789'
   metadata: {}
   object: bank_account
@@ -488,8 +548,8 @@ fee_refund:
   balance_transaction: ''
   created: 1234567890
   currency: usd
-  fee: fee_19mq3pAXZ0PAB0quKLPknTXJ
-  id: fr_A74Ce1Bh7Kr6UC
+  fee: fee_19qYWoAmUcJIthQ81JzKWcmc
+  id: fr_AAuLnHfz4zsfMV
   metadata: {}
   object: fee_refund
 invoice:
@@ -501,30 +561,30 @@ invoice:
   charge: ''
   closed: false
   currency: usd
-  customer: cus_A74CGlAc6Xc9o8
+  customer: cus_AAuLxPuOFN7Ull
   date: 1234567890
   description: ''
   discount: {}
   due_date: 1234567890
   ending_balance: 0
   forgiven: false
-  id: in_19mq3pAXZ0PAB0qupydNkllt
+  id: in_19qYWoAmUcJIthQ8mMavVKyP
   lines:
     data:
     - amount: 2000
       currency: usd
       description: 
       discountable: true
-      id: sub_A74CDfuKRtyn06
+      id: sub_AAuLAT8thsFpDe
       livemode: true
       metadata: {}
       object: line_item
       period:
-        end: 1492113872
-        start: 1489435472
+        end: 1492999790
+        start: 1490321390
       plan:
         amount: 2000
-        created: 1487016273
+        created: 1487902190
         currency: usd
         id: gold
         interval: month
@@ -538,11 +598,11 @@ invoice:
       proration: false
       quantity: 1
       subscription: 
-      subscription_item: si_19mq3oBFZK1NInhSuSpw3kRl
+      subscription_item: si_19qYWoBKPgWF2WHuVSwKNUvS
       type: subscription
     object: list
     total_count: 1
-    url: "/v1/invoices/in_19mq3pAXZ0PAB0qupydNkllt/lines"
+    url: "/v1/invoices/in_19qYWoAmUcJIthQ8mMavVKyP/lines"
   livemode: false
   metadata: {}
   next_payment_attempt: 1234567890
@@ -564,18 +624,18 @@ invoice:
 invoice_item:
   amount: 1000
   currency: usd
-  customer: cus_A74CGlAc6Xc9o8
+  customer: cus_AAuLxPuOFN7Ull
   date: 1234567890
   description: My First Invoice Item (created for API docs)
   discountable: true
-  id: ii_19mq3pAXZ0PAB0quXd6LJkwP
+  id: ii_19qYWoAmUcJIthQ8V8c0aOsd
   invoice: ''
   livemode: false
   metadata: {}
   object: invoiceitem
   period:
-    end: 1487016273
-    start: 1487016273
+    end: 1487902190
+    start: 1487902190
   plan: {}
   proration: false
   quantity: 0
@@ -586,13 +646,13 @@ invoice_line_item:
   currency: usd
   description: My First Invoice Item (created for API docs)
   discountable: true
-  id: ii_19mq3pAXZ0PAB0quXd6LJkwP
+  id: ii_19qYWoAmUcJIthQ8V8c0aOsd
   livemode: false
   metadata: {}
   object: line_item
   period:
-    end: 1487016273
-    start: 1487016273
+    end: 1487902190
+    start: 1487902190
   plan: {}
   proration: false
   quantity: 0
@@ -612,23 +672,23 @@ legacy_transfer:
   date: 1234567890
   delay_reason: ''
   description: Transfer to test@example.com
-  destination: ba_19mq3pAXZ0PAB0qurDV9Avlb
+  destination: ba_19qYWoAmUcJIthQ8qTr0A9Em
   destination_payment: ''
   failure_code: ''
   failure_message: ''
-  id: tr_19mq3pAXZ0PAB0qubIKTrixZ
+  id: tr_19qYWoAmUcJIthQ88M6TcLVT
   legacy_date: 1234567890
   livemode: false
   metadata: {}
   method: standard
   object: transfer
-  recipient: rp_19mq3pAXZ0PAB0quySWBNl2v
+  recipient: ''
   reversals:
     data: []
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/transfers/tr_19mq3pAXZ0PAB0qubIKTrixZ/reversals"
+    url: "/v1/transfers/tr_19qYWoAmUcJIthQ88M6TcLVT/reversals"
   reversed: false
   source_transaction: ''
   source_type: card
@@ -649,13 +709,13 @@ order:
   email: ''
   external_coupon_code: ''
   external_sku_ids: []
-  id: or_19mq3qAXZ0PAB0qua7xjbAdc
+  id: or_19qYWpAmUcJIthQ8qyjYeMOA
   items:
   - amount: 1500
     currency: usd
     description: T-shirt
     object: order_item
-    parent: sk_19mq3qAXZ0PAB0quLkoPCkNK
+    parent: sk_19qYWpAmUcJIthQ81nFJf7oq
     quantity: 
     type: sku
   livemode: false
@@ -666,7 +726,7 @@ order:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/order_returns?order=or_19mq3qAXZ0PAB0qua7xjbAdc"
+    url: "/v1/order_returns?order=or_19qYWpAmUcJIthQ8qyjYeMOA"
   selected_shipping_method: ''
   shipping:
     address:
@@ -690,73 +750,19 @@ order_return:
   amount: 1500
   created: 1234567890
   currency: usd
-  id: orret_19mq3qAXZ0PAB0qu32DCGDSQ
+  id: orret_19qYWpAmUcJIthQ87Z2XSNB7
   items:
   - amount: 1500
     currency: usd
     description: T-shirt
     object: order_item
-    parent: sk_19mq3qAXZ0PAB0quLkoPCkNK
+    parent: sk_19qYWpAmUcJIthQ81nFJf7oq
     quantity: 
     type: sku
   livemode: false
   object: order_return
-  order: or_19mq3qAXZ0PAB0qu1Sr0vNrE
-  refund: re_19mq3qAXZ0PAB0qu9txUplQ2
-payment_bank_account:
-  account_holder_name: Jane Austen
-  account_holder_type: individual
-  address_city: ''
-  address_line1: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  bank_name: STRIPE TEST BANK
-  bank_phone_number: ''
-  country: US
-  currency: usd
-  customer: ''
-  customer_reference: ''
-  fingerprint: d23J1TFOicgP64nb
-  id: ba_19mq3pAXZ0PAB0que2xYqubF
-  last4: '6789'
-  metadata: {}
-  object: bank_account
-  reusable: false
-  routing_number: '110000000'
-  status: new
-  used: false
-payment_card:
-  3d_secure: {}
-  address_city: ''
-  address_country: ''
-  address_line1: ''
-  address_line1_check: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  address_zip_check: ''
-  brand: ''
-  country: ''
-  customer: ''
-  cvc_check: ''
-  description: ''
-  dynamic_last4: ''
-  emv_auth_data: ''
-  exp_month: 0
-  exp_year: 0
-  fingerprint: ''
-  funding: ''
-  google_reference: ''
-  id: tok_19mq3pAXZ0PAB0qucG7ckr0s
-  iin: ''
-  issuer: ''
-  last4: ''
-  metadata: {}
-  name: ''
-  object: token
-  three_d_secure: {}
-  tokenization_method: ''
+  order: or_19qYWpAmUcJIthQ8UTxcPzrC
+  refund: re_19qYWpAmUcJIthQ8zCfRSInM
 plan:
   amount: 2000
   created: 1234567890
@@ -771,15 +777,15 @@ plan:
   statement_descriptor: ''
   trial_period_days: 0
 platform_earning:
-  account: acct_19mq3gAXZ0PAB0qu
+  account: acct_19qYWjAmUcJIthQ8
   amount: 100
   amount_refunded: 0
-  application: ca_A74Cy7ZahkUTCBUvdzDMqtBz3n9zWjJw
-  balance_transaction: txn_19mq3mAXZ0PAB0quuB601NdX
-  charge: ch_19mq3mAXZ0PAB0quafODEaTb
+  application: ca_AAuLq9yGtXXwqlznUKq6kGjBvQpnZj1R
+  balance_transaction: txn_19qYWoAmUcJIthQ8nkS84OrS
+  charge: ch_19qYWoAmUcJIthQ8bXdOlg7i
   created: 1234567890
   currency: usd
-  id: fee_19mq3pAXZ0PAB0quKLPknTXJ
+  id: fee_19qYWoAmUcJIthQ81JzKWcmc
   livemode: false
   object: application_fee
   originating_transaction: ''
@@ -789,7 +795,7 @@ platform_earning:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/application_fees/fee_19mq3pAXZ0PAB0quKLPknTXJ/refunds"
+    url: "/v1/application_fees/fee_19qYWoAmUcJIthQ81JzKWcmc/refunds"
 product:
   active: true
   attributes:
@@ -800,7 +806,7 @@ product:
   deactivate_on: []
   description: Comfortable gray cotton t-shirts
   donation: false
-  id: prod_A74CjbvJG198EF
+  id: prod_AAuLwRhYxnv0sx
   images: []
   livemode: false
   metadata: {}
@@ -814,49 +820,19 @@ product:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/skus?product=prod_A74CjbvJG198EF&active=true"
+    url: "/v1/skus?product=prod_AAuLwRhYxnv0sx&active=true"
   tweetable_url: ''
   updated: 1234567890
   url: ''
-recipient_payout_card:
-  address_city: ''
-  address_country: ''
-  address_line1: ''
-  address_line1_check: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  address_zip_check: ''
-  brand: ''
-  country: ''
-  cvc_check: ''
-  description: ''
-  dynamic_last4: ''
-  estimated_availability: ''
-  exp_month: 0
-  exp_year: 0
-  fingerprint: ''
-  funding: ''
-  google_reference: ''
-  id: tok_19mq3pAXZ0PAB0qucG7ckr0s
-  iin: ''
-  issuer: ''
-  last4: ''
-  metadata: {}
-  name: ''
-  object: token
-  recipient: ''
-  three_d_secure: {}
-  tokenization_method: ''
 refund:
   amount: 100
   balance_transaction: ''
-  charge: ch_19mq3mAXZ0PAB0quafODEaTb
+  charge: ch_19qYWoAmUcJIthQ8bXdOlg7i
   created: 1234567890
   currency: usd
   description: ''
   fee_balance_transactions: {}
-  id: re_19mq3nAXZ0PAB0quqH5KQOit
+  id: re_19qYWoAmUcJIthQ8cKkdY9yt
   metadata: {}
   object: refund
   reason: ''
@@ -870,7 +846,7 @@ sku:
     size: Medium
   created: 1234567890
   currency: usd
-  id: sku_A74CaPnn1qmjb1
+  id: sku_AAuLi9h04wg7cg
   image: ''
   inventory:
     quantity: 50
@@ -881,7 +857,7 @@ sku:
   object: sku
   package_dimensions: {}
   price: 1500
-  product: prod_A74CjbvJG198EF
+  product: prod_AAuLwRhYxnv0sx
   updated: 1234567890
 source:
   amount: 0
@@ -891,7 +867,7 @@ source:
   currency: ''
   customer: ''
   flow: ''
-  id: card_19mq3pAXZ0PAB0quryDGMYFl
+  id: card_19qYWoAmUcJIthQ8t6Dm5Ol6
   livemode: false
   metadata: {}
   object: card
@@ -911,19 +887,19 @@ subscription:
   created: 1234567890
   current_period_end: 1234567890
   current_period_start: 1234567890
-  customer: cus_A74CD39bY4X367
+  customer: cus_AAuLOB7WALx4Zo
   days_until_due: 0
   discount: {}
   ended_at: 1234567890
-  id: sub_A74CDfuKRtyn06
+  id: sub_AAuLAT8thsFpDe
   items:
     data:
-    - created: 1487016273
-      id: si_19mq3oBFZK1NInhSuSpw3kRl
+    - created: 1487902191
+      id: si_19qYWoBKPgWF2WHuVSwKNUvS
       object: subscription_item
       plan:
         amount: 2000
-        created: 1487016272
+        created: 1487902190
         currency: usd
         id: gold
         interval: month
@@ -938,14 +914,14 @@ subscription:
     has_more: false
     object: list
     total_count: 1
-    url: "/v1/subscription_items?subscription=sub_A74CDfuKRtyn06"
+    url: "/v1/subscription_items?subscription=sub_AAuLAT8thsFpDe"
   livemode: false
   max_occurrences: 0
   metadata: {}
   object: subscription
   plan:
     amount: 2000
-    created: 1487016272
+    created: 1487902190
     currency: usd
     id: gold
     interval: month
@@ -964,12 +940,12 @@ subscription:
   trial_end: 1234567890
   trial_start: 1234567890
 subscription_item:
-  created: 1487016273
-  id: si_19mq3oBFZK1NInhS3ZhhdFF8
+  created: 1487902191
+  id: si_19qYWoBKPgWF2WHuFvY9YdCi
   object: subscription_item
   plan:
     amount: 2000
-    created: 1487016272
+    created: 1487902190
     currency: usd
     id: gold
     interval: month
@@ -1001,7 +977,7 @@ three_d_secure:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19mq3pAXZ0PAB0quryDGMYFl
+    id: card_19qYWoAmUcJIthQ8yFmDKOnd
     last4: '4242'
     metadata: {}
     name: 
@@ -1009,10 +985,10 @@ three_d_secure:
     tokenization_method: 
   created: 1234567890
   currency: usd
-  id: tdsrc_A74Cn8dTJLosfe
+  id: tdsrc_AAuLnCzSLJVLB4
   livemode: false
   object: three_d_secure
-  redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_A74Cn8dTJLosfe
+  redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AAuLnCzSLJVLB4
   status: redirect_pending
 token:
   account_details: {}
@@ -1034,7 +1010,7 @@ token:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19mq3pAXZ0PAB0quryDGMYFl
+    id: card_19qYWoAmUcJIthQ8yFmDKOnd
     last4: '4242'
     metadata: {}
     name: 
@@ -1044,7 +1020,7 @@ token:
   created: 1234567890
   description: ''
   email: ''
-  id: tok_19mq3pAXZ0PAB0qucG7ckr0s
+  id: tok_19qYWoAmUcJIthQ8xAwoDoXA
   livemode: false
   object: token
   type: card
@@ -1053,12 +1029,12 @@ token:
 transfer:
   amount: 1100
   amount_reversed: 0
-  balance_transaction: txn_19mq3mAXZ0PAB0quuB601NdX
+  balance_transaction: txn_19qYWoAmUcJIthQ8nkS84OrS
   created: 1234567890
   currency: usd
-  destination: ba_19mq3pAXZ0PAB0qurDV9Avlb
+  destination: ba_19qYWoAmUcJIthQ8qTr0A9Em
   destination_payment: ''
-  id: tr_19mq3pAXZ0PAB0qubIKTrixZ
+  id: tr_19qYWoAmUcJIthQ88M6TcLVT
   livemode: false
   metadata: {}
   object: transfer
@@ -1067,7 +1043,7 @@ transfer:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/transfers/tr_19mq3pAXZ0PAB0qubIKTrixZ/reversals"
+    url: "/v1/transfers/tr_19qYWoAmUcJIthQ88M6TcLVT/reversals"
   reversed: false
   transfer_group: ''
 transfer_recipient:
@@ -1083,7 +1059,7 @@ transfer_recipient:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/recipients/rp_19mq3pAXZ0PAB0quySWBNl2v/cards"
+    url: "/v1/recipients/rp_19qYWoAmUcJIthQ8Xx4vHz7G/cards"
   country: ''
   created: 1234567890
   default_card: ''
@@ -1092,7 +1068,7 @@ transfer_recipient:
   dob_month: ''
   dob_year: ''
   email: test@example.com
-  id: rp_19mq3pAXZ0PAB0quySWBNl2v
+  id: rp_19qYWoAmUcJIthQ8Xx4vHz7G
   livemode: false
   metadata: {}
   migrated_to: ''
@@ -1107,10 +1083,10 @@ transfer_reversal:
   balance_transaction: ''
   created: 1234567890
   currency: usd
-  id: trr_19mq3pAXZ0PAB0quDwZdcrSt
+  id: trr_19qYWoAmUcJIthQ8aCB1cCjt
   metadata: {}
   object: transfer_reversal
-  transfer: tr_19mq3pAXZ0PAB0qubIKTrixZ
+  transfer: tr_19qYWoAmUcJIthQ88M6TcLVT
 upcoming_invoice:
   amount_due: 0
   application_fee: 0
@@ -1120,7 +1096,7 @@ upcoming_invoice:
   charge: ''
   closed: false
   currency: usd
-  customer: cus_A74CGlAc6Xc9o8
+  customer: cus_AAuLxPuOFN7Ull
   date: 1234567890
   description: ''
   discount: {}
@@ -1132,7 +1108,7 @@ upcoming_invoice:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/invoices/in_19mq3pAXZ0PAB0qupydNkllt/lines"
+    url: "/v1/invoices/in_19qYWoAmUcJIthQ8mMavVKyP/lines"
   livemode: false
   metadata: {}
   next_payment_attempt: 1234567890

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -764,7 +764,7 @@
     "balance": {
       "properties": {
         "available": {
-          "description": "Funds that are available to be paid out automatically by Stripe or explicitly via the [transfers AP](#transfers). The available balance for each currency and payment type can be found in the `source_types` property.",
+          "description": "Funds that are available to be paid out automatically by Stripe or explicitly via the [transfers API](#transfers). The available balance for each currency and payment type can be found in the `source_types` property.",
           "type": [
             "array"
           ]
@@ -902,6 +902,167 @@
         "object"
       ],
       "x-resourceId": "balance_transaction"
+    },
+    "bank_account": {
+      "properties": {
+        "account": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "account_holder_name": {
+          "description": "The name of the person or business that owns the bank account.",
+          "type": [
+            "string"
+          ]
+        },
+        "account_holder_type": {
+          "description": "The type of entity that holds the account. This can be either `individual` or `company`.",
+          "type": [
+            "string"
+          ]
+        },
+        "address_city": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_line1": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_line2": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_state": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_zip": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "allows_debits": {
+          "description": "",
+          "type": [
+            "boolean"
+          ]
+        },
+        "bank_name": {
+          "description": "Name of the bank associated with the routing number, e.g. `WELLS FARGO`.",
+          "type": [
+            "string"
+          ]
+        },
+        "country": {
+          "description": "Two-letter ISO code representing the country the bank account is located in.",
+          "type": [
+            "string"
+          ]
+        },
+        "currency": {
+          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
+          "type": [
+            "string"
+          ]
+        },
+        "customer": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "customer_reference": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "default_for_currency": {
+          "description": "Whether this external account is the default account for its currency.",
+          "type": [
+            "boolean"
+          ]
+        },
+        "fingerprint": {
+          "description": "Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "last4": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "metadata": {
+          "description": "A set of key/value pairs that you can attach to a bank account object. It can be useful for storing additional information about the bank account in a structured format.",
+          "type": [
+            "object"
+          ]
+        },
+        "object": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "reusable": {
+          "description": "",
+          "type": [
+            "boolean"
+          ]
+        },
+        "routing_number": {
+          "description": "The routing transit number for the bank account.",
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "Possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isn’t enough information to know (e.g. for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a transfer sent to this bank account fails, we'll set the status to `errored` and will not continue to send transfers until the bank details are updated.",
+          "type": [
+            "string"
+          ]
+        },
+        "used": {
+          "description": "",
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "country",
+        "currency",
+        "id",
+        "last4",
+        "object",
+        "status"
+      ],
+      "title": "BankAccount",
+      "type": [
+        "object"
+      ],
+      "x-resourceId": "bank_account"
     },
     "bitcoin_receiver": {
       "properties": {
@@ -1165,6 +1326,211 @@
       ],
       "x-resourceId": "bitcoin_transaction"
     },
+    "card": {
+      "properties": {
+        "account": {
+          "description": "The account this card belongs to. This attribute will not be in the card object if the card belongs to a customer or recipient instead.",
+          "type": [
+            "string"
+          ]
+        },
+        "address_city": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_country": {
+          "description": "Billing address country, if provided when creating card.",
+          "type": [
+            "string"
+          ]
+        },
+        "address_line1": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_line1_check": {
+          "description": "If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
+          "type": [
+            "string"
+          ]
+        },
+        "address_line2": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_state": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_zip": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "address_zip_check": {
+          "description": "If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
+          "type": [
+            "string"
+          ]
+        },
+        "available_payout_methods": {
+          "description": "A set of available payout methods for this card. Will be either `[\"standard\"]` or `[\"standard\", \"instant\"]`. Only values from this set should be passed as the `method` when creating a transfer.",
+          "type": [
+            "array"
+          ]
+        },
+        "brand": {
+          "description": "Card brand. Can be `Visa`, `American Express`, `MasterCard`, `Discover`, `JCB`, `Diners Club`, or `Unknown`.",
+          "type": [
+            "string"
+          ]
+        },
+        "country": {
+          "description": "Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.",
+          "type": [
+            "string"
+          ]
+        },
+        "currency": {
+          "description": "Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency.",
+          "type": [
+            "string"
+          ]
+        },
+        "customer": {
+          "description": "The customer that this card belongs to. This attribute will not be in the card object if the card belongs to an account or recipient instead.",
+          "type": [
+            "string"
+          ]
+        },
+        "cvc_check": {
+          "description": "If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
+          "type": [
+            "string"
+          ]
+        },
+        "default_for_currency": {
+          "description": "Only applicable on accounts (not customers or recipients). This indicates whether or not this card is the default external account for its currency.",
+          "type": [
+            "boolean"
+          ]
+        },
+        "dynamic_last4": {
+          "description": "(For tokenized numbers only.) The last four digits of the device account number.",
+          "type": [
+            "string"
+          ]
+        },
+        "estimated_availability": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "exp_month": {
+          "description": "",
+          "type": [
+            "integer"
+          ]
+        },
+        "exp_year": {
+          "description": "",
+          "type": [
+            "integer"
+          ]
+        },
+        "fingerprint": {
+          "description": "Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example.",
+          "type": [
+            "string"
+          ]
+        },
+        "funding": {
+          "description": "Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.",
+          "type": [
+            "string"
+          ]
+        },
+        "google_reference": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "ID of card (used in conjunction with a customer or recipient ID).",
+          "type": [
+            "string"
+          ]
+        },
+        "last4": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "metadata": {
+          "description": "A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.",
+          "type": [
+            "object"
+          ]
+        },
+        "name": {
+          "description": "Cardholder name.",
+          "type": [
+            "string"
+          ]
+        },
+        "object": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
+        "recipient": {
+          "description": "The recipient that this card belongs to. This attribute will not be in the card object if the card belongs to a customer or account instead.",
+          "type": [
+            "string"
+          ]
+        },
+        "three_d_secure": {
+          "description": "",
+          "type": [
+            "object"
+          ]
+        },
+        "tokenization_method": {
+          "description": "If the card number is tokenized, this is the method that was used. Can be `apple_pay` or `android_pay`.",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "brand",
+        "exp_month",
+        "exp_year",
+        "funding",
+        "id",
+        "last4",
+        "metadata",
+        "object"
+      ],
+      "title": "Card",
+      "type": [
+        "object"
+      ],
+      "x-resourceId": "card"
+    },
     "channel_settings": {
       "properties": {
         "twitter": {
@@ -1210,7 +1576,7 @@
           ]
         },
         "application_fee": {
-          "description": "The application fee (if any) for the charge. [See the Connect documentation](/docs/connect/payments-fees#collecting-fees) for details.",
+          "description": "The application fee (if any) for the charge. [See the Connect documentation](/docs/connect/direct-charges#collecting-fees) for details.",
           "type": [
             "string"
           ]
@@ -1228,7 +1594,7 @@
           ]
         },
         "card": {
-          "$ref": "#/definitions/payment_card"
+          "$ref": "#/definitions/card"
         },
         "created": {
           "description": "",
@@ -1255,7 +1621,7 @@
           ]
         },
         "destination": {
-          "description": "The account (if any) the charge was made on behalf of, with an automatic transfer. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform) for details.",
+          "description": "The account (if any) the charge was made on behalf of, with an automatic transfer. [See the Connect documentation](/docs/connect/destination-charges) for details.",
           "type": [
             "string"
           ]
@@ -1315,7 +1681,7 @@
           ]
         },
         "on_behalf_of": {
-          "description": "The account (if any) the charge was made on behalf of without triggering an automatic transfer. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform) for details.",
+          "description": "The account (if any) the charge was made on behalf of without triggering an automatic transfer. See the [Connect documentation](/docs/connect/charges-transfers) for details.",
           "type": [
             "string"
           ]
@@ -1412,7 +1778,7 @@
           "$ref": "#/definitions/shipping"
         },
         "source_transfer": {
-          "description": "The transfer ID which created this charge. Only present if the charge came from another Stripe account. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform) for details.",
+          "description": "The transfer ID which created this charge. Only present if the charge came from another Stripe account. [See the Connect documentation](/docs/connect/destination-charges) for details.",
           "type": [
             "string"
           ]
@@ -1436,7 +1802,7 @@
           ]
         },
         "transfer_group": {
-          "description": "A string that identifies this transaction as part of a group. [See the Connect documentation](/docs/connect/transfer-group) for details.",
+          "description": "A string that identifies this transaction as part of a group. See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions) for details.",
           "type": [
             "string"
           ]
@@ -1497,7 +1863,7 @@
           ]
         },
         "type": {
-          "description": "Possible values are `authorized`, `issuer_declined`, `blocked`, and `invalid`. See [understanding declines](/docs/declines) for details.",
+          "description": "Possible values are `authorized`, `manual_review`, `issuer_declined`, `blocked`, and `invalid`. See [understanding declines](/docs/declines) and [Radar reviews](radar/review) for details.",
           "type": [
             "string"
           ]
@@ -1545,7 +1911,7 @@
           ]
         },
         "supported_payment_methods": {
-          "description": "Payment methods available in the specified country. You will need to [enable bitcoin](https://dashboard.stripe.com/account/bitcoin/enable) and [ACH](https://stripe.com/docs/guides/ach) payments on your account for those methods to appear in this list. The `stripe` payment method refers to [charging through your platform](https://stripe.com/docs/connect/payments-fees#charging-through-the-platform).",
+          "description": "Payment methods available in the specified country. You will need to [enable bitcoin](https://dashboard.stripe.com/account/bitcoin/enable) and [ACH](https://stripe.com/docs/guides/ach) payments on your account for those methods to appear in this list. The `stripe` payment method refers to [charging through your platform](https://stripe.com/docs/connect/destination-charges).",
           "type": [
             "array"
           ]
@@ -1736,7 +2102,7 @@
           "properties": {
             "data": {
               "items": {
-                "$ref": "#/definitions/payment_bank_account"
+                "$ref": "#/definitions/bank_account"
               },
               "type": [
                 "array"
@@ -1776,7 +2142,7 @@
             "object",
             "url"
           ],
-          "title": "PaymentBankAccountList",
+          "title": "BankAccountList",
           "type": [
             "object"
           ]
@@ -1791,7 +2157,7 @@
           "properties": {
             "data": {
               "items": {
-                "$ref": "#/definitions/payment_card"
+                "$ref": "#/definitions/card"
               },
               "type": [
                 "array"
@@ -1831,7 +2197,7 @@
             "object",
             "url"
           ],
-          "title": "PaymentCardList",
+          "title": "CardList",
           "type": [
             "object"
           ]
@@ -2062,6 +2428,12 @@
     },
     "customer_source": {
       "properties": {
+        "customer": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
         "id": {
           "description": "",
           "type": [
@@ -2083,7 +2455,6 @@
       },
       "required": [
         "id",
-        "metadata",
         "object"
       ],
       "title": "Polymorphic",
@@ -2479,6 +2850,12 @@
             "string"
           ]
         },
+        "customer": {
+          "description": "",
+          "type": [
+            "string"
+          ]
+        },
         "default_for_currency": {
           "description": "Whether this external account is the default account for its currency.",
           "type": [
@@ -2517,13 +2894,10 @@
         }
       },
       "required": [
-        "account",
         "country",
         "currency",
-        "default_for_currency",
         "id",
         "last4",
-        "metadata",
         "object"
       ],
       "title": "Polymorphic",
@@ -3369,7 +3743,7 @@
           ]
         },
         "transfer_group": {
-          "description": "A string that identifies this transaction as part of a group. [See the Connect documentation](/docs/connect/transfer-group) for details.",
+          "description": "A string that identifies this transaction as part of a group. See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions) for details.",
           "type": [
             "string"
           ]
@@ -4123,319 +4497,6 @@
       ],
       "x-resourceId": "package_dimensions"
     },
-    "payment_bank_account": {
-      "properties": {
-        "account_holder_name": {
-          "description": "The name of the person or business that owns the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "account_holder_type": {
-          "description": "The type of entity that holds the account. This can be either `individual` or `company`.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_city": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line2": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_state": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "bank_name": {
-          "description": "Name of the bank associated with the routing number, e.g. `WELLS FARGO`.",
-          "type": [
-            "string"
-          ]
-        },
-        "country": {
-          "description": "Two-letter ISO code representing the country the bank account is located in.",
-          "type": [
-            "string"
-          ]
-        },
-        "currency": {
-          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "customer": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "customer_reference": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "fingerprint": {
-          "description": "Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "last4": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "metadata": {
-          "description": "",
-          "type": [
-            "object"
-          ]
-        },
-        "object": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "reusable": {
-          "description": "",
-          "type": [
-            "boolean"
-          ]
-        },
-        "routing_number": {
-          "description": "The routing transit number for the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "status": {
-          "description": "Possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isn’t enough information to know (e.g. for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a transfer sent to this bank account fails, we'll set the status to `errored` and will not continue to send transfers until the bank details are updated.",
-          "type": [
-            "string"
-          ]
-        },
-        "used": {
-          "description": "",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
-      "required": [
-        "country",
-        "currency",
-        "id",
-        "last4",
-        "metadata",
-        "object",
-        "status"
-      ],
-      "title": "PaymentBankAccount",
-      "type": [
-        "object"
-      ],
-      "x-resourceId": "payment_bank_account"
-    },
-    "payment_card": {
-      "properties": {
-        "address_city": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_country": {
-          "description": "Billing address country, if provided when creating card.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1_check": {
-          "description": "If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line2": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_state": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip_check": {
-          "description": "If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "brand": {
-          "description": "Card brand. Can be `Visa`, `American Express`, `MasterCard`, `Discover`, `JCB`, `Diners Club`, or `Unknown`.",
-          "type": [
-            "string"
-          ]
-        },
-        "country": {
-          "description": "Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.",
-          "type": [
-            "string"
-          ]
-        },
-        "customer": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "cvc_check": {
-          "description": "If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "dynamic_last4": {
-          "description": "(For tokenized numbers only.) The last four digits of the device account number.",
-          "type": [
-            "string"
-          ]
-        },
-        "exp_month": {
-          "description": "",
-          "type": [
-            "integer"
-          ]
-        },
-        "exp_year": {
-          "description": "",
-          "type": [
-            "integer"
-          ]
-        },
-        "fingerprint": {
-          "description": "Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example.",
-          "type": [
-            "string"
-          ]
-        },
-        "funding": {
-          "description": "Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.",
-          "type": [
-            "string"
-          ]
-        },
-        "google_reference": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "ID of card (used in conjunction with a customer or recipient ID).",
-          "type": [
-            "string"
-          ]
-        },
-        "last4": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "metadata": {
-          "description": "A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.",
-          "type": [
-            "object"
-          ]
-        },
-        "name": {
-          "description": "Cardholder name.",
-          "type": [
-            "string"
-          ]
-        },
-        "object": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "three_d_secure": {
-          "description": "",
-          "type": [
-            "object"
-          ]
-        },
-        "tokenization_method": {
-          "description": "If the card number is tokenized, this is the method that was used. Can be `apple_pay` or `android_pay`.",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "brand",
-        "exp_month",
-        "exp_year",
-        "funding",
-        "id",
-        "last4",
-        "metadata",
-        "object"
-      ],
-      "title": "PaymentCard",
-      "type": [
-        "object"
-      ],
-      "x-resourceId": "payment_card"
-    },
     "plan": {
       "properties": {
         "amount": {
@@ -4843,312 +4904,6 @@
         "object"
       ],
       "x-resourceId": "product"
-    },
-    "recipient_payout_bank_account": {
-      "properties": {
-        "account_holder_name": {
-          "description": "The name of the person or business that owns the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "account_holder_type": {
-          "description": "The type of entity that holds the account. This can be either `individual` or `company`.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_city": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line2": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_state": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "allows_debits": {
-          "description": "",
-          "type": [
-            "boolean"
-          ]
-        },
-        "bank_name": {
-          "description": "Name of the bank associated with the routing number, e.g. `WELLS FARGO`.",
-          "type": [
-            "string"
-          ]
-        },
-        "country": {
-          "description": "Two-letter ISO code representing the country the bank account is located in.",
-          "type": [
-            "string"
-          ]
-        },
-        "currency": {
-          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "fingerprint": {
-          "description": "Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "last4": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "object": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "reusable": {
-          "description": "",
-          "type": [
-            "boolean"
-          ]
-        },
-        "routing_number": {
-          "description": "The routing transit number for the bank account.",
-          "type": [
-            "string"
-          ]
-        },
-        "status": {
-          "description": "Possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isn’t enough information to know (e.g. for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a transfer sent to this bank account fails, we'll set the status to `errored` and will not continue to send transfers until the bank details are updated.",
-          "type": [
-            "string"
-          ]
-        },
-        "used": {
-          "description": "",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
-      "required": [
-        "country",
-        "currency",
-        "id",
-        "last4",
-        "object",
-        "status"
-      ],
-      "title": "RecipientPayoutBankAccount",
-      "type": [
-        "object"
-      ],
-      "x-resourceId": "recipient_payout_bank_account"
-    },
-    "recipient_payout_card": {
-      "properties": {
-        "address_city": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_country": {
-          "description": "Billing address country, if provided when creating card.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line1_check": {
-          "description": "If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "address_line2": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_state": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "address_zip_check": {
-          "description": "If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "brand": {
-          "description": "Card brand. Can be `Visa`, `American Express`, `MasterCard`, `Discover`, `JCB`, `Diners Club`, or `Unknown`.",
-          "type": [
-            "string"
-          ]
-        },
-        "country": {
-          "description": "Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.",
-          "type": [
-            "string"
-          ]
-        },
-        "cvc_check": {
-          "description": "If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.",
-          "type": [
-            "string"
-          ]
-        },
-        "dynamic_last4": {
-          "description": "(For tokenized numbers only.) The last four digits of the device account number.",
-          "type": [
-            "string"
-          ]
-        },
-        "estimated_availability": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "exp_month": {
-          "description": "",
-          "type": [
-            "integer"
-          ]
-        },
-        "exp_year": {
-          "description": "",
-          "type": [
-            "integer"
-          ]
-        },
-        "fingerprint": {
-          "description": "Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example.",
-          "type": [
-            "string"
-          ]
-        },
-        "funding": {
-          "description": "Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.",
-          "type": [
-            "string"
-          ]
-        },
-        "google_reference": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "ID of card (used in conjunction with a customer or recipient ID).",
-          "type": [
-            "string"
-          ]
-        },
-        "last4": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "metadata": {
-          "description": "A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.",
-          "type": [
-            "object"
-          ]
-        },
-        "name": {
-          "description": "Cardholder name.",
-          "type": [
-            "string"
-          ]
-        },
-        "object": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "recipient": {
-          "description": "",
-          "type": [
-            "string"
-          ]
-        },
-        "three_d_secure": {
-          "description": "",
-          "type": [
-            "object"
-          ]
-        },
-        "tokenization_method": {
-          "description": "If the card number is tokenized, this is the method that was used. Can be `apple_pay` or `android_pay`.",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "brand",
-        "exp_month",
-        "exp_year",
-        "funding",
-        "id",
-        "last4",
-        "metadata",
-        "object"
-      ],
-      "title": "RecipientPayoutCard",
-      "type": [
-        "object"
-      ],
-      "x-resourceId": "recipient_payout_card"
     },
     "refund": {
       "properties": {
@@ -6158,7 +5913,7 @@
           ]
         },
         "card": {
-          "$ref": "#/definitions/payment_card"
+          "$ref": "#/definitions/card"
         },
         "created": {
           "description": "",
@@ -6742,13 +6497,13 @@
     "transfer_recipient": {
       "properties": {
         "active_account": {
-          "$ref": "#/definitions/recipient_payout_bank_account"
+          "$ref": "#/definitions/bank_account"
         },
         "cards": {
           "properties": {
             "data": {
               "items": {
-                "$ref": "#/definitions/recipient_payout_card"
+                "$ref": "#/definitions/card"
               },
               "type": [
                 "array"
@@ -6788,7 +6543,7 @@
             "object",
             "url"
           ],
-          "title": "RecipientPayoutCardList",
+          "title": "CardList",
           "type": [
             "object"
           ]
@@ -7348,7 +7103,7 @@
     "description": "The Stripe REST API. Please see https://stripe.com/docs/api for more details.",
     "termsOfService": "https://stripe.com/us/terms/",
     "title": "Stripe API",
-    "version": "2017-01-27"
+    "version": "2017-02-14"
   },
   "paths": {
     "/v1/3d_secure": {
@@ -7628,7 +7383,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).",
+                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -8281,7 +8036,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).",
+                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -8515,7 +8270,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).",
+                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -9790,7 +9545,7 @@
         }
       }
     },
-    "/v1/bitcoin/payments/{payment}/refund": {
+    "/v1/bitcoin/payments/{charge}/refund": {
       "post": {
         "description": "",
         "operationId": "CreatePaymentRefundWithPaymentResponse",
@@ -9798,7 +9553,7 @@
           {
             "description": "",
             "in": "path",
-            "name": "payment",
+            "name": "charge",
             "required": true,
             "type": "string"
           },
@@ -9814,13 +9569,6 @@
                   "title": "amount",
                   "type": [
                     "integer"
-                  ]
-                },
-                "charge": {
-                  "description": "",
-                  "title": "charge",
-                  "type": [
-                    "string"
                   ]
                 },
                 "description": {
@@ -9872,10 +9620,7 @@
                     "boolean"
                   ]
                 }
-              },
-              "required": [
-                "charge"
-              ]
+              }
             }
           }
         ],
@@ -10649,13 +10394,6 @@
                     "boolean"
                   ]
                 },
-                "card": {
-                  "description": "",
-                  "title": "card",
-                  "type": [
-                    "string"
-                  ]
-                },
                 "currency": {
                   "description": "",
                   "title": "currency",
@@ -10923,6 +10661,13 @@
                   "type": [
                     "object"
                   ]
+                },
+                "transfer_group": {
+                  "description": "A string that identifies this transaction as part of a group. `transfer_group` may only be provided if it has not been set. See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions) for details.",
+                  "title": "transfer_group",
+                  "type": [
+                    "string"
+                  ]
                 }
               }
             }
@@ -11165,13 +10910,6 @@
                   "title": "metadata",
                   "type": [
                     "object"
-                  ]
-                },
-                "payment": {
-                  "description": "",
-                  "title": "payment",
-                  "type": [
-                    "string"
                   ]
                 },
                 "reason": {
@@ -12516,7 +12254,7 @@
               "properties": {
                 "data": {
                   "items": {
-                    "$ref": "#/definitions/payment_bank_account"
+                    "$ref": "#/definitions/bank_account"
                   },
                   "type": [
                     "array"
@@ -12556,7 +12294,7 @@
                 "object",
                 "url"
               ],
-              "title": "PaymentBankAccountList",
+              "title": "BankAccountList",
               "type": [
                 "object"
               ]
@@ -12670,7 +12408,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_bank_account"
+              "$ref": "#/definitions/bank_account"
             }
           },
           "default": {
@@ -12791,7 +12529,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -12851,7 +12589,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_bank_account"
+              "$ref": "#/definitions/bank_account"
             }
           },
           "default": {
@@ -12904,7 +12642,7 @@
               "properties": {
                 "data": {
                   "items": {
-                    "$ref": "#/definitions/payment_card"
+                    "$ref": "#/definitions/card"
                   },
                   "type": [
                     "array"
@@ -12944,7 +12682,7 @@
                 "object",
                 "url"
               ],
-              "title": "PaymentCardList",
+              "title": "CardList",
               "type": [
                 "object"
               ]
@@ -13051,7 +12789,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -13172,7 +12910,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -13545,7 +13283,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -13605,7 +13343,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/payment_bank_account"
+              "$ref": "#/definitions/bank_account"
             }
           },
           "default": {
@@ -14832,14 +14570,14 @@
             "type": "string"
           },
           {
-            "description": "The identifier of the customer whose invoices to return. If none is provided, all invoices will be returned.",
+            "description": "The identifier of the customer whose invoices to return.",
             "in": "query",
             "name": "customer",
             "required": false,
             "type": "string"
           },
           {
-            "description": "",
+            "description": "The identifier of the subscription whose invoices to return.",
             "in": "query",
             "name": "subscription",
             "required": false,
@@ -15075,6 +14813,13 @@
             "type": "integer"
           },
           {
+            "description": "If provided, the invoice returned will preview updating or creating a subscription with that tax percent. If set, one of `subscription_plan` or `subscription` is required.",
+            "in": "query",
+            "name": "subscription_tax_percent",
+            "required": false,
+            "type": "number"
+          },
+          {
             "description": "The code of the coupon to apply. If a `subscription` or `subscription_plan` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions.",
             "in": "query",
             "name": "coupon",
@@ -15301,6 +15046,13 @@
             "name": "subscription_trial_end",
             "required": false,
             "type": "integer"
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "subscription_tax_percent",
+            "required": false,
+            "type": "number"
           },
           {
             "description": "For upcoming invoices, preview applying this coupon to the invoice. If a `subscription` or `subscription_plan` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. Otherwise this parameter is ignored.",
@@ -17370,7 +17122,7 @@
               "properties": {
                 "data": {
                   "items": {
-                    "$ref": "#/definitions/recipient_payout_card"
+                    "$ref": "#/definitions/card"
                   },
                   "type": [
                     "array"
@@ -17410,7 +17162,7 @@
                 "object",
                 "url"
               ],
-              "title": "RecipientPayoutCardList",
+              "title": "CardList",
               "type": [
                 "object"
               ]
@@ -17454,7 +17206,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/recipient_payout_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -17490,7 +17242,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/recipient_payout_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -17524,7 +17276,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/recipient_payout_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -17617,7 +17369,7 @@
           "200": {
             "description": "Successful response.",
             "schema": {
-              "$ref": "#/definitions/recipient_payout_card"
+              "$ref": "#/definitions/card"
             }
           },
           "default": {
@@ -18282,6 +18034,13 @@
             "required": false,
             "schema": {
               "properties": {
+                "alipay": {
+                  "description": "",
+                  "title": "alipay",
+                  "type": [
+                    "object"
+                  ]
+                },
                 "amount": {
                   "description": "Amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single-use` sources.",
                   "title": "amount",
@@ -19555,6 +19314,13 @@
                   "title": "metadata",
                   "type": [
                     "object"
+                  ]
+                },
+                "source_transaction": {
+                  "description": "",
+                  "title": "source_transaction",
+                  "type": [
+                    "string"
                   ]
                 },
                 "transfer_group": {

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -579,7 +579,7 @@ definitions:
     properties:
       available:
         description: Funds that are available to be paid out automatically by Stripe
-          or explicitly via the [transfers AP](#transfers). The available balance
+          or explicitly via the [transfers API](#transfers). The available balance
           for each currency and payment type can be found in the `source_types` property.
         type:
         - array
@@ -685,6 +685,132 @@ definitions:
     type:
     - object
     x-resourceId: balance_transaction
+  bank_account:
+    properties:
+      account:
+        description: ''
+        type:
+        - string
+      account_holder_name:
+        description: The name of the person or business that owns the bank account.
+        type:
+        - string
+      account_holder_type:
+        description: The type of entity that holds the account. This can be either
+          `individual` or `company`.
+        type:
+        - string
+      address_city:
+        description: ''
+        type:
+        - string
+      address_line1:
+        description: ''
+        type:
+        - string
+      address_line2:
+        description: ''
+        type:
+        - string
+      address_state:
+        description: ''
+        type:
+        - string
+      address_zip:
+        description: ''
+        type:
+        - string
+      allows_debits:
+        description: ''
+        type:
+        - boolean
+      bank_name:
+        description: Name of the bank associated with the routing number, e.g. `WELLS
+          FARGO`.
+        type:
+        - string
+      country:
+        description: Two-letter ISO code representing the country the bank account
+          is located in.
+        type:
+        - string
+      currency:
+        description: Three-letter ISO currency code representing the currency paid
+          out to the bank account.
+        type:
+        - string
+      customer:
+        description: ''
+        type:
+        - string
+      customer_reference:
+        description: ''
+        type:
+        - string
+      default_for_currency:
+        description: Whether this external account is the default account for its
+          currency.
+        type:
+        - boolean
+      fingerprint:
+        description: Uniquely identifies this particular bank account. You can use
+          this attribute to check whether two bank accounts are the same.
+        type:
+        - string
+      id:
+        description: ''
+        type:
+        - string
+      last4:
+        description: ''
+        type:
+        - string
+      metadata:
+        description: A set of key/value pairs that you can attach to a bank account
+          object. It can be useful for storing additional information about the bank
+          account in a structured format.
+        type:
+        - object
+      object:
+        description: ''
+        type:
+        - string
+      reusable:
+        description: ''
+        type:
+        - boolean
+      routing_number:
+        description: The routing transit number for the bank account.
+        type:
+        - string
+      status:
+        description: Possible values are `new`, `validated`, `verified`, `verification_failed`,
+          or `errored`. A bank account that hasn't had any activity or validation
+          performed is `new`. If Stripe can determine that the bank account exists,
+          its status will be `validated`. Note that there often isn’t enough information
+          to know (e.g. for smaller credit unions), and the validation is not always
+          run. If customer bank account verification has succeeded, the bank account
+          status will be `verified`. If the verification failed for any reason, such
+          as microdeposit failure, the status will be `verification_failed`. If a
+          transfer sent to this bank account fails, we'll set the status to `errored`
+          and will not continue to send transfers until the bank details are updated.
+        type:
+        - string
+      used:
+        description: ''
+        type:
+        - boolean
+    required:
+    - country
+    - currency
+    - id
+    - last4
+    - object
+    - status
+    title: BankAccount
+    type:
+    - object
+    x-resourceId: bank_account
   bitcoin_receiver:
     properties:
       active:
@@ -885,6 +1011,166 @@ definitions:
     type:
     - object
     x-resourceId: bitcoin_transaction
+  card:
+    properties:
+      account:
+        description: The account this card belongs to. This attribute will not be
+          in the card object if the card belongs to a customer or recipient instead.
+        type:
+        - string
+      address_city:
+        description: ''
+        type:
+        - string
+      address_country:
+        description: Billing address country, if provided when creating card.
+        type:
+        - string
+      address_line1:
+        description: ''
+        type:
+        - string
+      address_line1_check:
+        description: 'If `address_line1` was provided, results of the check: `pass`,
+          `fail`, `unavailable`, or `unchecked`.'
+        type:
+        - string
+      address_line2:
+        description: ''
+        type:
+        - string
+      address_state:
+        description: ''
+        type:
+        - string
+      address_zip:
+        description: ''
+        type:
+        - string
+      address_zip_check:
+        description: 'If `address_zip` was provided, results of the check: `pass`,
+          `fail`, `unavailable`, or `unchecked`.'
+        type:
+        - string
+      available_payout_methods:
+        description: A set of available payout methods for this card. Will be either
+          `["standard"]` or `["standard", "instant"]`. Only values from this set should
+          be passed as the `method` when creating a transfer.
+        type:
+        - array
+      brand:
+        description: Card brand. Can be `Visa`, `American Express`, `MasterCard`,
+          `Discover`, `JCB`, `Diners Club`, or `Unknown`.
+        type:
+        - string
+      country:
+        description: Two-letter ISO code representing the country of the card. You
+          could use this attribute to get a sense of the international breakdown of
+          cards you've collected.
+        type:
+        - string
+      currency:
+        description: Only applicable on accounts (not customers or recipients). The
+          card can be used as a transfer destination for funds in this currency.
+        type:
+        - string
+      customer:
+        description: The customer that this card belongs to. This attribute will not
+          be in the card object if the card belongs to an account or recipient instead.
+        type:
+        - string
+      cvc_check:
+        description: 'If a CVC was provided, results of the check: `pass`, `fail`,
+          `unavailable`, or `unchecked`.'
+        type:
+        - string
+      default_for_currency:
+        description: Only applicable on accounts (not customers or recipients). This
+          indicates whether or not this card is the default external account for its
+          currency.
+        type:
+        - boolean
+      dynamic_last4:
+        description: "(For tokenized numbers only.) The last four digits of the device
+          account number."
+        type:
+        - string
+      estimated_availability:
+        description: ''
+        type:
+        - string
+      exp_month:
+        description: ''
+        type:
+        - integer
+      exp_year:
+        description: ''
+        type:
+        - integer
+      fingerprint:
+        description: Uniquely identifies this particular card number. You can use
+          this attribute to check whether two customers who've signed up with you
+          are using the same card number, for example.
+        type:
+        - string
+      funding:
+        description: Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.
+        type:
+        - string
+      google_reference:
+        description: ''
+        type:
+        - string
+      id:
+        description: ID of card (used in conjunction with a customer or recipient
+          ID).
+        type:
+        - string
+      last4:
+        description: ''
+        type:
+        - string
+      metadata:
+        description: A set of key/value pairs that you can attach to a card object.
+          It can be useful for storing additional information about the card in a
+          structured format.
+        type:
+        - object
+      name:
+        description: Cardholder name.
+        type:
+        - string
+      object:
+        description: ''
+        type:
+        - string
+      recipient:
+        description: The recipient that this card belongs to. This attribute will
+          not be in the card object if the card belongs to a customer or account instead.
+        type:
+        - string
+      three_d_secure:
+        description: ''
+        type:
+        - object
+      tokenization_method:
+        description: If the card number is tokenized, this is the method that was
+          used. Can be `apple_pay` or `android_pay`.
+        type:
+        - string
+    required:
+    - brand
+    - exp_month
+    - exp_year
+    - funding
+    - id
+    - last4
+    - metadata
+    - object
+    title: Card
+    type:
+    - object
+    x-resourceId: card
   channel_settings:
     properties:
       twitter:
@@ -921,7 +1207,7 @@ definitions:
         - string
       application_fee:
         description: The application fee (if any) for the charge. [See the Connect
-          documentation](/docs/connect/payments-fees#collecting-fees) for details.
+          documentation](/docs/connect/direct-charges#collecting-fees) for details.
         type:
         - string
       balance_transaction:
@@ -935,7 +1221,7 @@ definitions:
         type:
         - boolean
       card:
-        "$ref": "#/definitions/payment_card"
+        "$ref": "#/definitions/card"
       created:
         description: ''
         type:
@@ -955,7 +1241,7 @@ definitions:
         - string
       destination:
         description: The account (if any) the charge was made on behalf of, with an
-          automatic transfer. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform)
+          automatic transfer. [See the Connect documentation](/docs/connect/destination-charges)
           for details.
         type:
         - string
@@ -1004,7 +1290,7 @@ definitions:
         - string
       on_behalf_of:
         description: The account (if any) the charge was made on behalf of without
-          triggering an automatic transfer. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform)
+          triggering an automatic transfer. See the [Connect documentation](/docs/connect/charges-transfers)
           for details.
         type:
         - string
@@ -1077,7 +1363,7 @@ definitions:
         "$ref": "#/definitions/shipping"
       source_transfer:
         description: The transfer ID which created this charge. Only present if the
-          charge came from another Stripe account. [See the Connect documentation](/docs/connect/payments-fees#charging-through-the-platform)
+          charge came from another Stripe account. [See the Connect documentation](/docs/connect/destination-charges)
           for details.
         type:
         - string
@@ -1098,7 +1384,8 @@ definitions:
         - string
       transfer_group:
         description: A string that identifies this transaction as part of a group.
-          [See the Connect documentation](/docs/connect/transfer-group) for details.
+          See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions)
+          for details.
         type:
         - string
     required:
@@ -1153,8 +1440,9 @@ definitions:
         type:
         - string
       type:
-        description: Possible values are `authorized`, `issuer_declined`, `blocked`,
-          and `invalid`. See [understanding declines](/docs/declines) for details.
+        description: Possible values are `authorized`, `manual_review`, `issuer_declined`,
+          `blocked`, and `invalid`. See [understanding declines](/docs/declines) and
+          [Radar reviews](radar/review) for details.
         type:
         - string
     required:
@@ -1193,7 +1481,7 @@ definitions:
           need to [enable bitcoin](https://dashboard.stripe.com/account/bitcoin/enable)
           and [ACH](https://stripe.com/docs/guides/ach) payments on your account for
           those methods to appear in this list. The `stripe` payment method refers
-          to [charging through your platform](https://stripe.com/docs/connect/payments-fees#charging-through-the-platform).
+          to [charging through your platform](https://stripe.com/docs/connect/destination-charges).
         type:
         - array
       verification_fields:
@@ -1346,7 +1634,7 @@ definitions:
         properties:
           data:
             items:
-              "$ref": "#/definitions/payment_bank_account"
+              "$ref": "#/definitions/bank_account"
             type:
             - array
           has_more:
@@ -1374,7 +1662,7 @@ definitions:
         - has_more
         - object
         - url
-        title: PaymentBankAccountList
+        title: BankAccountList
         type:
         - object
       business_vat_id:
@@ -1385,7 +1673,7 @@ definitions:
         properties:
           data:
             items:
-              "$ref": "#/definitions/payment_card"
+              "$ref": "#/definitions/card"
             type:
             - array
           has_more:
@@ -1413,7 +1701,7 @@ definitions:
         - has_more
         - object
         - url
-        title: PaymentCardList
+        title: CardList
         type:
         - object
       created:
@@ -1578,6 +1866,10 @@ definitions:
     x-resourceId: customer_shipping
   customer_source:
     properties:
+      customer:
+        description: ''
+        type:
+        - string
       id:
         description: ''
         type:
@@ -1594,7 +1886,6 @@ definitions:
         - string
     required:
     - id
-    - metadata
     - object
     title: Polymorphic
     type:
@@ -1902,6 +2193,10 @@ definitions:
           out to the bank account.
         type:
         - string
+      customer:
+        description: ''
+        type:
+        - string
       default_for_currency:
         description: Whether this external account is the default account for its
           currency.
@@ -1931,13 +2226,10 @@ definitions:
         type:
         - string
     required:
-    - account
     - country
     - currency
-    - default_for_currency
     - id
     - last4
-    - metadata
     - object
     title: Polymorphic
     type:
@@ -2610,7 +2902,8 @@ definitions:
         - string
       transfer_group:
         description: A string that identifies this transaction as part of a group.
-          [See the Connect documentation](/docs/connect/transfer-group) for details.
+          See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions)
+          for details.
         type:
         - string
       type:
@@ -3167,246 +3460,6 @@ definitions:
     type:
     - object
     x-resourceId: package_dimensions
-  payment_bank_account:
-    properties:
-      account_holder_name:
-        description: The name of the person or business that owns the bank account.
-        type:
-        - string
-      account_holder_type:
-        description: The type of entity that holds the account. This can be either
-          `individual` or `company`.
-        type:
-        - string
-      address_city:
-        description: ''
-        type:
-        - string
-      address_line1:
-        description: ''
-        type:
-        - string
-      address_line2:
-        description: ''
-        type:
-        - string
-      address_state:
-        description: ''
-        type:
-        - string
-      address_zip:
-        description: ''
-        type:
-        - string
-      bank_name:
-        description: Name of the bank associated with the routing number, e.g. `WELLS
-          FARGO`.
-        type:
-        - string
-      country:
-        description: Two-letter ISO code representing the country the bank account
-          is located in.
-        type:
-        - string
-      currency:
-        description: Three-letter ISO currency code representing the currency paid
-          out to the bank account.
-        type:
-        - string
-      customer:
-        description: ''
-        type:
-        - string
-      customer_reference:
-        description: ''
-        type:
-        - string
-      fingerprint:
-        description: Uniquely identifies this particular bank account. You can use
-          this attribute to check whether two bank accounts are the same.
-        type:
-        - string
-      id:
-        description: ''
-        type:
-        - string
-      last4:
-        description: ''
-        type:
-        - string
-      metadata:
-        description: ''
-        type:
-        - object
-      object:
-        description: ''
-        type:
-        - string
-      reusable:
-        description: ''
-        type:
-        - boolean
-      routing_number:
-        description: The routing transit number for the bank account.
-        type:
-        - string
-      status:
-        description: Possible values are `new`, `validated`, `verified`, `verification_failed`,
-          or `errored`. A bank account that hasn't had any activity or validation
-          performed is `new`. If Stripe can determine that the bank account exists,
-          its status will be `validated`. Note that there often isn’t enough information
-          to know (e.g. for smaller credit unions), and the validation is not always
-          run. If customer bank account verification has succeeded, the bank account
-          status will be `verified`. If the verification failed for any reason, such
-          as microdeposit failure, the status will be `verification_failed`. If a
-          transfer sent to this bank account fails, we'll set the status to `errored`
-          and will not continue to send transfers until the bank details are updated.
-        type:
-        - string
-      used:
-        description: ''
-        type:
-        - boolean
-    required:
-    - country
-    - currency
-    - id
-    - last4
-    - metadata
-    - object
-    - status
-    title: PaymentBankAccount
-    type:
-    - object
-    x-resourceId: payment_bank_account
-  payment_card:
-    properties:
-      address_city:
-        description: ''
-        type:
-        - string
-      address_country:
-        description: Billing address country, if provided when creating card.
-        type:
-        - string
-      address_line1:
-        description: ''
-        type:
-        - string
-      address_line1_check:
-        description: 'If `address_line1` was provided, results of the check: `pass`,
-          `fail`, `unavailable`, or `unchecked`.'
-        type:
-        - string
-      address_line2:
-        description: ''
-        type:
-        - string
-      address_state:
-        description: ''
-        type:
-        - string
-      address_zip:
-        description: ''
-        type:
-        - string
-      address_zip_check:
-        description: 'If `address_zip` was provided, results of the check: `pass`,
-          `fail`, `unavailable`, or `unchecked`.'
-        type:
-        - string
-      brand:
-        description: Card brand. Can be `Visa`, `American Express`, `MasterCard`,
-          `Discover`, `JCB`, `Diners Club`, or `Unknown`.
-        type:
-        - string
-      country:
-        description: Two-letter ISO code representing the country of the card. You
-          could use this attribute to get a sense of the international breakdown of
-          cards you've collected.
-        type:
-        - string
-      customer:
-        description: ''
-        type:
-        - string
-      cvc_check:
-        description: 'If a CVC was provided, results of the check: `pass`, `fail`,
-          `unavailable`, or `unchecked`.'
-        type:
-        - string
-      dynamic_last4:
-        description: "(For tokenized numbers only.) The last four digits of the device
-          account number."
-        type:
-        - string
-      exp_month:
-        description: ''
-        type:
-        - integer
-      exp_year:
-        description: ''
-        type:
-        - integer
-      fingerprint:
-        description: Uniquely identifies this particular card number. You can use
-          this attribute to check whether two customers who've signed up with you
-          are using the same card number, for example.
-        type:
-        - string
-      funding:
-        description: Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.
-        type:
-        - string
-      google_reference:
-        description: ''
-        type:
-        - string
-      id:
-        description: ID of card (used in conjunction with a customer or recipient
-          ID).
-        type:
-        - string
-      last4:
-        description: ''
-        type:
-        - string
-      metadata:
-        description: A set of key/value pairs that you can attach to a card object.
-          It can be useful for storing additional information about the card in a
-          structured format.
-        type:
-        - object
-      name:
-        description: Cardholder name.
-        type:
-        - string
-      object:
-        description: ''
-        type:
-        - string
-      three_d_secure:
-        description: ''
-        type:
-        - object
-      tokenization_method:
-        description: If the card number is tokenized, this is the method that was
-          used. Can be `apple_pay` or `android_pay`.
-        type:
-        - string
-    required:
-    - brand
-    - exp_month
-    - exp_year
-    - funding
-    - id
-    - last4
-    - metadata
-    - object
-    title: PaymentCard
-    type:
-    - object
-    x-resourceId: payment_card
   plan:
     properties:
       amount:
@@ -3711,241 +3764,6 @@ definitions:
     type:
     - object
     x-resourceId: product
-  recipient_payout_bank_account:
-    properties:
-      account_holder_name:
-        description: The name of the person or business that owns the bank account.
-        type:
-        - string
-      account_holder_type:
-        description: The type of entity that holds the account. This can be either
-          `individual` or `company`.
-        type:
-        - string
-      address_city:
-        description: ''
-        type:
-        - string
-      address_line1:
-        description: ''
-        type:
-        - string
-      address_line2:
-        description: ''
-        type:
-        - string
-      address_state:
-        description: ''
-        type:
-        - string
-      address_zip:
-        description: ''
-        type:
-        - string
-      allows_debits:
-        description: ''
-        type:
-        - boolean
-      bank_name:
-        description: Name of the bank associated with the routing number, e.g. `WELLS
-          FARGO`.
-        type:
-        - string
-      country:
-        description: Two-letter ISO code representing the country the bank account
-          is located in.
-        type:
-        - string
-      currency:
-        description: Three-letter ISO currency code representing the currency paid
-          out to the bank account.
-        type:
-        - string
-      fingerprint:
-        description: Uniquely identifies this particular bank account. You can use
-          this attribute to check whether two bank accounts are the same.
-        type:
-        - string
-      id:
-        description: ''
-        type:
-        - string
-      last4:
-        description: ''
-        type:
-        - string
-      object:
-        description: ''
-        type:
-        - string
-      reusable:
-        description: ''
-        type:
-        - boolean
-      routing_number:
-        description: The routing transit number for the bank account.
-        type:
-        - string
-      status:
-        description: Possible values are `new`, `validated`, `verified`, `verification_failed`,
-          or `errored`. A bank account that hasn't had any activity or validation
-          performed is `new`. If Stripe can determine that the bank account exists,
-          its status will be `validated`. Note that there often isn’t enough information
-          to know (e.g. for smaller credit unions), and the validation is not always
-          run. If customer bank account verification has succeeded, the bank account
-          status will be `verified`. If the verification failed for any reason, such
-          as microdeposit failure, the status will be `verification_failed`. If a
-          transfer sent to this bank account fails, we'll set the status to `errored`
-          and will not continue to send transfers until the bank details are updated.
-        type:
-        - string
-      used:
-        description: ''
-        type:
-        - boolean
-    required:
-    - country
-    - currency
-    - id
-    - last4
-    - object
-    - status
-    title: RecipientPayoutBankAccount
-    type:
-    - object
-    x-resourceId: recipient_payout_bank_account
-  recipient_payout_card:
-    properties:
-      address_city:
-        description: ''
-        type:
-        - string
-      address_country:
-        description: Billing address country, if provided when creating card.
-        type:
-        - string
-      address_line1:
-        description: ''
-        type:
-        - string
-      address_line1_check:
-        description: 'If `address_line1` was provided, results of the check: `pass`,
-          `fail`, `unavailable`, or `unchecked`.'
-        type:
-        - string
-      address_line2:
-        description: ''
-        type:
-        - string
-      address_state:
-        description: ''
-        type:
-        - string
-      address_zip:
-        description: ''
-        type:
-        - string
-      address_zip_check:
-        description: 'If `address_zip` was provided, results of the check: `pass`,
-          `fail`, `unavailable`, or `unchecked`.'
-        type:
-        - string
-      brand:
-        description: Card brand. Can be `Visa`, `American Express`, `MasterCard`,
-          `Discover`, `JCB`, `Diners Club`, or `Unknown`.
-        type:
-        - string
-      country:
-        description: Two-letter ISO code representing the country of the card. You
-          could use this attribute to get a sense of the international breakdown of
-          cards you've collected.
-        type:
-        - string
-      cvc_check:
-        description: 'If a CVC was provided, results of the check: `pass`, `fail`,
-          `unavailable`, or `unchecked`.'
-        type:
-        - string
-      dynamic_last4:
-        description: "(For tokenized numbers only.) The last four digits of the device
-          account number."
-        type:
-        - string
-      estimated_availability:
-        description: ''
-        type:
-        - string
-      exp_month:
-        description: ''
-        type:
-        - integer
-      exp_year:
-        description: ''
-        type:
-        - integer
-      fingerprint:
-        description: Uniquely identifies this particular card number. You can use
-          this attribute to check whether two customers who've signed up with you
-          are using the same card number, for example.
-        type:
-        - string
-      funding:
-        description: Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`.
-        type:
-        - string
-      google_reference:
-        description: ''
-        type:
-        - string
-      id:
-        description: ID of card (used in conjunction with a customer or recipient
-          ID).
-        type:
-        - string
-      last4:
-        description: ''
-        type:
-        - string
-      metadata:
-        description: A set of key/value pairs that you can attach to a card object.
-          It can be useful for storing additional information about the card in a
-          structured format.
-        type:
-        - object
-      name:
-        description: Cardholder name.
-        type:
-        - string
-      object:
-        description: ''
-        type:
-        - string
-      recipient:
-        description: ''
-        type:
-        - string
-      three_d_secure:
-        description: ''
-        type:
-        - object
-      tokenization_method:
-        description: If the card number is tokenized, this is the method that was
-          used. Can be `apple_pay` or `android_pay`.
-        type:
-        - string
-    required:
-    - brand
-    - exp_month
-    - exp_year
-    - funding
-    - id
-    - last4
-    - metadata
-    - object
-    title: RecipientPayoutCard
-    type:
-    - object
-    x-resourceId: recipient_payout_card
   refund:
     properties:
       amount:
@@ -4734,7 +4552,7 @@ definitions:
         type:
         - boolean
       card:
-        "$ref": "#/definitions/payment_card"
+        "$ref": "#/definitions/card"
       created:
         description: ''
         type:
@@ -5172,12 +4990,12 @@ definitions:
   transfer_recipient:
     properties:
       active_account:
-        "$ref": "#/definitions/recipient_payout_bank_account"
+        "$ref": "#/definitions/bank_account"
       cards:
         properties:
           data:
             items:
-              "$ref": "#/definitions/recipient_payout_card"
+              "$ref": "#/definitions/card"
             type:
             - array
           has_more:
@@ -5205,7 +5023,7 @@ definitions:
         - has_more
         - object
         - url
-        title: RecipientPayoutCardList
+        title: CardList
         type:
         - object
       created:
@@ -5645,7 +5463,7 @@ info:
     details.
   termsOfService: https://stripe.com/us/terms/
   title: Stripe API
-  version: '2017-01-27'
+  version: '2017-02-14'
 paths:
   "/v1/3d_secure":
     post:
@@ -5879,7 +5697,7 @@ paths:
               - string
             statement_descriptor:
               description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).
+                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
               title: statement_descriptor
               type:
               - string
@@ -6395,7 +6213,7 @@ paths:
               - string
             statement_descriptor:
               description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).
+                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
               title: statement_descriptor
               type:
               - string
@@ -6602,7 +6420,7 @@ paths:
               - string
             statement_descriptor:
               description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/payments-fees#charging-directly).
+                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
               title: statement_descriptor
               type:
               - string
@@ -7558,14 +7376,14 @@ paths:
           description: Error response.
           schema:
             "$ref": "#/definitions/error"
-  "/v1/bitcoin/payments/{payment}/refund":
+  "/v1/bitcoin/payments/{charge}/refund":
     post:
       description: ''
       operationId: CreatePaymentRefundWithPaymentResponse
       parameters:
       - description: ''
         in: path
-        name: payment
+        name: charge
         required: true
         type: string
       - description: Body parameters for the request.
@@ -7579,11 +7397,6 @@ paths:
               title: amount
               type:
               - integer
-            charge:
-              description: ''
-              title: charge
-              type:
-              - string
             description:
               description: ''
               title: description
@@ -7619,8 +7432,6 @@ paths:
               title: reverse_transfer
               type:
               - boolean
-          required:
-          - charge
       responses:
         '200':
           description: Successful response.
@@ -8203,11 +8014,6 @@ paths:
               title: capture
               type:
               - boolean
-            card:
-              description: ''
-              title: card
-              type:
-              - string
             currency:
               description: ''
               title: currency
@@ -8417,6 +8223,14 @@ paths:
               title: shipping
               type:
               - object
+            transfer_group:
+              description: A string that identifies this transaction as part of a
+                group. `transfer_group` may only be provided if it has not been set.
+                See the [Connect documentation](/docs/connect/charges-transfers#grouping-transactions)
+                for details.
+              title: transfer_group
+              type:
+              - string
       responses:
         '200':
           description: Successful response.
@@ -8599,11 +8413,6 @@ paths:
               title: metadata
               type:
               - object
-            payment:
-              description: ''
-              title: payment
-              type:
-              - string
             reason:
               description: ''
               title: reason
@@ -9646,7 +9455,7 @@ paths:
             properties:
               data:
                 items:
-                  "$ref": "#/definitions/payment_bank_account"
+                  "$ref": "#/definitions/bank_account"
                 type:
                 - array
               has_more:
@@ -9674,7 +9483,7 @@ paths:
             - has_more
             - object
             - url
-            title: PaymentBankAccountList
+            title: BankAccountList
             type:
             - object
         default:
@@ -9754,7 +9563,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_bank_account"
+            "$ref": "#/definitions/bank_account"
         default:
           description: Error response.
           schema:
@@ -9838,7 +9647,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -9879,7 +9688,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_bank_account"
+            "$ref": "#/definitions/bank_account"
         default:
           description: Error response.
           schema:
@@ -9925,7 +9734,7 @@ paths:
             properties:
               data:
                 items:
-                  "$ref": "#/definitions/payment_card"
+                  "$ref": "#/definitions/card"
                 type:
                 - array
               has_more:
@@ -9953,7 +9762,7 @@ paths:
             - has_more
             - object
             - url
-            title: PaymentCardList
+            title: CardList
             type:
             - object
         default:
@@ -10026,7 +9835,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -10110,7 +9919,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -10374,7 +10183,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -10415,7 +10224,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/payment_bank_account"
+            "$ref": "#/definitions/bank_account"
         default:
           description: Error response.
           schema:
@@ -11449,13 +11258,12 @@ paths:
         name: ending_before
         required: false
         type: string
-      - description: The identifier of the customer whose invoices to return. If none
-          is provided, all invoices will be returned.
+      - description: The identifier of the customer whose invoices to return.
         in: query
         name: customer
         required: false
         type: string
-      - description: ''
+      - description: The identifier of the subscription whose invoices to return.
         in: query
         name: subscription
         required: false
@@ -11659,6 +11467,13 @@ paths:
         name: subscription_trial_end
         required: false
         type: integer
+      - description: If provided, the invoice returned will preview updating or creating
+          a subscription with that tax percent. If set, one of `subscription_plan`
+          or `subscription` is required.
+        in: query
+        name: subscription_tax_percent
+        required: false
+        type: number
       - description: The code of the coupon to apply. If a `subscription` or `subscription_plan`
           is provided, the invoice returned will preview updating or creating a subscription
           with that coupon. Otherwise, it will preview applying that coupon to the
@@ -11862,6 +11677,11 @@ paths:
         name: subscription_trial_end
         required: false
         type: integer
+      - description: ''
+        in: query
+        name: subscription_tax_percent
+        required: false
+        type: number
       - description: For upcoming invoices, preview applying this coupon to the invoice.
           If a `subscription` or `subscription_plan` is provided, the invoice returned
           will preview updating or creating a subscription with that coupon. Otherwise,
@@ -13489,7 +13309,7 @@ paths:
             properties:
               data:
                 items:
-                  "$ref": "#/definitions/recipient_payout_card"
+                  "$ref": "#/definitions/card"
                 type:
                 - array
               has_more:
@@ -13517,7 +13337,7 @@ paths:
             - has_more
             - object
             - url
-            title: RecipientPayoutCardList
+            title: CardList
             type:
             - object
         default:
@@ -13550,7 +13370,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/recipient_payout_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -13574,7 +13394,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/recipient_payout_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -13597,7 +13417,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/recipient_payout_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -13661,7 +13481,7 @@ paths:
         '200':
           description: Successful response.
           schema:
-            "$ref": "#/definitions/recipient_payout_card"
+            "$ref": "#/definitions/card"
         default:
           description: Error response.
           schema:
@@ -14181,6 +14001,11 @@ paths:
         required: false
         schema:
           properties:
+            alipay:
+              description: ''
+              title: alipay
+              type:
+              - object
             amount:
               description: Amount associated with the source. This is the amount for
                 which the source will be chargeable once ready. Required for `single-use`
@@ -15224,6 +15049,11 @@ paths:
               title: metadata
               type:
               - object
+            source_transaction:
+              description: ''
+              title: source_transaction
+              type:
+              - string
             transfer_group:
               description: ''
               title: transfer_group

--- a/test/stripe/recipient_card_test.rb
+++ b/test/stripe/recipient_card_test.rb
@@ -12,7 +12,7 @@ module Stripe
     should "be listable" do
       cards = @recipient.cards.list
       assert cards.data.kind_of?(Array)
-      assert cards.data[0].kind_of?(Stripe::Token)
+      assert cards.data[0].kind_of?(Stripe::Card)
     end
 
     should "be creatable" do
@@ -20,7 +20,7 @@ module Stripe
         card: API_FIXTURES.fetch(:token)[:id]
       )
       assert_requested :post, "#{Stripe.api_base}/v1/recipients/#{@recipient.id}/cards"
-      assert card.kind_of?(Stripe::Token)
+      assert card.kind_of?(Stripe::Card)
     end
 
     should "be deletable" do


### PR DESCRIPTION
Uses our latest generated OpenAPI spec.

We end up having to change the expected resource on a few tests because bank accounts and cards were recently consolidated into a single resource internally and this led to some synthesized responses becoming a little more accurate.