### PR TITLE
Exclude client when dumping objects

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -137,7 +137,12 @@ module Stripe
     end
 
     def _dump(level)
-      Marshal.dump([@values, @opts])
+      # The StripeClient instance in @opts is not serializable and is not
+      # really a property of the StripeObject, so we exclude it when
+      # dumping
+      opts = @opts.clone
+      opts.delete(:client)
+      Marshal.dump([@values, opts])
     end
 
     def self._load(args)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -36,7 +36,15 @@ module Stripe
     end
 
     should "marshal a stripe object correctly" do
-      obj = Stripe::StripeObject.construct_from({ :id => 1, :name => 'Stripe' }, {:api_key => 'apikey'})
+      obj = Stripe::StripeObject.construct_from(
+        { :id => 1, :name => 'Stripe' },
+        {
+          :api_key => 'apikey',
+          # StripeClient is not serializable and is expected to be removed
+          # when marshalling StripeObjects
+          :client => StripeClient.active_client,
+        }
+      )
       m = Marshal.load(Marshal.dump(obj))
       assert_equal 1, m.id
       assert_equal 'Stripe', m.name


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #512. The fix is not very elegant and somewhat brittle (what if we add other unmarshallable objects to `@opts`?) but it does the job. If you have a better suggestion for handling this, I'm happy to update the PR or close it in favor of a better solution.
