### PR TITLE
Adds support for detaching sources from customers

### DIFF
--- a/lib/stripe/card.rb
+++ b/lib/stripe/card.rb
@@ -5,11 +5,11 @@ module Stripe
     extend Stripe::APIOperations::List
 
     def resource_url
-      if respond_to?(:recipient)
+      if respond_to?(:recipient) && !recipient.nil? && !recipient.empty?
         "#{Recipient.resource_url}/#{CGI.escape(recipient)}/cards/#{CGI.escape(id)}"
-      elsif respond_to?(:customer)
+      elsif respond_to?(:customer) && !customer.nil? && !customer.empty?
         "#{Customer.resource_url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
-      elsif respond_to?(:account)
+      elsif respond_to?(:account) && !account.nil? && !account.empty?
         "#{Account.resource_url}/#{CGI.escape(account)}/external_accounts/#{CGI.escape(id)}"
       end
     end

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -3,8 +3,18 @@ module Stripe
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Save
 
+    def delete(params={}, opts={})
+      if respond_to?(:customer) && !customer.nil?
+        url = "#{Customer.resource_url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
+        resp, opts = request(:delete, url, params, Util.normalize_opts(opts))
+        initialize_from(resp.data, opts)
+      else
+        raise NotImplementedError.new("Source objects cannot be deleted, they can only be detached from customer objects. This source object does not appear to be currently attached to a customer object.")
+      end
+    end
+
     def verify(params={}, opts={})
-      resp, opts = request(:post, resource_url + '/verify', params, opts)
+      resp, opts = request(:post, resource_url + '/verify', params, Util.normalize_opts(opts))
       initialize_from(resp.data, opts)
     end
   end

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -4,7 +4,7 @@ module Stripe
     include Stripe::APIOperations::Save
 
     def delete(params={}, opts={})
-      if respond_to?(:customer) && !customer.nil?
+      if respond_to?(:customer) && !customer.nil? && !customer.empty?
         url = "#{Customer.resource_url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
         resp, opts = request(:delete, url, params, Util.normalize_opts(opts))
         initialize_from(resp.data, opts)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -50,6 +50,7 @@ module Stripe
         'recipient'               => Recipient,
         'refund'                  => Refund,
         'sku'                     => SKU,
+        'source'                  => Source,
         'subscription'            => Subscription,
         'subscription_item'       => SubscriptionItem,
         'three_d_secure'          => ThreeDSecure,

--- a/openapi/fixtures.json
+++ b/openapi/fixtures.json
@@ -19,7 +19,7 @@
     "default_currency": "usd",
     "details_submitted": false,
     "display_name": "",
