### PR TITLE
Replace invalid message Faraday::Response#code with valid #status

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -149,7 +149,7 @@ module Stripe
       begin
         resp = StripeResponse.from_faraday_response(http_resp)
       rescue JSON::ParserError
-        raise general_api_error(http_resp.code, http_resp.body)
+        raise general_api_error(http_resp.status, http_resp.body)
       end
 
       # Allows StripeClient#request to return a response object to a caller.

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -189,6 +189,18 @@ module Stripe
           assert_equal 'Invalid response object from API: "" (HTTP response code was 500)', e.message
         end
 
+        should "handle success response with empty body" do
+          stub_request(:post, "#{Stripe.api_base}/v1/charges").
+            to_return(body: '', status: 200)
+
+          client = StripeClient.new
+          e = assert_raises Stripe::APIError do
+            client.execute_request(:post, '/v1/charges')
+          end
+
+          assert_equal 'Invalid response object from API: "" (HTTP response code was 200)', e.message
+        end
+
         should "handle error response with non-object error value" do
           stub_request(:post, "#{Stripe.api_base}/v1/charges").
             to_return(body: JSON.generate({ error: "foo" }), status: 500)


### PR DESCRIPTION
The Faraday::Response object does not respond to #code. The correct message is #status. It seems this case was previously unhandled by the test suite as there was no case for the server responding "success" with an invalid JSON body.

Before the fix, the new test fails with:

```
» be rake
/Users/jay/.gem/ruby/2.4.0/gems/shoulda-context-1.2.2/lib/shoulda/context/context.rb:400: warning: assigned but unused variable -context
Loaded suite /Users/jay/.rubies/ruby-2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader
Started
..................................................................................................................................
............................................................................F
==================================================================================================================================
Failure: test: #execute_request error handling should handle success response with empty body. (Stripe::StripeClientTest)
/Users/jay/Code/OSS/stripe-ruby/test/stripe/stripe_client_test.rb:197:in `block (3 levels) in <class:StripeClientTest>'
/Users/jay/Code/OSS/stripe-ruby/test/stripe/stripe_client_test.rb:205:in `instance_exec'
/Users/jay/Code/OSS/stripe-ruby/test/stripe/stripe_client_test.rb:205:in `block in create_test_from_should_hash'

<Stripe::APIError> expected but was
<NoMethodError(<undefined method `code' for #<Faraday::Response:0x007ff1aa029ab0>>)>

diff:
? S   tripe::APIError
? NoMe hod           (<undefined method `code' for #<Faraday::Response:0x007ff1aa029ab0>>)
==================================================================================================================================
...........................................................................................................

Finished in 1.830672 seconds.
----------------------------------------------------------------------------------------------------------------------------------
314 tests, 343 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
99.6815% passed
----------------------------------------------------------------------------------------------------------------------------------
171.52 tests/s, 187.36 assertions/s
rake aborted!
Command failed with status (1)
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli/exec.rb:74:in `load'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli/exec.rb:27:in `run'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli.rb:335:in `exec'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli.rb:20:in `dispatch'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/cli.rb:11:in `start'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/exe/bundle:32:in `block in <top (required)>'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/jay/.gem/ruby/2.4.0/gems/bundler-1.14.5/exe/bundle:24:in `<top (required)>'
/Users/jay/.gem/ruby/2.4.0/bin/bundle:22:in `load'
/Users/jay/.gem/ruby/2.4.0/bin/bundle:22:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```