-    "email": "foo+ujebwko0fp@example.com",
+    "email": "foo+os4pphkove@example.com",
     "external_accounts": {
       "data": [
 
@@ -27,10 +27,10 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/accounts/acct_19xOmSA6KsQaPpsx/external_accounts"
+      "url": "/v1/accounts/acct_19y6HAAylotNGqt3/external_accounts"
     },
     "fake_account": false,
-    "id": "acct_19xOmSA6KsQaPpsx",
+    "id": "acct_19y6HAAylotNGqt3",
     "legal_entity": {
       "additional_owners": null,
       "address": {
@@ -138,11 +138,11 @@
     "default_currency": "usd",
     "details_submitted": false,
     "display_name": "",
-    "email": "foo+ujebwko0fp@example.com",
+    "email": "foo+os4pphkove@example.com",
     "external_accounts": {
     },
     "fake_account": false,
-    "id": "acct_19xOmSA6KsQaPpsx",
+    "id": "acct_19y6HAAylotNGqt3",
     "keys": {
     },
     "legal_entity": {
@@ -177,8 +177,8 @@
   "alipay_account": {
     "created": 1234567890,
     "customer": "",
-    "fingerprint": "NmrPSTwAXOffguOu",
-    "id": "aliacc_19xOmZA6KsQaPpsx8SQGAn0E",
+    "fingerprint": "eiRpjVAne6V7vzjH",
+    "id": "aliacc_19y6HIAylotNGqt3CWxIarua",
     "livemode": false,
     "metadata": {
     },
@@ -192,7 +192,7 @@
   "apple_pay_domain": {
     "created": 1234567890,
     "domain_name": "example.com",
-    "id": "apwc_19xOmYA6KsQaPpsxDX3zqwLL",
+    "id": "apwc_19y6HHAylotNGqt3514QiFTd",
     "livemode": true,
     "object": "apple_pay_domain"
   },
@@ -233,17 +233,17 @@
     "fee_details": [
 
     ],
-    "id": "txn_19xOmYA6KsQaPpsxgSCbKQ3d",
+    "id": "txn_19y6HHAylotNGqt33AMqhSaS",
     "net": 100,
     "object": "balance_transaction",
-    "source": "ch_19xOmYA6KsQaPpsxRpMRzREK",
+    "source": "ch_19y6HHAylotNGqt3dguVG1mI",
     "sourced_transfers": {
     },
     "status": "pending",
     "type": "charge"
   },
   "bank_account": {
-    "account": "acct_19xOmSA6KsQaPpsx",
+    "account": "acct_19y6HAAylotNGqt3",
     "account_holder_name": "Jane Austen",
     "account_holder_type": "individual",
     "address_city": "",
@@ -259,8 +259,8 @@
     "customer": "",
     "customer_reference": "",
     "default_for_currency": false,
-    "fingerprint": "rhUqyC2EcjMewT6o",
-    "id": "ba_19xOmZA6KsQaPpsx7DTyLvtT",
+    "fingerprint": "G8AlCiZpIixKrovm",
+    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
     "last4": "6789",
     "metadata": {
     },
@@ -283,7 +283,7 @@
     "description": "Receiver for John Doe",
     "email": "test@example.com",
     "filled": false,
-    "id": "btcrcv_19xOmZA6KsQaPpsx8TtHgMVX",
+    "id": "btcrcv_19y6HIAylotNGqt3PPrzs2zr",
     "inbound_address": "test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1",
     "livemode": false,
     "metadata": {
@@ -301,9 +301,9 @@
     "bitcoin_amount": 1757908,
     "created": 1234567890,
     "currency": "usd",
-    "id": "btctxn_19xOmZA6KsQaPpsx5FnHoZis",
+    "id": "btctxn_19y6HIAylotNGqt3ufx7IrFQ",
     "object": "bitcoin_transaction",
-    "receiver": "btcrcv_19xOmZB4YnRyKoofPMbLFiZa"
+    "receiver": "btcrcv_19y6HIBBq8Um5VVVjcO0R7nU"
   },
   "card": {
     "3d_secure": {
@@ -335,7 +335,7 @@
     "fingerprint": "",
     "funding": "unknown",
     "google_reference": "",
-    "id": "card_19xOmYA6KsQaPpsx93IwBRHM",
+    "id": "card_19y6HHAylotNGqt3SvYv7I1c",
     "iin": "",
     "issuer": "",
     "last4": "4242",
@@ -359,7 +359,7 @@
     "application_fee": "",
     "application_fees_refunded": 0,
     "authorization_code": "",
-    "balance_transaction": "txn_19xOmYA6KsQaPpsxgSCbKQ3d",
+    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
     "captured": true,
     "card": {
     },
@@ -375,7 +375,7 @@
     },
     "fraud_details": {
     },
-    "id": "ch_19xOmYA6KsQaPpsxRpMRzREK",
+    "id": "ch_19y6HHAylotNGqt3dguVG1mI",
     "invoice": "",
     "level3": {
     },
@@ -398,7 +398,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/charges/ch_19xOmYA6KsQaPpsxRpMRzREK/refunds"
+      "url": "/v1/charges/ch_19y6HHAylotNGqt3dguVG1mI/refunds"
     },
     "review": "",
     "shipping": {
@@ -420,7 +420,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19xOmYA6KsQaPpsx93IwBRHM",
+      "id": "card_19y6HHAylotNGqt3SvYv7I1c",
       "last4": "4242",
       "metadata": {
       },
@@ -514,7 +514,7 @@
     "discount": {
     },
     "email": "",
-    "id": "cus_AHykWO1tNrvBO2",
+    "id": "cus_AIhgCDhEsqLqXq",
     "livemode": false,
     "metadata": {
     },
@@ -528,7 +528,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/customers/cus_AHykWO1tNrvBO2/sources"
+      "url": "/v1/customers/cus_AIhgCDhEsqLqXq/sources"
     },
     "subscription": {
     },
@@ -539,7 +539,7 @@
   },
   "customer_source": {
     "customer": "",
-    "id": "ba_19xOmZA6KsQaPpsx7DTyLvtT",
+    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
     "metadata": {
     },
     "object": "bank_account"
@@ -547,7 +547,7 @@
   "discount": {
     "coupon": {
       "amount_off": null,
-      "created": 1489533023,
+      "created": 1489700220,
       "currency": "usd",
       "duration": "repeating",
       "duration_in_months": 3,
@@ -562,7 +562,7 @@
       "times_redeemed": 0,
       "valid": true
     },
-    "customer": "cus_AHykWO1tNrvBO2",
+    "customer": "cus_AIhgCDhEsqLqXq",
     "end": 1234567890,
     "object": "discount",
     "start": 1234567890,
@@ -575,7 +575,7 @@
     "balance_transactions": [
 
     ],
-    "charge": "ch_19xOmYA6KsQaPpsxRpMRzREK",
+    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
     "closed_at": 1234567890,
     "created": 1234567890,
     "currency": "usd",
@@ -610,7 +610,7 @@
       "uncategorized_text": null
     },
     "evidence_details": {
-      "due_by": 1491177599,
+      "due_by": 1491350399,
       "has_evidence": false,
       "past_due": false,
       "submission_count": 0
@@ -618,7 +618,7 @@
     "evidence_submitted_at": [
 
     ],
-    "id": "dp_19xOmYA6KsQaPpsxF27xl8iJ",
+    "id": "dp_19y6HHAylotNGqt3bvR7ZOnH",
     "is_charge_refundable": false,
     "is_protected": false,
     "livemode": false,
@@ -636,7 +636,7 @@
     "data": {
       "object": {
         "amount": 2000,
-        "created": 1489533023,
+        "created": 1489700220,
         "currency": "usd",
         "id": "gold",
         "interval": "month",
@@ -650,7 +650,7 @@
         "trial_period_days": null
       }
     },
-    "id": "evt_19xOmZA6KsQaPpsxg3PnM6Ax",
+    "id": "evt_19y6HIAylotNGqt349zSXYCk",
     "livemode": false,
     "object": "event",
     "pending_webhooks": 0,
@@ -659,7 +659,7 @@
     "type": "plan.created"
   },
   "external_account_source": {
-    "account": "acct_19xOmSA6KsQaPpsx",
+    "account": "acct_19y6HAAylotNGqt3",
     "address_city": "",
     "address_line1": "",
     "address_line2": "",
@@ -669,8 +669,8 @@
     "currency": "usd",
     "customer": "",
     "default_for_currency": false,
-    "fingerprint": "rhUqyC2EcjMewT6o",
-    "id": "ba_19xOmZA6KsQaPpsx7DTyLvtT",
+    "fingerprint": "G8AlCiZpIixKrovm",
+    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
     "last4": "6789",
     "metadata": {
     },
@@ -681,8 +681,8 @@
     "balance_transaction": "",
     "created": 1234567890,
     "currency": "usd",
-    "fee": "fee_19xOmZA6KsQaPpsxZCoZI7Ep",
-    "id": "fr_AHykVrc8RYtq3K",
+    "fee": "fee_19y6HIAylotNGqt3iEVMbEmJ",
+    "id": "fr_AIhghI4mXRpLEw",
     "metadata": {
     },
     "object": "fee_refund"
@@ -696,7 +696,7 @@
     "charge": "",
     "closed": false,
     "currency": "usd",
-    "customer": "cus_AHykWO1tNrvBO2",
+    "customer": "cus_AIhgCDhEsqLqXq",
     "date": 1234567890,
     "description": "",
     "discount": {
@@ -704,7 +704,7 @@
     "due_date": 1234567890,
     "ending_balance": 0,
     "forgiven": false,
-    "id": "in_19xOmZA6KsQaPpsxpXZEk0Jl",
+    "id": "in_19y6HIAylotNGqt3Kq1NUy5r",
     "lines": {
       "data": [
         {
@@ -712,18 +712,18 @@
           "currency": "usd",
           "description": null,
           "discountable": true,
-          "id": "sub_AHyk2EXaU2gAEV",
+          "id": "sub_AIhgP3KgCUJMuh",
           "livemode": true,
           "metadata": {
           },
           "object": "line_item",
           "period": {
-            "end": 1494803422,
-            "start": 1492211422
+            "end": 1494970619,
+            "start": 1492378619
           },
           "plan": {
             "amount": 2000,
-            "created": 1489533023,
+            "created": 1489700220,
             "currency": "usd",
             "id": "gold",
             "interval": "month",
@@ -739,13 +739,13 @@
           "proration": false,
           "quantity": 1,
           "subscription": null,
-          "subscription_item": "si_19xOmYB4YnRyKoofnPXr05OV",
+          "subscription_item": "si_19y6HHBBq8Um5VVVeabmVesw",
           "type": "subscription"
         }
       ],
       "object": "list",
       "total_count": 1,
-      "url": "/v1/invoices/in_19xOmZA6KsQaPpsxpXZEk0Jl/lines"
+      "url": "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
     },
     "livemode": false,
     "metadata": {
@@ -770,19 +770,19 @@
   "invoice_item": {
     "amount": 1000,
     "currency": "usd",
-    "customer": "cus_AHykWO1tNrvBO2",
+    "customer": "cus_AIhgCDhEsqLqXq",
     "date": 1234567890,
     "description": "My First Invoice Item (created for API docs)",
     "discountable": true,
-    "id": "ii_19xOmZA6KsQaPpsxw92LOZet",
+    "id": "ii_19y6HIAylotNGqt36BYYgGHq",
     "invoice": "",
     "livemode": false,
     "metadata": {
     },
     "object": "invoiceitem",
     "period": {
-      "end": 1489533023,
-      "start": 1489533023
+      "end": 1489700220,
+      "start": 1489700220
     },
     "plan": {
     },
@@ -796,14 +796,14 @@
     "currency": "usd",
     "description": "My First Invoice Item (created for API docs)",
     "discountable": true,
-    "id": "ii_19xOmZA6KsQaPpsxw92LOZet",
+    "id": "ii_19y6HIAylotNGqt36BYYgGHq",
     "livemode": false,
     "metadata": {
     },
     "object": "line_item",
     "period": {
-      "end": 1489533023,
-      "start": 1489533023
+      "end": 1489700220,
+      "start": 1489700220
     },
     "plan": {
     },
@@ -828,11 +828,11 @@
     "date": 1234567890,
     "delay_reason": "",
     "description": "Transfer to test@example.com",
-    "destination": "ba_19xOmZA6KsQaPpsxBhLhCCLJ",
+    "destination": "ba_19y6HIAylotNGqt3Tk6btLgn",
     "destination_payment": "",
     "failure_code": "",
     "failure_message": "",
-    "id": "tr_19xOmZA6KsQaPpsxxTnirGHq",
+    "id": "tr_19y6HIAylotNGqt3ph4EjS38",
     "legacy_date": 1234567890,
     "livemode": false,
     "metadata": {
@@ -847,7 +847,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/transfers/tr_19xOmZA6KsQaPpsxxTnirGHq/reversals"
+      "url": "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
     },
     "reversed": false,
     "source_transaction": "",
@@ -872,14 +872,14 @@
     "external_sku_ids": [
 
     ],
-    "id": "or_19xOmbA6KsQaPpsxdJuNEqnx",
+    "id": "or_19y6HJAylotNGqt3bov4Z4DC",
     "items": [
       {
         "amount": 1500,
         "currency": "usd",
         "description": "T-shirt",
         "object": "order_item",
-        "parent": "sk_19xOmbA6KsQaPpsx0niGDfiM",
+        "parent": "sk_19y6HJAylotNGqt3oddcLh9L",
         "quantity": null,
         "type": "sku"
       }
@@ -895,7 +895,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/order_returns?order=or_19xOmbA6KsQaPpsxdJuNEqnx"
+      "url": "/v1/order_returns?order=or_19y6HJAylotNGqt3bov4Z4DC"
     },
     "selected_shipping_method": "",
     "shipping": {
@@ -925,22 +925,22 @@
     "amount": 1500,
     "created": 1234567890,
     "currency": "usd",
-    "id": "orret_19xOmbA6KsQaPpsxFhO0lEnm",
+    "id": "orret_19y6HJAylotNGqt3bd5YsAXz",
     "items": [
       {
         "amount": 1500,
         "currency": "usd",
         "description": "T-shirt",
         "object": "order_item",
-        "parent": "sk_19xOmbA6KsQaPpsx0niGDfiM",
+        "parent": "sk_19y6HJAylotNGqt3oddcLh9L",
         "quantity": null,
         "type": "sku"
       }
     ],
     "livemode": false,
     "object": "order_return",
-    "order": "or_19xOmbA6KsQaPpsxcibE2Kys",
-    "refund": "re_19xOmbA6KsQaPpsxweFlRcU7"
+    "order": "or_19y6HJAylotNGqt36m18HzRj",
+    "refund": "re_19y6HJAylotNGqt3rTe2A05C"
   },
   "plan": {
     "amount": 2000,
@@ -958,15 +958,15 @@
     "trial_period_days": 0
   },
   "platform_earning": {
-    "account": "acct_19xOmSA6KsQaPpsx",
+    "account": "acct_19y6HAAylotNGqt3",
     "amount": 100,
     "amount_refunded": 0,
-    "application": "ca_AHykjKaDnL4KjnMmmkLzuwqk9hkgJA5M",
-    "balance_transaction": "txn_19xOmYA6KsQaPpsxgSCbKQ3d",
-    "charge": "ch_19xOmYA6KsQaPpsxRpMRzREK",
+    "application": "ca_AIhgFq8kWIDlYSeaCcuycCoERZL0J0ls",
+    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
+    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
     "created": 1234567890,
     "currency": "usd",
-    "id": "fee_19xOmZA6KsQaPpsxZCoZI7Ep",
+    "id": "fee_19y6HIAylotNGqt3iEVMbEmJ",
     "livemode": false,
     "object": "application_fee",
     "originating_transaction": "",
@@ -978,7 +978,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/application_fees/fee_19xOmZA6KsQaPpsxZCoZI7Ep/refunds"
+      "url": "/v1/application_fees/fee_19y6HIAylotNGqt3iEVMbEmJ/refunds"
     }
   },
   "product": {
@@ -994,7 +994,7 @@
     ],
     "description": "Comfortable gray cotton t-shirts",
     "donation": false,
-    "id": "prod_AHyk8gTS1wCWqa",
+    "id": "prod_AIhgWPx5D86mh1",
     "images": [
 
     ],
@@ -1014,7 +1014,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/skus?product=prod_AHyk8gTS1wCWqa\u0026active=true"
+      "url": "/v1/skus?product=prod_AIhgWPx5D86mh1\u0026active=true"
     },
     "tweetable_url": "",
     "updated": 1234567890,
@@ -1023,13 +1023,13 @@
   "refund": {
     "amount": 100,
     "balance_transaction": "",
-    "charge": "ch_19xOmYA6KsQaPpsxRpMRzREK",
+    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
     "created": 1234567890,
     "currency": "usd",
     "description": "",
     "fee_balance_transactions": {
     },
-    "id": "re_19xOmYA6KsQaPpsxnI34WZGS",
+    "id": "re_19y6HHAylotNGqt3o9CUC2fJ",
     "metadata": {
     },
     "object": "refund",
@@ -1046,7 +1046,7 @@
     },
     "created": 1234567890,
     "currency": "usd",
-    "id": "sku_AHyktKapJTzgmX",
+    "id": "sku_AIhgANg1XshOPI",
     "image": "",
     "inventory": {
       "quantity": 50,
@@ -1060,33 +1060,47 @@
     "package_dimensions": {
     },
     "price": 1500,
-    "product": "prod_AHyk8gTS1wCWqa",
+    "product": "prod_AIhgWPx5D86mh1",
     "updated": 1234567890
   },
   "source": {
-    "amount": 0,
-    "client_secret": "",
+    "amount": 1000,
+    "client_secret": "src_client_secret_UxYHcfjreLYKMVWptfFyAsxp",
     "code_verification": {
     },
     "created": 1234567890,
-    "currency": "",
+    "currency": "usd",
     "customer": "",
-    "flow": "",
-    "id": "card_19xOmYA6KsQaPpsx93IwBRHM",
+    "flow": "receiver",
+    "id": "src_19y6HJAylotNGqt3wfuVnNWw",
     "livemode": false,
     "metadata": {
     },
-    "object": "card",
+    "object": "source",
     "order": "",
     "owner": {
+      "address": null,
+      "email": "jenny.rosen@example.com",
+      "name": null,
+      "phone": null,
+      "verified_address": null,
+      "verified_email": null,
+      "verified_name": null,
+      "verified_phone": null
     },
     "receiver": {
+      "address": "test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N",
+      "amount_charged": 0,
+      "amount_received": 0,
+      "amount_returned": 0,
+      "refund_attributes_method": "email",
+      "refund_attributes_status": "missing"
     },
     "redirect": {
     },
-    "status": "",
-    "type": "",
-    "usage": ""
+    "status": "pending",
+    "type": "bitcoin",
+    "usage": "single_use"
   },
   "subscription": {
     "account_balance": 0,
@@ -1097,21 +1111,21 @@
     "created": 1234567890,
     "current_period_end": 1234567890,
     "current_period_start": 1234567890,
-    "customer": "cus_AHykJG3Ru2BgKh",
+    "customer": "cus_AIhg2AZ0oZn9hq",
     "days_until_due": 0,
     "discount": {
     },
     "ended_at": 1234567890,
-    "id": "sub_AHyk2EXaU2gAEV",
+    "id": "sub_AIhgP3KgCUJMuh",
     "items": {
       "data": [
         {
-          "created": 1489533023,
-          "id": "si_19xOmYB4YnRyKoofnPXr05OV",
+          "created": 1489700220,
+          "id": "si_19y6HHBBq8Um5VVVeabmVesw",
           "object": "subscription_item",
           "plan": {
             "amount": 2000,
-            "created": 1489533022,
+            "created": 1489700219,
             "currency": "usd",
             "id": "gold",
             "interval": "month",
@@ -1130,7 +1144,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 1,
-      "url": "/v1/subscription_items?subscription=sub_AHyk2EXaU2gAEV"
+      "url": "/v1/subscription_items?subscription=sub_AIhgP3KgCUJMuh"
     },
     "livemode": false,
     "max_occurrences": 0,
@@ -1140,7 +1154,7 @@
     "on_behalf_of": "",
     "plan": {
       "amount": 2000,
-      "created": 1489533022,
+      "created": 1489700219,
       "currency": "usd",
       "id": "gold",
       "interval": "month",
@@ -1162,12 +1176,12 @@
     "trial_start": 1234567890
   },
   "subscription_item": {
-    "created": 1489533023,
-    "id": "si_19xOmZB4YnRyKoofmmqQD542",
+    "created": 1489700220,
+    "id": "si_19y6HHBBq8Um5VVVWtAse22Z",
     "object": "subscription_item",
     "plan": {
       "amount": 2000,
-      "created": 1489533022,
+      "created": 1489700219,
       "currency": "usd",
       "id": "gold",
       "interval": "month",
@@ -1202,7 +1216,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19xOmZA6KsQaPpsx1TPW9v1Z",
+      "id": "card_19y6HIAylotNGqt3tSobdlid",
       "last4": "4242",
       "metadata": {
       },
@@ -1212,10 +1226,10 @@
     },
     "created": 1234567890,
     "currency": "usd",
-    "id": "tdsrc_AHyk0Ny8jTjJoy",
+    "id": "tdsrc_AIhge8Euw6YKbc",
     "livemode": false,
     "object": "three_d_secure",
-    "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AHyk0Ny8jTjJoy",
+    "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AIhge8Euw6YKbc",
     "status": "redirect_pending"
   },
   "token": {
@@ -1241,7 +1255,7 @@
       "exp_month": 8,
       "exp_year": 2018,
       "funding": "unknown",
-      "id": "card_19xOmZA6KsQaPpsx1TPW9v1Z",
+      "id": "card_19y6HIAylotNGqt3tSobdlid",
       "last4": "4242",
       "metadata": {
       },
@@ -1253,7 +1267,7 @@
     "created": 1234567890,
     "description": "",
     "email": "",
-    "id": "tok_19xOmZA6KsQaPpsxwCla8HhZ",
+    "id": "tok_19y6HIAylotNGqt3RgAWCZVp",
     "livemode": false,
     "object": "token",
     "type": "card",
@@ -1263,12 +1277,12 @@
   "transfer": {
     "amount": 1100,
     "amount_reversed": 0,
-    "balance_transaction": "txn_19xOmYA6KsQaPpsxgSCbKQ3d",
+    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
     "created": 1234567890,
     "currency": "usd",
-    "destination": "ba_19xOmZA6KsQaPpsxBhLhCCLJ",
+    "destination": "ba_19y6HIAylotNGqt3Tk6btLgn",
     "destination_payment": "",
-    "id": "tr_19xOmZA6KsQaPpsxxTnirGHq",
+    "id": "tr_19y6HIAylotNGqt3ph4EjS38",
     "livemode": false,
     "metadata": {
     },
@@ -1280,7 +1294,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/transfers/tr_19xOmZA6KsQaPpsxxTnirGHq/reversals"
+      "url": "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
     },
     "reversed": false,
     "transfer_group": ""
@@ -1301,7 +1315,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/recipients/rp_19xOmZA6KsQaPpsxz5JlUIpQ/cards"
+      "url": "/v1/recipients/rp_19y6HIAylotNGqt3CTykthsz/cards"
     },
     "country": "",
     "created": 1234567890,
@@ -1311,7 +1325,7 @@
     "dob_month": "",
     "dob_year": "",
     "email": "test@example.com",
-    "id": "rp_19xOmZA6KsQaPpsxz5JlUIpQ",
+    "id": "rp_19y6HIAylotNGqt3CTykthsz",
     "livemode": false,
     "metadata": {
     },
@@ -1328,11 +1342,11 @@
     "balance_transaction": "",
     "created": 1234567890,
     "currency": "usd",
-    "id": "trr_19xOmZA6KsQaPpsxg8vF5JSH",
+    "id": "trr_19y6HIAylotNGqt3nITPrdUW",
     "metadata": {
     },
     "object": "transfer_reversal",
-    "transfer": "tr_19xOmZA6KsQaPpsxxTnirGHq"
+    "transfer": "tr_19y6HIAylotNGqt3ph4EjS38"
   },
   "upcoming_invoice": {
     "amount_due": 0,
@@ -1343,7 +1357,7 @@
     "charge": "",
     "closed": false,
     "currency": "usd",
-    "customer": "cus_AHykWO1tNrvBO2",
+    "customer": "cus_AIhgCDhEsqLqXq",
     "date": 1234567890,
     "description": "",
     "discount": {
@@ -1358,7 +1372,7 @@
       "has_more": false,
       "object": "list",
       "total_count": 0,
-      "url": "/v1/invoices/in_19xOmZA6KsQaPpsxpXZEk0Jl/lines"
+      "url": "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
     },
     "livemode": false,
     "metadata": {

--- a/openapi/fixtures.yaml
+++ b/openapi/fixtures.yaml
@@ -15,15 +15,15 @@ account:
   default_currency: usd
   details_submitted: false
   display_name: ''
-  email: foo+ujebwko0fp@example.com
+  email: foo+os4pphkove@example.com
   external_accounts:
     data: []
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/accounts/acct_19xOmSA6KsQaPpsx/external_accounts"
+    url: "/v1/accounts/acct_19y6HAAylotNGqt3/external_accounts"
   fake_account: false
-  id: acct_19xOmSA6KsQaPpsx
+  id: acct_19y6HAAylotNGqt3
   legal_entity:
     additional_owners: 
     address:
@@ -113,10 +113,10 @@ account_with_keys:
   default_currency: usd
   details_submitted: false
   display_name: ''
-  email: foo+ujebwko0fp@example.com
+  email: foo+os4pphkove@example.com
   external_accounts: {}
   fake_account: false
-  id: acct_19xOmSA6KsQaPpsx
+  id: acct_19y6HAAylotNGqt3
   keys: {}
   legal_entity: {}
   light: false
@@ -141,8 +141,8 @@ account_with_keys:
 alipay_account:
   created: 1234567890
   customer: ''
-  fingerprint: NmrPSTwAXOffguOu
-  id: aliacc_19xOmZA6KsQaPpsx8SQGAn0E
+  fingerprint: eiRpjVAne6V7vzjH
+  id: aliacc_19y6HIAylotNGqt3CWxIarua
   livemode: false
   metadata: {}
   object: alipay_account
@@ -154,7 +154,7 @@ alipay_account:
 apple_pay_domain:
   created: 1234567890
   domain_name: example.com
-  id: apwc_19xOmYA6KsQaPpsxDX3zqwLL
+  id: apwc_19y6HHAylotNGqt3514QiFTd
   livemode: true
   object: apple_pay_domain
 balance:
@@ -180,15 +180,15 @@ balance_transaction:
   description: ''
   fee: 0
   fee_details: []
-  id: txn_19xOmYA6KsQaPpsxgSCbKQ3d
+  id: txn_19y6HHAylotNGqt33AMqhSaS
   net: 100
   object: balance_transaction
-  source: ch_19xOmYA6KsQaPpsxRpMRzREK
+  source: ch_19y6HHAylotNGqt3dguVG1mI
   sourced_transfers: {}
   status: pending
   type: charge
 bank_account:
-  account: acct_19xOmSA6KsQaPpsx
+  account: acct_19y6HAAylotNGqt3
   account_holder_name: Jane Austen
   account_holder_type: individual
   address_city: ''
@@ -204,8 +204,8 @@ bank_account:
   customer: ''
   customer_reference: ''
   default_for_currency: false
-  fingerprint: rhUqyC2EcjMewT6o
-  id: ba_19xOmZA6KsQaPpsx7DTyLvtT
+  fingerprint: G8AlCiZpIixKrovm
+  id: ba_19y6HIAylotNGqt37Bbh2BEi
   last4: '6789'
   metadata: {}
   object: bank_account
@@ -226,7 +226,7 @@ bitcoin_receiver:
   description: Receiver for John Doe
   email: test@example.com
   filled: false
-  id: btcrcv_19xOmZA6KsQaPpsx8TtHgMVX
+  id: btcrcv_19y6HIAylotNGqt3PPrzs2zr
   inbound_address: test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1
   livemode: false
   metadata: {}
@@ -241,9 +241,9 @@ bitcoin_transaction:
   bitcoin_amount: 1757908
   created: 1234567890
   currency: usd
-  id: btctxn_19xOmZA6KsQaPpsx5FnHoZis
+  id: btctxn_19y6HIAylotNGqt3ufx7IrFQ
   object: bitcoin_transaction
-  receiver: btcrcv_19xOmZB4YnRyKoofPMbLFiZa
+  receiver: btcrcv_19y6HIBBq8Um5VVVjcO0R7nU
 card:
   3d_secure: {}
   account: ''
@@ -271,7 +271,7 @@ card:
   fingerprint: ''
   funding: unknown
   google_reference: ''
-  id: card_19xOmYA6KsQaPpsx93IwBRHM
+  id: card_19y6HHAylotNGqt3SvYv7I1c
   iin: ''
   issuer: ''
   last4: '4242'
@@ -291,7 +291,7 @@ charge:
   application_fee: ''
   application_fees_refunded: 0
   authorization_code: ''
-  balance_transaction: txn_19xOmYA6KsQaPpsxgSCbKQ3d
+  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
   captured: true
   card: {}
   created: 1234567890
@@ -304,7 +304,7 @@ charge:
   failure_message: ''
   fee_balance_transactions: {}
   fraud_details: {}
-  id: ch_19xOmYA6KsQaPpsxRpMRzREK
+  id: ch_19y6HHAylotNGqt3dguVG1mI
   invoice: ''
   level3: {}
   livemode: false
@@ -322,7 +322,7 @@ charge:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/charges/ch_19xOmYA6KsQaPpsxRpMRzREK/refunds"
+    url: "/v1/charges/ch_19y6HHAylotNGqt3dguVG1mI/refunds"
   review: ''
   shipping: {}
   source:
@@ -342,7 +342,7 @@ charge:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19xOmYA6KsQaPpsx93IwBRHM
+    id: card_19y6HHAylotNGqt3SvYv7I1c
     last4: '4242'
     metadata: {}
     name: 
@@ -409,7 +409,7 @@ customer:
   description: ''
   discount: {}
   email: ''
-  id: cus_AHykWO1tNrvBO2
+  id: cus_AIhgCDhEsqLqXq
   livemode: false
   metadata: {}
   object: customer
@@ -419,19 +419,19 @@ customer:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/customers/cus_AHykWO1tNrvBO2/sources"
+    url: "/v1/customers/cus_AIhgCDhEsqLqXq/sources"
   subscription: {}
   subscriptions: {}
   trust: {}
 customer_source:
   customer: ''
-  id: ba_19xOmZA6KsQaPpsx7DTyLvtT
+  id: ba_19y6HIAylotNGqt37Bbh2BEi
   metadata: {}
   object: bank_account
 discount:
   coupon:
     amount_off: 
-    created: 1489533023
+    created: 1489700220
     currency: usd
     duration: repeating
     duration_in_months: 3
@@ -444,7 +444,7 @@ discount:
     redeem_by: 
     times_redeemed: 0
     valid: true
-  customer: cus_AHykWO1tNrvBO2
+  customer: cus_AIhgCDhEsqLqXq
   end: 1234567890
   object: discount
   start: 1234567890
@@ -454,7 +454,7 @@ dispute:
   amount: 1000
   balance_transaction: ''
   balance_transactions: []
-  charge: ch_19xOmYA6KsQaPpsxRpMRzREK
+  charge: ch_19y6HHAylotNGqt3dguVG1mI
   closed_at: 1234567890
   created: 1234567890
   currency: usd
@@ -488,12 +488,12 @@ dispute:
     uncategorized_file: 
     uncategorized_text: 
   evidence_details:
-    due_by: 1491177599
+    due_by: 1491350399
     has_evidence: false
     past_due: false
     submission_count: 0
   evidence_submitted_at: []
-  id: dp_19xOmYA6KsQaPpsxF27xl8iJ
+  id: dp_19y6HHAylotNGqt3bvR7ZOnH
   is_charge_refundable: false
   is_protected: false
   livemode: false
@@ -509,7 +509,7 @@ event:
   data:
     object:
       amount: 2000
-      created: 1489533023
+      created: 1489700220
       currency: usd
       id: gold
       interval: month
@@ -520,7 +520,7 @@ event:
       object: plan
       statement_descriptor: 
       trial_period_days: 
-  id: evt_19xOmZA6KsQaPpsxg3PnM6Ax
+  id: evt_19y6HIAylotNGqt349zSXYCk
   livemode: false
   object: event
   pending_webhooks: 0
@@ -528,7 +528,7 @@ event:
   request: ''
   type: plan.created
 external_account_source:
-  account: acct_19xOmSA6KsQaPpsx
+  account: acct_19y6HAAylotNGqt3
   address_city: ''
   address_line1: ''
   address_line2: ''
@@ -538,8 +538,8 @@ external_account_source:
   currency: usd
   customer: ''
   default_for_currency: false
-  fingerprint: rhUqyC2EcjMewT6o
-  id: ba_19xOmZA6KsQaPpsx7DTyLvtT
+  fingerprint: G8AlCiZpIixKrovm
+  id: ba_19y6HIAylotNGqt37Bbh2BEi
   last4: '6789'
   metadata: {}
   object: bank_account
@@ -548,8 +548,8 @@ fee_refund:
   balance_transaction: ''
   created: 1234567890
   currency: usd
-  fee: fee_19xOmZA6KsQaPpsxZCoZI7Ep
-  id: fr_AHykVrc8RYtq3K
+  fee: fee_19y6HIAylotNGqt3iEVMbEmJ
+  id: fr_AIhghI4mXRpLEw
   metadata: {}
   object: fee_refund
 invoice:
@@ -561,30 +561,30 @@ invoice:
   charge: ''
   closed: false
   currency: usd
-  customer: cus_AHykWO1tNrvBO2
+  customer: cus_AIhgCDhEsqLqXq
   date: 1234567890
   description: ''
   discount: {}
   due_date: 1234567890
   ending_balance: 0
   forgiven: false
-  id: in_19xOmZA6KsQaPpsxpXZEk0Jl
+  id: in_19y6HIAylotNGqt3Kq1NUy5r
   lines:
     data:
     - amount: 2000
       currency: usd
       description: 
       discountable: true
-      id: sub_AHyk2EXaU2gAEV
+      id: sub_AIhgP3KgCUJMuh
       livemode: true
       metadata: {}
       object: line_item
       period:
-        end: 1494803422
-        start: 1492211422
+        end: 1494970619
+        start: 1492378619
       plan:
         amount: 2000
-        created: 1489533023
+        created: 1489700220
         currency: usd
         id: gold
         interval: month
@@ -598,11 +598,11 @@ invoice:
       proration: false
       quantity: 1
       subscription: 
-      subscription_item: si_19xOmYB4YnRyKoofnPXr05OV
+      subscription_item: si_19y6HHBBq8Um5VVVeabmVesw
       type: subscription
     object: list
     total_count: 1
-    url: "/v1/invoices/in_19xOmZA6KsQaPpsxpXZEk0Jl/lines"
+    url: "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
   livemode: false
   metadata: {}
   next_payment_attempt: 1234567890
@@ -624,18 +624,18 @@ invoice:
 invoice_item:
   amount: 1000
   currency: usd
-  customer: cus_AHykWO1tNrvBO2
+  customer: cus_AIhgCDhEsqLqXq
   date: 1234567890
   description: My First Invoice Item (created for API docs)
   discountable: true
-  id: ii_19xOmZA6KsQaPpsxw92LOZet
+  id: ii_19y6HIAylotNGqt36BYYgGHq
   invoice: ''
   livemode: false
   metadata: {}
   object: invoiceitem
   period:
-    end: 1489533023
-    start: 1489533023
+    end: 1489700220
+    start: 1489700220
   plan: {}
   proration: false
   quantity: 0
@@ -646,13 +646,13 @@ invoice_line_item:
   currency: usd
   description: My First Invoice Item (created for API docs)
   discountable: true
-  id: ii_19xOmZA6KsQaPpsxw92LOZet
+  id: ii_19y6HIAylotNGqt36BYYgGHq
   livemode: false
   metadata: {}
   object: line_item
   period:
-    end: 1489533023
-    start: 1489533023
+    end: 1489700220
+    start: 1489700220
   plan: {}
   proration: false
   quantity: 0
@@ -672,11 +672,11 @@ legacy_transfer:
   date: 1234567890
   delay_reason: ''
   description: Transfer to test@example.com
-  destination: ba_19xOmZA6KsQaPpsxBhLhCCLJ
+  destination: ba_19y6HIAylotNGqt3Tk6btLgn
   destination_payment: ''
   failure_code: ''
   failure_message: ''
-  id: tr_19xOmZA6KsQaPpsxxTnirGHq
+  id: tr_19y6HIAylotNGqt3ph4EjS38
   legacy_date: 1234567890
   livemode: false
   metadata: {}
@@ -688,7 +688,7 @@ legacy_transfer:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/transfers/tr_19xOmZA6KsQaPpsxxTnirGHq/reversals"
+    url: "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
   reversed: false
   source_transaction: ''
   source_type: card
@@ -709,13 +709,13 @@ order:
   email: ''
   external_coupon_code: ''
   external_sku_ids: []
-  id: or_19xOmbA6KsQaPpsxdJuNEqnx
+  id: or_19y6HJAylotNGqt3bov4Z4DC
   items:
   - amount: 1500
     currency: usd
     description: T-shirt
     object: order_item
-    parent: sk_19xOmbA6KsQaPpsx0niGDfiM
+    parent: sk_19y6HJAylotNGqt3oddcLh9L
     quantity: 
     type: sku
   livemode: false
@@ -726,7 +726,7 @@ order:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/order_returns?order=or_19xOmbA6KsQaPpsxdJuNEqnx"
+    url: "/v1/order_returns?order=or_19y6HJAylotNGqt3bov4Z4DC"
   selected_shipping_method: ''
   shipping:
     address:
@@ -750,19 +750,19 @@ order_return:
   amount: 1500
   created: 1234567890
   currency: usd
-  id: orret_19xOmbA6KsQaPpsxFhO0lEnm
+  id: orret_19y6HJAylotNGqt3bd5YsAXz
   items:
   - amount: 1500
     currency: usd
     description: T-shirt
     object: order_item
-    parent: sk_19xOmbA6KsQaPpsx0niGDfiM
+    parent: sk_19y6HJAylotNGqt3oddcLh9L
     quantity: 
     type: sku
   livemode: false
   object: order_return
-  order: or_19xOmbA6KsQaPpsxcibE2Kys
-  refund: re_19xOmbA6KsQaPpsxweFlRcU7
+  order: or_19y6HJAylotNGqt36m18HzRj
+  refund: re_19y6HJAylotNGqt3rTe2A05C
 plan:
   amount: 2000
   created: 1234567890
@@ -777,15 +777,15 @@ plan:
   statement_descriptor: ''
   trial_period_days: 0
 platform_earning:
-  account: acct_19xOmSA6KsQaPpsx
+  account: acct_19y6HAAylotNGqt3
   amount: 100
   amount_refunded: 0
-  application: ca_AHykjKaDnL4KjnMmmkLzuwqk9hkgJA5M
-  balance_transaction: txn_19xOmYA6KsQaPpsxgSCbKQ3d
-  charge: ch_19xOmYA6KsQaPpsxRpMRzREK
+  application: ca_AIhgFq8kWIDlYSeaCcuycCoERZL0J0ls
+  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
+  charge: ch_19y6HHAylotNGqt3dguVG1mI
   created: 1234567890
   currency: usd
-  id: fee_19xOmZA6KsQaPpsxZCoZI7Ep
+  id: fee_19y6HIAylotNGqt3iEVMbEmJ
   livemode: false
   object: application_fee
   originating_transaction: ''
@@ -795,7 +795,7 @@ platform_earning:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/application_fees/fee_19xOmZA6KsQaPpsxZCoZI7Ep/refunds"
+    url: "/v1/application_fees/fee_19y6HIAylotNGqt3iEVMbEmJ/refunds"
 product:
   active: true
   attributes:
@@ -806,7 +806,7 @@ product:
   deactivate_on: []
   description: Comfortable gray cotton t-shirts
   donation: false
-  id: prod_AHyk8gTS1wCWqa
+  id: prod_AIhgWPx5D86mh1
   images: []
   livemode: false
   metadata: {}
@@ -820,19 +820,19 @@ product:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/skus?product=prod_AHyk8gTS1wCWqa&active=true"
+    url: "/v1/skus?product=prod_AIhgWPx5D86mh1&active=true"
   tweetable_url: ''
   updated: 1234567890
   url: ''
 refund:
   amount: 100
   balance_transaction: ''
-  charge: ch_19xOmYA6KsQaPpsxRpMRzREK
+  charge: ch_19y6HHAylotNGqt3dguVG1mI
   created: 1234567890
   currency: usd
   description: ''
   fee_balance_transactions: {}
-  id: re_19xOmYA6KsQaPpsxnI34WZGS
+  id: re_19y6HHAylotNGqt3o9CUC2fJ
   metadata: {}
   object: refund
   reason: ''
@@ -846,7 +846,7 @@ sku:
     size: Medium
   created: 1234567890
   currency: usd
-  id: sku_AHyktKapJTzgmX
+  id: sku_AIhgANg1XshOPI
   image: ''
   inventory:
     quantity: 50
@@ -857,27 +857,41 @@ sku:
   object: sku
   package_dimensions: {}
   price: 1500
-  product: prod_AHyk8gTS1wCWqa
+  product: prod_AIhgWPx5D86mh1
   updated: 1234567890
 source:
-  amount: 0
-  client_secret: ''
+  amount: 1000
+  client_secret: src_client_secret_UxYHcfjreLYKMVWptfFyAsxp
   code_verification: {}
   created: 1234567890
-  currency: ''
+  currency: usd
   customer: ''
-  flow: ''
-  id: card_19xOmYA6KsQaPpsx93IwBRHM
+  flow: receiver
+  id: src_19y6HJAylotNGqt3wfuVnNWw
   livemode: false
   metadata: {}
-  object: card
+  object: source
   order: ''
-  owner: {}
-  receiver: {}
+  owner:
+    address: 
+    email: jenny.rosen@example.com
+    name: 
+    phone: 
+    verified_address: 
+    verified_email: 
+    verified_name: 
+    verified_phone: 
+  receiver:
+    address: test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N
+    amount_charged: 0
+    amount_received: 0
+    amount_returned: 0
+    refund_attributes_method: email
+    refund_attributes_status: missing
   redirect: {}
-  status: ''
-  type: ''
-  usage: ''
+  status: pending
+  type: bitcoin
+  usage: single_use
 subscription:
   account_balance: 0
   application_fee_percent: 0.0
@@ -887,19 +901,19 @@ subscription:
   created: 1234567890
   current_period_end: 1234567890
   current_period_start: 1234567890
-  customer: cus_AHykJG3Ru2BgKh
+  customer: cus_AIhg2AZ0oZn9hq
   days_until_due: 0
   discount: {}
   ended_at: 1234567890
-  id: sub_AHyk2EXaU2gAEV
+  id: sub_AIhgP3KgCUJMuh
   items:
     data:
-    - created: 1489533023
-      id: si_19xOmYB4YnRyKoofnPXr05OV
+    - created: 1489700220
+      id: si_19y6HHBBq8Um5VVVeabmVesw
       object: subscription_item
       plan:
         amount: 2000
-        created: 1489533022
+        created: 1489700219
         currency: usd
         id: gold
         interval: month
@@ -914,7 +928,7 @@ subscription:
     has_more: false
     object: list
     total_count: 1
-    url: "/v1/subscription_items?subscription=sub_AHyk2EXaU2gAEV"
+    url: "/v1/subscription_items?subscription=sub_AIhgP3KgCUJMuh"
   livemode: false
   max_occurrences: 0
   metadata: {}
@@ -922,7 +936,7 @@ subscription:
   on_behalf_of: ''
   plan:
     amount: 2000
-    created: 1489533022
+    created: 1489700219
     currency: usd
     id: gold
     interval: month
@@ -941,12 +955,12 @@ subscription:
   trial_end: 1234567890
   trial_start: 1234567890
 subscription_item:
-  created: 1489533023
-  id: si_19xOmZB4YnRyKoofmmqQD542
+  created: 1489700220
+  id: si_19y6HHBBq8Um5VVVWtAse22Z
   object: subscription_item
   plan:
     amount: 2000
-    created: 1489533022
+    created: 1489700219
     currency: usd
     id: gold
     interval: month
@@ -978,7 +992,7 @@ three_d_secure:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19xOmZA6KsQaPpsx1TPW9v1Z
+    id: card_19y6HIAylotNGqt3tSobdlid
     last4: '4242'
     metadata: {}
     name: 
@@ -986,10 +1000,10 @@ three_d_secure:
     tokenization_method: 
   created: 1234567890
   currency: usd
-  id: tdsrc_AHyk0Ny8jTjJoy
+  id: tdsrc_AIhge8Euw6YKbc
   livemode: false
   object: three_d_secure
-  redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AHyk0Ny8jTjJoy
+  redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AIhge8Euw6YKbc
   status: redirect_pending
 token:
   account_details: {}
@@ -1011,7 +1025,7 @@ token:
     exp_month: 8
     exp_year: 2018
     funding: unknown
-    id: card_19xOmZA6KsQaPpsx1TPW9v1Z
+    id: card_19y6HIAylotNGqt3tSobdlid
     last4: '4242'
     metadata: {}
     name: 
@@ -1021,7 +1035,7 @@ token:
   created: 1234567890
   description: ''
   email: ''
-  id: tok_19xOmZA6KsQaPpsxwCla8HhZ
+  id: tok_19y6HIAylotNGqt3RgAWCZVp
   livemode: false
   object: token
   type: card
@@ -1030,12 +1044,12 @@ token:
 transfer:
   amount: 1100
   amount_reversed: 0
-  balance_transaction: txn_19xOmYA6KsQaPpsxgSCbKQ3d
+  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
   created: 1234567890
   currency: usd
-  destination: ba_19xOmZA6KsQaPpsxBhLhCCLJ
+  destination: ba_19y6HIAylotNGqt3Tk6btLgn
   destination_payment: ''
-  id: tr_19xOmZA6KsQaPpsxxTnirGHq
+  id: tr_19y6HIAylotNGqt3ph4EjS38
   livemode: false
   metadata: {}
   object: transfer
@@ -1044,7 +1058,7 @@ transfer:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/transfers/tr_19xOmZA6KsQaPpsxxTnirGHq/reversals"
+    url: "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
   reversed: false
   transfer_group: ''
 transfer_recipient:
@@ -1060,7 +1074,7 @@ transfer_recipient:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/recipients/rp_19xOmZA6KsQaPpsxz5JlUIpQ/cards"
+    url: "/v1/recipients/rp_19y6HIAylotNGqt3CTykthsz/cards"
   country: ''
   created: 1234567890
   default_card: ''
@@ -1069,7 +1083,7 @@ transfer_recipient:
   dob_month: ''
   dob_year: ''
   email: test@example.com
-  id: rp_19xOmZA6KsQaPpsxz5JlUIpQ
+  id: rp_19y6HIAylotNGqt3CTykthsz
   livemode: false
   metadata: {}
   migrated_to: ''
@@ -1084,10 +1098,10 @@ transfer_reversal:
   balance_transaction: ''
   created: 1234567890
   currency: usd
-  id: trr_19xOmZA6KsQaPpsxg8vF5JSH
+  id: trr_19y6HIAylotNGqt3nITPrdUW
   metadata: {}
   object: transfer_reversal
-  transfer: tr_19xOmZA6KsQaPpsxxTnirGHq
+  transfer: tr_19y6HIAylotNGqt3ph4EjS38
 upcoming_invoice:
   amount_due: 0
   application_fee: 0
@@ -1097,7 +1111,7 @@ upcoming_invoice:
   charge: ''
   closed: false
   currency: usd
-  customer: cus_AHykWO1tNrvBO2
+  customer: cus_AIhgCDhEsqLqXq
   date: 1234567890
   description: ''
   discount: {}
@@ -1109,7 +1123,7 @@ upcoming_invoice:
     has_more: false
     object: list
     total_count: 0
-    url: "/v1/invoices/in_19xOmZA6KsQaPpsxpXZEk0Jl/lines"
+    url: "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
   livemode: false
   metadata: {}
   next_payment_attempt: 1234567890

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 module Stripe
   class CustomerCardTest < Test::Unit::TestCase
-    FIXTURE = API_FIXTURES.fetch(:source)
+    FIXTURE = API_FIXTURES.fetch(:card)
 
     setup do
       @customer =

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -32,20 +32,22 @@ module Stripe
       assert source.kind_of?(Stripe::Source)
     end
 
-    should "not be deletable when unattached" do
-      source = Stripe::Source.retrieve(FIXTURE[:id])
+    context "#delete" do
+      should "not be deletable when unattached" do
+        source = Stripe::Source.retrieve(FIXTURE[:id])
 
-      assert_raises NotImplementedError do
-        source.delete
+        assert_raises NotImplementedError do
+          source.delete
+        end
       end
-    end
 
-    should "be deletable when attached to a customer" do
-      customer = Stripe::Customer.retrieve(API_FIXTURES.fetch(:customer)[:id])
-      source = Stripe::Card.construct_from(FIXTURE.merge(customer: customer.id))
-      source = source.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{@customer.id}/sources/#{FIXTURE[:id]}"
-      assert source.kind_of?(Stripe::Source)
+      should "be deletable when attached to a customer" do
+        customer_id = API_FIXTURES.fetch(:customer)[:id]
+        source = Stripe::Source.construct_from(FIXTURE.merge(customer: customer_id))
+        stub_request(:delete, "#{Stripe.api_base}/v1/customers/#{customer_id}/sources/#{FIXTURE[:id]}").
+          to_return(body: JSON.generate(FIXTURE))
+        assert source.kind_of?(Stripe::Source)
+      end
     end
 
     should 'not be listable' do


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @will-stripe

This PR adds support for detaching sources from customers. Unlike cards or bank accounts, sources cannot be deleted, but they can now be detached from customers by sending a `DELETE` request to `/v1/customers/{CUSTOMER_ID}/sources/{SOURCE_ID}`.

Incidentally, while working on this PR, I stumbled upon a couple of related issues:

- we were lacking an entry for `source` in  [`Util.object_classes`](https://github.com/stripe/stripe-ruby/blob/5dd5d2b608af8b597b5298b22eab171d570d6408/lib/stripe/util.rb#L20). This means that `source` objects returned by the API were instantiated as generic `StripeObject`s rather than `Source`s

- the `source` entry in `fixtures.json` currently contains a card object rather than a source object

  I've fixed the source tests to (correctly) expect a source object, which means tests won't pass until `fixtures.json` is fixed and this PR is rebased.
