### PR TITLE
Update some OpenAPI repository conventions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,9 +18,9 @@ desc "Update OpenAPI specification"
 task :update_openapi do
   require "faraday"
 
-  ["fixtures.json", "fixtures.yaml", "spec.json", "spec.yaml"].map { |file|
+  ["fixtures.json", "fixtures.yaml", "spec2.json", "spec2.yaml"].map { |file|
     Thread.new do
-      fetch_file "https://raw.githubusercontent.com/stripe/openapi/master/spec/#{file}",
+      fetch_file "https://raw.githubusercontent.com/stripe/openapi/master/openapi/#{file}",
         File.expand_path("../openapi/#{file}", __FILE__)
     end
   }.map { |t| t.join }

--- a/openapi/fixtures.json
+++ b/openapi/fixtures.json
@@ -1,642 +1,1197 @@
 {
-  "account": {
-    "active_payment_methods": [
-
-    ],
-    "bank_accounts": {
-    },
-    "business_logo": "",
-    "business_name": "",
-    "business_primary_color": "",
-    "business_url": "",
-    "charges_enabled": false,
-    "country": "US",
-    "debit_negative_balances": true,
-    "decline_charge_on": {
-      "avs_failure": false,
-      "cvc_failure": false
-    },
-    "default_currency": "usd",
-    "details_submitted": false,
-    "display_name": "",
-    "email": "foo+os4pphkove@example.com",
-    "external_accounts": {
-      "data": [
+  "resources": {
+    "account": {
+      "active_payment_methods": [
 
       ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/accounts/acct_19y6HAAylotNGqt3/external_accounts"
-    },
-    "fake_account": false,
-    "id": "acct_19y6HAAylotNGqt3",
-    "legal_entity": {
-      "additional_owners": null,
-      "address": {
-        "city": null,
-        "country": "US",
-        "line1": null,
-        "line2": null,
-        "postal_code": null,
-        "state": null
+      "bank_accounts": {
       },
-      "business_name": null,
-      "business_name_kana": null,
-      "business_name_kanji": null,
-      "business_tax_id_provided": false,
-      "business_vat_id_provided": false,
-      "dob": {
-        "day": null,
-        "month": null,
-        "year": null
+      "business_logo": "",
+      "business_name": "",
+      "business_primary_color": "",
+      "business_url": "",
+      "charges_enabled": false,
+      "country": "US",
+      "debit_negative_balances": true,
+      "decline_charge_on": {
+        "avs_failure": true,
+        "cvc_failure": true
       },
-      "first_name": null,
-      "first_name_kana": null,
-      "first_name_kanji": null,
-      "gender": null,
-      "last_name": null,
-      "last_name_kana": null,
-      "last_name_kanji": null,
-      "maiden_name": null,
-      "personal_address": {
-        "city": null,
-        "country": "US",
-        "line1": null,
-        "line2": null,
-        "postal_code": null,
-        "state": null
+      "default_currency": "usd",
+      "details_submitted": false,
+      "display_name": "",
+      "email": "site@stripe.com",
+      "external_accounts": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/accounts/acct_19tLK7DSlTMT26Mk/external_accounts"
       },
-      "personal_id_number_provided": false,
-      "phone_number": null,
-      "ssn_last_4_provided": false,
-      "type": null,
+      "fake_account": false,
+      "id": "acct_19tLK7DSlTMT26Mk",
+      "legal_entity": {
+        "address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "business_name": null,
+        "business_tax_id_provided": false,
+        "dob": {
+          "day": null,
+          "month": null,
+          "year": null
+        },
+        "first_name": null,
+        "last_name": null,
+        "personal_address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "ssn_last_4_provided": false,
+        "type": null,
+        "verification": {
+          "details": null,
+          "details_code": null,
+          "document": null,
+          "status": "unverified"
+        }
+      },
+      "light": false,
+      "managed": true,
+      "mcc": "",
+      "metadata": {
+      },
+      "object": "account",
+      "orders": {
+      },
+      "product_description": "",
+      "risk_details": {
+      },
+      "statement_descriptor": "",
+      "support_address": {
+      },
+      "support_email": "",
+      "support_phone": "",
+      "support_url": "",
+      "timezone": "Etc/UTC",
+      "tos_acceptance": {
+        "date": null,
+        "ip": null,
+        "user_agent": null
+      },
+      "transfer_schedule": {
+        "delay_days": 2,
+        "interval": "daily"
+      },
+      "transfer_statement_descriptor": "",
+      "transfers_enabled": false,
       "verification": {
-        "details": null,
-        "details_code": null,
-        "document": null,
-        "status": "unverified"
+        "disabled_reason": "fields_needed",
+        "due_by": null,
+        "fields_needed": [
+          "business_url",
+          "external_account",
+          "product_description",
+          "support_phone",
+          "tos_acceptance.date",
+          "tos_acceptance.ip"
+        ]
       }
     },
-    "light": false,
-    "managed": true,
-    "mcc": "",
-    "metadata": {
-    },
-    "object": "account",
-    "orders": {
-    },
-    "product_description": "",
-    "risk_details": {
-    },
-    "statement_descriptor": "",
-    "support_address": {
-    },
-    "support_email": "",
-    "support_phone": "",
-    "support_url": "",
-    "timezone": "Etc/UTC",
-    "tos_acceptance": {
-      "date": null,
-      "ip": null,
-      "user_agent": null
-    },
-    "transfer_schedule": {
-      "delay_days": 7,
-      "interval": "daily"
-    },
-    "transfer_statement_descriptor": "",
-    "transfers_enabled": false,
-    "verification": {
-      "disabled_reason": "fields_needed",
-      "due_by": null,
-      "fields_needed": [
-        "business_url",
-        "external_account",
-        "product_description",
-        "support_phone",
-        "tos_acceptance.date",
-        "tos_acceptance.ip"
-      ]
-    }
-  },
-  "account_with_keys": {
-    "active_payment_methods": [
-
-    ],
-    "bank_accounts": {
-    },
-    "business_logo": "",
-    "business_name": "",
-    "business_primary_color": "",
-    "business_url": "",
-    "charges_enabled": false,
-    "country": "US",
-    "debit_negative_balances": false,
-    "decline_charge_on": {
-    },
-    "default_currency": "usd",
-    "details_submitted": false,
-    "display_name": "",
-    "email": "foo+os4pphkove@example.com",
-    "external_accounts": {
-    },
-    "fake_account": false,
-    "id": "acct_19y6HAAylotNGqt3",
-    "keys": {
-    },
-    "legal_entity": {
-    },
-    "light": false,
-    "managed": false,
-    "mcc": "",
-    "metadata": {
-    },
-    "object": "account",
-    "orders": {
-    },
-    "product_description": "",
-    "risk_details": {
-    },
-    "statement_descriptor": "",
-    "support_address": {
-    },
-    "support_email": "",
-    "support_phone": "",
-    "support_url": "",
-    "timezone": "Etc/UTC",
-    "tos_acceptance": {
-    },
-    "transfer_schedule": {
-    },
-    "transfer_statement_descriptor": "",
-    "transfers_enabled": false,
-    "verification": {
-    }
-  },
-  "alipay_account": {
-    "created": 1234567890,
-    "customer": "",
-    "fingerprint": "eiRpjVAne6V7vzjH",
-    "id": "aliacc_19y6HIAylotNGqt3CWxIarua",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "alipay_account",
-    "payment_amount": 1000,
-    "payment_currency": "usd",
-    "reusable": false,
-    "used": false,
-    "username": "test@example.com"
-  },
-  "apple_pay_domain": {
-    "created": 1234567890,
-    "domain_name": "example.com",
-    "id": "apwc_19y6HHAylotNGqt3514QiFTd",
-    "livemode": true,
-    "object": "apple_pay_domain"
-  },
-  "balance": {
-    "available": [
-      {
-        "amount": 0,
-        "currency": "usd",
-        "source_types": {
-          "card": 0
-        }
-      }
-    ],
-    "connect_reserved": [
-
-    ],
-    "livemode": false,
-    "object": "balance",
-    "pending": [
-      {
-        "amount": 0,
-        "currency": "usd",
-        "source_types": {
-          "card": 0
-        }
-      }
-    ]
-  },
-  "balance_transaction": {
-    "amount": 100,
-    "automatic_transfer": {
-    },
-    "available_on": 1234567890,
-    "created": 1234567890,
-    "currency": "usd",
-    "description": "",
-    "fee": 0,
-    "fee_details": [
-
-    ],
-    "id": "txn_19y6HHAylotNGqt33AMqhSaS",
-    "net": 100,
-    "object": "balance_transaction",
-    "source": "ch_19y6HHAylotNGqt3dguVG1mI",
-    "sourced_transfers": {
-    },
-    "status": "pending",
-    "type": "charge"
-  },
-  "bank_account": {
-    "account": "acct_19y6HAAylotNGqt3",
-    "account_holder_name": "Jane Austen",
-    "account_holder_type": "individual",
-    "address_city": "",
-    "address_line1": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "allows_debits": false,
-    "bank_name": "STRIPE TEST BANK",
-    "bank_phone_number": "",
-    "country": "US",
-    "currency": "usd",
-    "customer": "",
-    "customer_reference": "",
-    "default_for_currency": false,
-    "fingerprint": "G8AlCiZpIixKrovm",
-    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
-    "last4": "6789",
-    "metadata": {
-    },
-    "object": "bank_account",
-    "reusable": false,
-    "routing_number": "110000000",
-    "status": "new",
-    "used": false
-  },
-  "bitcoin_receiver": {
-    "active": false,
-    "amount": 100,
-    "amount_received": 0,
-    "bitcoin_amount": 1757908,
-    "bitcoin_amount_received": 0,
-    "bitcoin_uri": "bitcoin:test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1?amount=0.01757908",
-    "created": 1234567890,
-    "currency": "usd",
-    "customer": "",
-    "description": "Receiver for John Doe",
-    "email": "test@example.com",
-    "filled": false,
-    "id": "btcrcv_19y6HIAylotNGqt3PPrzs2zr",
-    "inbound_address": "test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "bitcoin_receiver",
-    "payment": "",
-    "refund_address": "",
-    "transactions": {
-    },
-    "uncaptured_funds": false,
-    "used_for_payment": false
-  },
-  "bitcoin_transaction": {
-    "amount": 100,
-    "bitcoin_amount": 1757908,
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "btctxn_19y6HIAylotNGqt3ufx7IrFQ",
-    "object": "bitcoin_transaction",
-    "receiver": "btcrcv_19y6HIBBq8Um5VVVjcO0R7nU"
-  },
-  "card": {
-    "3d_secure": {
-    },
-    "account": "",
-    "address_city": "",
-    "address_country": "",
-    "address_line1": "",
-    "address_line1_check": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "address_zip_check": "",
-    "available_payout_methods": [
-
-    ],
-    "brand": "Visa",
-    "country": "",
-    "currency": "",
-    "customer": "",
-    "cvc_check": "",
-    "default_for_currency": false,
-    "description": "",
-    "dynamic_last4": "",
-    "emv_auth_data": "",
-    "estimated_availability": "",
-    "exp_month": 8,
-    "exp_year": 2018,
-    "fingerprint": "",
-    "funding": "unknown",
-    "google_reference": "",
-    "id": "card_19y6HHAylotNGqt3SvYv7I1c",
-    "iin": "",
-    "issuer": "",
-    "last4": "4242",
-    "metadata": {
-    },
-    "name": "",
-    "object": "card",
-    "recipient": "",
-    "three_d_secure": {
-    },
-    "tokenization_method": ""
-  },
-  "charge": {
-    "alternate_statement_descriptors": {
-    },
-    "amount": 100,
-    "amount_authorized": 0,
-    "amount_captured": 0,
-    "amount_refunded": 0,
-    "application": "",
-    "application_fee": "",
-    "application_fees_refunded": 0,
-    "authorization_code": "",
-    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
-    "captured": true,
-    "card": {
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "customer": "",
-    "description": "My First Test Charge (created for API docs)",
-    "destination": "",
-    "dispute": "",
-    "failure_code": "",
-    "failure_message": "",
-    "fee_balance_transactions": {
-    },
-    "fraud_details": {
-    },
-    "id": "ch_19y6HHAylotNGqt3dguVG1mI",
-    "invoice": "",
-    "level3": {
-    },
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "charge",
-    "on_behalf_of": "",
-    "order": "",
-    "outcome": {
-    },
-    "paid": true,
-    "receipt_email": "",
-    "receipt_number": "",
-    "refunded": false,
-    "refunds": {
-      "data": [
+    "account_with_keys": {
+      "active_payment_methods": [
 
       ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/charges/ch_19y6HHAylotNGqt3dguVG1mI/refunds"
+      "bank_accounts": {
+      },
+      "business_logo": "",
+      "business_name": "",
+      "business_primary_color": "",
+      "business_url": "",
+      "charges_enabled": false,
+      "country": "US",
+      "debit_negative_balances": false,
+      "decline_charge_on": {
+      },
+      "default_currency": "usd",
+      "details_submitted": false,
+      "display_name": "",
+      "email": "site@stripe.com",
+      "external_accounts": {
+      },
+      "fake_account": false,
+      "id": "acct_19tLK7DSlTMT26Mk",
+      "keys": {
+      },
+      "legal_entity": {
+      },
+      "light": false,
+      "managed": false,
+      "mcc": "",
+      "metadata": {
+      },
+      "object": "account",
+      "orders": {
+      },
+      "product_description": "",
+      "risk_details": {
+      },
+      "statement_descriptor": "",
+      "support_address": {
+      },
+      "support_email": "",
+      "support_phone": "",
+      "support_url": "",
+      "timezone": "Etc/UTC",
+      "tos_acceptance": {
+      },
+      "transfer_schedule": {
+      },
+      "transfer_statement_descriptor": "",
+      "transfers_enabled": false,
+      "verification": {
+      }
     },
-    "review": "",
-    "shipping": {
+    "alipay_account": {
+      "created": 1234567890,
+      "customer": "",
+      "fingerprint": "NYUNwalrZGyUB5WV",
+      "id": "aliacc_19zuujDSlTMT26MkefiECdjT",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "alipay_account",
+      "payment_amount": 1000,
+      "payment_currency": "usd",
+      "reusable": false,
+      "used": false,
+      "username": "test@example.com"
     },
-    "source": {
-      "address_city": null,
-      "address_country": null,
-      "address_line1": null,
-      "address_line1_check": null,
-      "address_line2": null,
-      "address_state": null,
-      "address_zip": null,
-      "address_zip_check": null,
+    "apple_pay_domain": {
+      "created": 1234567890,
+      "domain_name": "example.com",
+      "id": "apwc_19zuugDSlTMT26MkaEqesPjq",
+      "livemode": true,
+      "object": "apple_pay_domain"
+    },
+    "balance": {
+      "available": [
+        {
+          "amount": 0,
+          "currency": "usd",
+          "source_types": {
+            "card": 0
+          }
+        }
+      ],
+      "connect_reserved": [
+
+      ],
+      "livemode": false,
+      "object": "balance",
+      "pending": [
+        {
+          "amount": 0,
+          "currency": "usd",
+          "source_types": {
+            "card": 0
+          }
+        }
+      ]
+    },
+    "balance_transaction": {
+      "amount": 100,
+      "automatic_transfer": {
+      },
+      "available_on": 1234567890,
+      "created": 1234567890,
+      "currency": "usd",
+      "description": "",
+      "fee": 0,
+      "fee_details": [
+
+      ],
+      "id": "txn_19zuuhDSlTMT26Mk2gJnG0ti",
+      "net": 100,
+      "object": "balance_transaction",
+      "source": "ch_19zuuhDSlTMT26MkKLSiekJ9",
+      "sourced_transfers": {
+      },
+      "status": "pending",
+      "type": "charge"
+    },
+    "bank_account": {
+      "account": "acct_19tLK7DSlTMT26Mk",
+      "account_holder_name": "Jane Austen",
+      "account_holder_type": "individual",
+      "address_city": "",
+      "address_line1": "",
+      "address_line2": "",
+      "address_state": "",
+      "address_zip": "",
+      "allows_debits": false,
+      "bank_name": "STRIPE TEST BANK",
+      "bank_phone_number": "",
+      "country": "US",
+      "currency": "usd",
+      "customer": "",
+      "customer_reference": "",
+      "default_for_currency": false,
+      "fingerprint": "ryfzKJTPWAUfw2iL",
+      "id": "ba_19zuuiDSlTMT26Mk8HQCpGLE",
+      "last4": "6789",
+      "metadata": {
+      },
+      "object": "bank_account",
+      "reusable": false,
+      "routing_number": "110000000",
+      "status": "new",
+      "used": false
+    },
+    "bitcoin_receiver": {
+      "active": false,
+      "amount": 100,
+      "amount_received": 0,
+      "bitcoin_amount": 1757908,
+      "bitcoin_amount_received": 0,
+      "bitcoin_uri": "bitcoin:test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1?amount=0.01757908",
+      "created": 1234567890,
+      "currency": "usd",
+      "customer": "",
+      "description": "Receiver for John Doe",
+      "email": "test@example.com",
+      "filled": false,
+      "id": "btcrcv_19zYqFDSlTMT26Mk31J1pMex",
+      "inbound_address": "test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "bitcoin_receiver",
+      "payment": "",
+      "refund_address": "",
+      "transactions": {
+      },
+      "uncaptured_funds": false,
+      "used_for_payment": false
+    },
+    "bitcoin_transaction": {
+      "amount": 100,
+      "bitcoin_amount": 1757908,
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "btctxn_19zuujDSlTMT26MkHOZALNf7",
+      "object": "bitcoin_transaction",
+      "receiver": "btcrcv_19zYqFDSlTMT26Mk31J1pMex"
+    },
+    "card": {
+      "3d_secure": {
+      },
+      "account": "",
+      "address_city": "",
+      "address_country": "",
+      "address_line1": "",
+      "address_line1_check": "",
+      "address_line2": "",
+      "address_state": "",
+      "address_zip": "",
+      "address_zip_check": "",
+      "available_payout_methods": [
+
+      ],
       "brand": "Visa",
-      "country": null,
-      "customer": null,
-      "cvc_check": null,
-      "dynamic_last4": null,
+      "country": "",
+      "currency": "",
+      "customer": "",
+      "cvc_check": "",
+      "default_for_currency": false,
+      "description": "",
+      "dynamic_last4": "",
+      "emv_auth_data": "",
+      "estimated_availability": "",
       "exp_month": 8,
       "exp_year": 2018,
+      "fingerprint": "",
       "funding": "unknown",
-      "id": "card_19y6HHAylotNGqt3SvYv7I1c",
+      "google_reference": "",
+      "id": "card_19tLKYDSlTMT26Mkl7bixGYc",
+      "iin": "",
+      "issuer": "",
       "last4": "4242",
       "metadata": {
       },
-      "name": null,
+      "name": "",
       "object": "card",
-      "tokenization_method": null
+      "recipient": "",
+      "three_d_secure": {
+      },
+      "tokenization_method": ""
     },
-    "source_transfer": "",
-    "statement_descriptor": "",
-    "status": "succeeded",
-    "transfer": "",
-    "transfer_group": "",
-    "trust": {
-    }
-  },
-  "country_spec": {
-    "default_currency": "usd",
-    "field_schemas": {
-    },
-    "id": "US",
-    "object": "country_spec",
-    "supported_bank_account_currencies": {
-      "usd": [
-        "US"
-      ]
-    },
-    "supported_payment_currencies": [
-      "...",
-      "aed",
-      "afn",
-      "usd"
-    ],
-    "supported_payment_methods": [
-      "alipay",
-      "card",
-      "stripe"
-    ],
-    "verification_fields": {
-      "company": {
-        "additional": [
+    "charge": {
+      "alternate_statement_descriptors": {
+      },
+      "amount": 100,
+      "amount_authorized": 0,
+      "amount_captured": 0,
+      "amount_refunded": 0,
+      "application": "",
+      "application_fee": "",
+      "application_fees_refunded": 0,
+      "authorization_code": "",
+      "balance_transaction": "txn_19zuuhDSlTMT26Mk2gJnG0ti",
+      "captured": true,
+      "card": {
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "customer": "",
+      "description": "My First Test Charge (created for API docs)",
+      "destination": "",
+      "dispute": "",
+      "failure_code": "",
+      "failure_message": "",
+      "fee_balance_transactions": {
+      },
+      "fraud_details": {
+      },
+      "id": "ch_19zuuhDSlTMT26MkKLSiekJ9",
+      "invoice": "",
+      "level3": {
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "charge",
+      "on_behalf_of": "",
+      "order": "",
+      "outcome": {
+      },
+      "paid": true,
+      "receipt_email": "",
+      "receipt_number": "",
+      "refunded": false,
+      "refunds": {
+        "data": [
 
         ],
-        "minimum": [
-
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/charges/ch_19zuuhDSlTMT26MkKLSiekJ9/refunds"
+      },
+      "review": "",
+      "shipping": {
+      },
+      "source": {
+        "address_city": null,
+        "address_country": null,
+        "address_line1": null,
+        "address_line1_check": null,
+        "address_line2": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_zip_check": null,
+        "brand": "Visa",
+        "country": null,
+        "customer": null,
+        "cvc_check": null,
+        "dynamic_last4": null,
+        "exp_month": 8,
+        "exp_year": 2018,
+        "funding": "unknown",
+        "id": "card_19tLKYDSlTMT26Mkl7bixGYc",
+        "last4": "4242",
+        "metadata": {
+        },
+        "name": null,
+        "object": "card",
+        "tokenization_method": null
+      },
+      "source_transfer": "",
+      "statement_descriptor": "",
+      "status": "succeeded",
+      "transfer": "",
+      "transfer_group": "",
+      "trust": {
+      }
+    },
+    "country_spec": {
+      "default_currency": "usd",
+      "field_schemas": {
+      },
+      "id": "US",
+      "object": "country_spec",
+      "supported_bank_account_currencies": {
+        "usd": [
+          "US"
         ]
       },
-      "individual": {
-        "additional": [
-
-        ],
-        "minimum": [
-
-        ]
-      }
-    }
-  },
-  "coupon": {
-    "amount_off": 0,
-    "created": 1234567890,
-    "currency": "usd",
-    "duration": "repeating",
-    "duration_in_months": 3,
-    "id": "25OFF",
-    "livemode": false,
-    "max_redemptions": 0,
-    "metadata": {
-    },
-    "object": "coupon",
-    "percent_off": 25,
-    "redeem_by": 1234567890,
-    "times_redeemed": 0,
-    "valid": true
-  },
-  "customer": {
-    "account_balance": 0,
-    "alipay_accounts": {
-    },
-    "bank_accounts": {
-    },
-    "business_vat_id": "",
-    "cards": {
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "default_bank_account": "",
-    "default_card": "",
-    "default_source": "",
-    "default_source_type": "",
-    "delinquent": false,
-    "description": "",
-    "discount": {
-    },
-    "email": "",
-    "id": "cus_AIhgCDhEsqLqXq",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "customer",
-    "shipping": {
-    },
-    "sources": {
-      "data": [
-
+      "supported_payment_currencies": [
+        "...",
+        "aed",
+        "afn",
+        "usd"
       ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/customers/cus_AIhgCDhEsqLqXq/sources"
+      "supported_payment_methods": [
+        "alipay",
+        "card",
+        "stripe"
+      ],
+      "verification_fields": {
+        "company": {
+          "additional": [
+            "legal_entity.verification.document"
+          ],
+          "minimum": [
+            "external_account",
+            "legal_entity.address.city",
+            "legal_entity.address.line1",
+            "legal_entity.address.postal_code",
+            "legal_entity.address.state",
+            "legal_entity.business_name",
+            "legal_entity.business_tax_id",
+            "legal_entity.dob.day",
+            "legal_entity.dob.month",
+            "legal_entity.dob.year",
+            "legal_entity.first_name",
+            "legal_entity.last_name",
+            "legal_entity.ssn_last_4",
+            "legal_entity.type",
+            "tos_acceptance.date",
+            "tos_acceptance.ip"
+          ]
+        },
+        "individual": {
+          "additional": [
+            "legal_entity.verification.document"
+          ],
+          "minimum": [
+            "external_account",
+            "legal_entity.address.city",
+            "legal_entity.address.line1",
+            "legal_entity.address.postal_code",
+            "legal_entity.address.state",
+            "legal_entity.dob.day",
+            "legal_entity.dob.month",
+            "legal_entity.dob.year",
+            "legal_entity.first_name",
+            "legal_entity.last_name",
+            "legal_entity.ssn_last_4",
+            "legal_entity.type",
+            "tos_acceptance.date",
+            "tos_acceptance.ip"
+          ]
+        }
+      }
     },
-    "subscription": {
-    },
-    "subscriptions": {
-    },
-    "trust": {
-    }
-  },
-  "customer_source": {
-    "customer": "",
-    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
-    "metadata": {
-    },
-    "object": "bank_account"
-  },
-  "discount": {
     "coupon": {
-      "amount_off": null,
-      "created": 1489700220,
+      "amount_off": 0,
+      "created": 1234567890,
       "currency": "usd",
       "duration": "repeating",
       "duration_in_months": 3,
       "id": "25OFF",
       "livemode": false,
-      "max_redemptions": null,
+      "max_redemptions": 0,
       "metadata": {
       },
       "object": "coupon",
       "percent_off": 25,
-      "redeem_by": null,
+      "redeem_by": 1234567890,
       "times_redeemed": 0,
       "valid": true
     },
-    "customer": "cus_AIhgCDhEsqLqXq",
-    "end": 1234567890,
-    "object": "discount",
-    "start": 1234567890,
-    "subscription": ""
-  },
-  "dispute": {
-    "accepted_at": 1234567890,
-    "amount": 1000,
-    "balance_transaction": "",
-    "balance_transactions": [
+    "customer": {
+      "account_balance": 0,
+      "alipay_accounts": {
+      },
+      "bank_accounts": {
+      },
+      "business_vat_id": "",
+      "cards": {
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "default_bank_account": "",
+      "default_card": "",
+      "default_source": "",
+      "default_source_type": "",
+      "delinquent": false,
+      "description": "",
+      "discount": {
+      },
+      "email": "",
+      "id": "cus_ADmuABetLS15eF",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "customer",
+      "shipping": {
+      },
+      "sources": {
+        "data": [
 
-    ],
-    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
-    "closed_at": 1234567890,
-    "created": 1234567890,
-    "currency": "usd",
-    "escalated_at": 1234567890,
-    "evidence": {
-      "access_activity_log": null,
-      "billing_address": null,
-      "cancellation_policy": null,
-      "cancellation_policy_disclosure": null,
-      "cancellation_rebuttal": null,
-      "customer_communication": null,
-      "customer_email_address": null,
-      "customer_name": null,
-      "customer_purchase_ip": null,
-      "customer_signature": null,
-      "duplicate_charge_documentation": null,
-      "duplicate_charge_explanation": null,
-      "duplicate_charge_id": null,
-      "product_description": null,
-      "receipt": null,
-      "refund_policy": null,
-      "refund_policy_disclosure": null,
-      "refund_refusal_explanation": null,
-      "service_date": null,
-      "service_documentation": null,
-      "shipping_address": null,
-      "shipping_carrier": null,
-      "shipping_date": null,
-      "shipping_documentation": null,
-      "shipping_tracking_number": null,
-      "uncategorized_file": null,
-      "uncategorized_text": null
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/customers/cus_ADmuABetLS15eF/sources"
+      },
+      "subscription": {
+      },
+      "subscriptions": {
+      },
+      "trust": {
+      }
     },
-    "evidence_details": {
-      "due_by": 1491350399,
-      "has_evidence": false,
-      "past_due": false,
-      "submission_count": 0
+    "customer_source": {
+      "customer": "",
+      "id": "ba_19zuuiDSlTMT26Mk8HQCpGLE",
+      "metadata": {
+      },
+      "object": "bank_account"
     },
-    "evidence_submitted_at": [
+    "discount": {
+      "coupon": {
+        "amount_off": null,
+        "created": 1490133192,
+        "currency": "usd",
+        "duration": "repeating",
+        "duration_in_months": 3,
+        "id": "25OFF",
+        "livemode": false,
+        "max_redemptions": null,
+        "metadata": {
+        },
+        "object": "coupon",
+        "percent_off": 25,
+        "redeem_by": null,
+        "times_redeemed": 0,
+        "valid": true
+      },
+      "customer": "cus_ADmuABetLS15eF",
+      "end": 1234567890,
+      "object": "discount",
+      "start": 1234567890,
+      "subscription": ""
+    },
+    "dispute": {
+      "accepted_at": 1234567890,
+      "amount": 1000,
+      "balance_transaction": "",
+      "balance_transactions": [
 
-    ],
-    "id": "dp_19y6HHAylotNGqt3bvR7ZOnH",
-    "is_charge_refundable": false,
-    "is_protected": false,
-    "livemode": false,
-    "metadata": {
+      ],
+      "charge": "ch_19zuuhDSlTMT26MkKLSiekJ9",
+      "closed_at": 1234567890,
+      "created": 1234567890,
+      "currency": "usd",
+      "escalated_at": 1234567890,
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": null,
+        "customer_name": null,
+        "customer_purchase_ip": null,
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1491782399,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "evidence_submitted_at": [
+
+      ],
+      "id": "dp_19zuuhDSlTMT26Mkp7PHaa4O",
+      "is_charge_refundable": false,
+      "is_protected": false,
+      "livemode": false,
+      "metadata": {
+      },
+      "network_reason_code": "",
+      "object": "dispute",
+      "reason": "general",
+      "status": "needs_response"
     },
-    "network_reason_code": "",
-    "object": "dispute",
-    "reason": "general",
-    "status": "needs_response"
-  },
-  "event": {
-    "api_version": "",
-    "created": 1234567890,
-    "customer_email": "",
-    "data": {
-      "object": {
+    "event": {
+      "api_version": "2017-02-14",
+      "created": 1234567890,
+      "customer_email": "",
+      "data": {
+        "object": {
+          "account_balance": 0,
+          "created": 1488566449,
+          "currency": "usd",
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "id": "cus_ADmuABetLS15eF",
+          "livemode": false,
+          "metadata": {
+          },
+          "object": "customer",
+          "shipping": null,
+          "sources": {
+            "data": [
+
+            ],
+            "has_more": false,
+            "object": "list",
+            "total_count": 0,
+            "url": "/v1/customers/cus_ADmuABetLS15eF/sources"
+          },
+          "subscriptions": {
+            "data": [
+
+            ],
+            "has_more": false,
+            "object": "list",
+            "total_count": 0,
+            "url": "/v1/customers/cus_ADmuABetLS15eF/subscriptions"
+          }
+        }
+      },
+      "id": "evt_19tLKfDSlTMT26MkKD3pohqX",
+      "livemode": false,
+      "object": "event",
+      "pending_webhooks": 0,
+      "recipient_best_description": "",
+      "request": "",
+      "type": "customer.created"
+    },
+    "external_account_source": {
+      "account": "acct_19tLK7DSlTMT26Mk",
+      "address_city": "",
+      "address_line1": "",
+      "address_line2": "",
+      "address_state": "",
+      "address_zip": "",
+      "country": "US",
+      "currency": "usd",
+      "customer": "",
+      "default_for_currency": false,
+      "fingerprint": "ryfzKJTPWAUfw2iL",
+      "id": "ba_19zuuiDSlTMT26Mk8HQCpGLE",
+      "last4": "6789",
+      "metadata": {
+      },
+      "object": "bank_account"
+    },
+    "fee_refund": {
+      "amount": 100,
+      "balance_transaction": "",
+      "created": 1234567890,
+      "currency": "usd",
+      "fee": "fee_19zuujDSlTMT26MkEMvXUsIx",
+      "id": "fr_AKa4dv904Dvl5q",
+      "metadata": {
+      },
+      "object": "fee_refund"
+    },
+    "invoice": {
+      "amount_due": 0,
+      "application_fee": 0,
+      "attempt_count": 0,
+      "attempted": false,
+      "billing": "",
+      "charge": "",
+      "closed": false,
+      "currency": "usd",
+      "customer": "cus_ADmuABetLS15eF",
+      "date": 1234567890,
+      "description": "",
+      "discount": {
+      },
+      "due_date": 1234567890,
+      "ending_balance": 0,
+      "forgiven": false,
+      "id": "in_19zuuiDSlTMT26Mk1XitxqCb",
+      "lines": {
+        "data": [
+          {
+            "amount": 2000,
+            "currency": "usd",
+            "description": null,
+            "discountable": true,
+            "id": "sub_AKa4uss8vCMAZC",
+            "livemode": true,
+            "metadata": {
+            },
+            "object": "line_item",
+            "period": {
+              "end": 1495403592,
+              "start": 1492811592
+            },
+            "plan": {
+              "amount": 2000,
+              "created": 1488566449,
+              "currency": "usd",
+              "id": "gold",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "name": "Gold Special",
+              "object": "plan",
+              "statement_descriptor": null,
+              "trial_period_days": null
+            },
+            "proration": false,
+            "quantity": 1,
+            "subscription": null,
+            "subscription_item": "si_19zuuiDSlTMT26Mk9HayBPe9",
+            "type": "subscription"
+          }
+        ],
+        "object": "list",
+        "total_count": 1,
+        "url": "/v1/invoices/in_19zuuiDSlTMT26Mk1XitxqCb/lines"
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "next_payment_attempt": 1234567890,
+      "number": "",
+      "object": "invoice",
+      "paid": false,
+      "period_end": 1234567890,
+      "period_start": 1234567890,
+      "receipt_number": "",
+      "send_next_at": 1234567890,
+      "starting_balance": 0,
+      "statement_descriptor": "",
+      "subscription": "",
+      "subscription_proration_date": 0,
+      "subtotal": 0,
+      "tax": 0,
+      "tax_percent": 0.0,
+      "total": 0,
+      "webhooks_delivered_at": 1234567890
+    },
+    "invoice_item": {
+      "amount": 1000,
+      "currency": "usd",
+      "customer": "cus_ADmuABetLS15eF",
+      "date": 1234567890,
+      "description": "My First Invoice Item (created for API docs)",
+      "discountable": true,
+      "id": "ii_19zuuiDSlTMT26MkvsaAgAi7",
+      "invoice": "",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "invoiceitem",
+      "period": {
+        "end": 1490133192,
+        "start": 1490133192
+      },
+      "plan": {
+      },
+      "proration": false,
+      "quantity": 0,
+      "subscription": "",
+      "subscription_item": ""
+    },
+    "invoice_line_item": {
+      "amount": 1000,
+      "currency": "usd",
+      "description": "My First Invoice Item (created for API docs)",
+      "discountable": true,
+      "id": "ii_19zuuiDSlTMT26MkvsaAgAi7",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "line_item",
+      "period": {
+        "end": 1490133192,
+        "start": 1490133192
+      },
+      "plan": {
+      },
+      "proration": false,
+      "quantity": 0,
+      "subscription": "",
+      "subscription_item": "",
+      "type": "invoiceitem"
+    },
+    "legacy_transfer": {
+      "amount": 1100,
+      "amount_reversed": 0,
+      "application_fee": "",
+      "auto": false,
+      "balance_transaction": "",
+      "bank_account": {
+      },
+      "card": {
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "date": 1234567890,
+      "delay_reason": "",
+      "description": "Transfer to test@example.com",
+      "destination": "ba_19zuujDSlTMT26MkRkpqv9Ud",
+      "destination_payment": "",
+      "failure_code": "",
+      "failure_message": "",
+      "id": "tr_19zuujDSlTMT26Mk81npuLjT",
+      "legacy_date": 1234567890,
+      "livemode": false,
+      "metadata": {
+      },
+      "method": "standard",
+      "object": "transfer",
+      "recipient": "",
+      "reversals": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/transfers/tr_19zuujDSlTMT26Mk81npuLjT/reversals"
+      },
+      "reversed": false,
+      "source_transaction": "",
+      "source_type": "card",
+      "statement_descriptor": "",
+      "status": "in_transit",
+      "transfer_group": "",
+      "type": "bank_account",
+      "user_visible_date": 1234567890
+    },
+    "order": {
+      "amount": 1500,
+      "amount_returned": 0,
+      "application": "",
+      "application_fee": 0,
+      "charge": "",
+      "created": 1234567890,
+      "currency": "usd",
+      "customer": "",
+      "email": "",
+      "external_coupon_code": "",
+      "external_sku_ids": [
+
+      ],
+      "id": "or_19zuukDSlTMT26MktR8hwCzJ",
+      "items": [
+        {
+          "amount": 1500,
+          "currency": "usd",
+          "description": "T-shirt",
+          "object": "order_item",
+          "parent": "sk_19tLKeDSlTMT26MkWafeCAS4",
+          "quantity": null,
+          "type": "sku"
+        }
+      ],
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "order",
+      "returns": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/order_returns?order=or_19zuukDSlTMT26MktR8hwCzJ"
+      },
+      "selected_shipping_method": "",
+      "shipping": {
+        "address": {
+          "city": "Anytown",
+          "country": "US",
+          "line1": "1234 Main street",
+          "line2": null,
+          "postal_code": "123456",
+          "state": null
+        },
+        "carrier": null,
+        "name": "Jenny Rosen",
+        "phone": null,
+        "tracking_number": null
+      },
+      "shipping_methods": {
+      },
+      "signature": "",
+      "status": "created",
+      "status_transitions": {
+      },
+      "updated": 1234567890,
+      "upstream_id": ""
+    },
+    "order_return": {
+      "amount": 1500,
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "orret_19zuukDSlTMT26Mkxjz1bcqv",
+      "items": [
+        {
+          "amount": 1500,
+          "currency": "usd",
+          "description": "T-shirt",
+          "object": "order_item",
+          "parent": "sk_19zuukDSlTMT26MkepWkJtmm",
+          "quantity": null,
+          "type": "sku"
+        }
+      ],
+      "livemode": false,
+      "object": "order_return",
+      "order": "or_19zuukDSlTMT26MkL38GRWYx",
+      "refund": "re_19zuukDSlTMT26MkKx6aokup"
+    },
+    "plan": {
+      "amount": 2000,
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "gold",
+      "interval": "month",
+      "interval_count": 1,
+      "livemode": false,
+      "metadata": {
+      },
+      "name": "Gold Special",
+      "object": "plan",
+      "statement_descriptor": "",
+      "trial_period_days": 0
+    },
+    "platform_earning": {
+      "account": "acct_19tLK7DSlTMT26Mk",
+      "amount": 100,
+      "amount_refunded": 0,
+      "application": "ca_AKa4xbTjCsfO9n8mgC6PyMNf6FCnXMyM",
+      "balance_transaction": "txn_19zuuhDSlTMT26Mk2gJnG0ti",
+      "charge": "ch_19zuuhDSlTMT26MkKLSiekJ9",
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "fee_19zuujDSlTMT26MkEMvXUsIx",
+      "livemode": false,
+      "object": "application_fee",
+      "originating_transaction": "",
+      "refunded": false,
+      "refunds": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/application_fees/fee_19zuujDSlTMT26MkEMvXUsIx/refunds"
+      }
+    },
+    "product": {
+      "active": true,
+      "attributes": [
+        "gender",
+        "size"
+      ],
+      "caption": "",
+      "created": 1234567890,
+      "deactivate_on": [
+
+      ],
+      "description": "Comfortable gray cotton t-shirts",
+      "donation": false,
+      "id": "prod_AKa4nDYkPszdDl",
+      "images": [
+
+      ],
+      "livemode": false,
+      "metadata": {
+      },
+      "name": "T-shirt",
+      "object": "product",
+      "package_dimensions": {
+      },
+      "reason_product_not_tweetable": "",
+      "shippable": true,
+      "skus": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/skus?product=prod_AKa4nDYkPszdDl&active=true"
+      },
+      "tweetable_url": "",
+      "updated": 1234567890,
+      "url": ""
+    },
+    "refund": {
+      "amount": 100,
+      "balance_transaction": "",
+      "charge": "ch_19zuuhDSlTMT26MkKLSiekJ9",
+      "created": 1234567890,
+      "currency": "usd",
+      "description": "",
+      "fee_balance_transactions": {
+      },
+      "id": "re_19zuuhDSlTMT26MkpLosorvD",
+      "metadata": {
+      },
+      "object": "refund",
+      "reason": "",
+      "receipt_number": "",
+      "status": "succeeded",
+      "type": ""
+    },
+    "sku": {
+      "active": true,
+      "attributes": {
+        "gender": "Unisex",
+        "size": "Medium"
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "sku_AKa48dqsB87bsK",
+      "image": "",
+      "inventory": {
+        "quantity": 50,
+        "type": "finite",
+        "value": null
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "sku",
+      "package_dimensions": {
+      },
+      "price": 1500,
+      "product": "prod_AKa4nDYkPszdDl",
+      "updated": 1234567890
+    },
+    "source": {
+      "amount": 1000,
+      "client_secret": "src_client_secret_G7TlNFAGB2mThKeaF9jOBdWt",
+      "code_verification": {
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "customer": "",
+      "flow": "receiver",
+      "id": "src_19zuukDSlTMT26MkL5AZBjwf",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "source",
+      "order": "",
+      "owner": {
+        "address": null,
+        "email": "jenny.rosen@example.com",
+        "name": null,
+        "phone": null,
+        "verified_address": null,
+        "verified_email": null,
+        "verified_name": null,
+        "verified_phone": null
+      },
+      "receiver": {
+        "address": "test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N",
+        "amount_charged": 0,
+        "amount_received": 0,
+        "amount_returned": 0,
+        "refund_attributes_method": "email",
+        "refund_attributes_status": "missing"
+      },
+      "redirect": {
+      },
+      "status": "pending",
+      "type": "bitcoin",
+      "usage": "single_use"
+    },
+    "subscription": {
+      "account_balance": 0,
+      "application_fee_percent": 0.0,
+      "billing": "",
+      "cancel_at_period_end": false,
+      "canceled_at": 1234567890,
+      "created": 1234567890,
+      "current_period_end": 1234567890,
+      "current_period_start": 1234567890,
+      "customer": "cus_ADmuABetLS15eF",
+      "days_until_due": 0,
+      "discount": {
+      },
+      "ended_at": 1234567890,
+      "id": "sub_AKa4uss8vCMAZC",
+      "items": {
+        "data": [
+          {
+            "created": 1490133192,
+            "id": "si_19zuuiDSlTMT26Mk9HayBPe9",
+            "object": "subscription_item",
+            "plan": {
+              "amount": 2000,
+              "created": 1488566449,
+              "currency": "usd",
+              "id": "gold",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "name": "Gold Special",
+              "object": "plan",
+              "statement_descriptor": null,
+              "trial_period_days": null
+            },
+            "quantity": 1
+          }
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_AKa4uss8vCMAZC"
+      },
+      "livemode": false,
+      "max_occurrences": 0,
+      "metadata": {
+      },
+      "object": "subscription",
+      "on_behalf_of": "",
+      "plan": {
         "amount": 2000,
-        "created": 1489700220,
+        "created": 1488566449,
         "currency": "usd",
         "id": "gold",
         "interval": "month",
@@ -648,750 +1203,234 @@
         "object": "plan",
         "statement_descriptor": null,
         "trial_period_days": null
-      }
-    },
-    "id": "evt_19y6HIAylotNGqt349zSXYCk",
-    "livemode": false,
-    "object": "event",
-    "pending_webhooks": 0,
-    "recipient_best_description": "",
-    "request": "",
-    "type": "plan.created"
-  },
-  "external_account_source": {
-    "account": "acct_19y6HAAylotNGqt3",
-    "address_city": "",
-    "address_line1": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "country": "US",
-    "currency": "usd",
-    "customer": "",
-    "default_for_currency": false,
-    "fingerprint": "G8AlCiZpIixKrovm",
-    "id": "ba_19y6HIAylotNGqt37Bbh2BEi",
-    "last4": "6789",
-    "metadata": {
-    },
-    "object": "bank_account"
-  },
-  "fee_refund": {
-    "amount": 100,
-    "balance_transaction": "",
-    "created": 1234567890,
-    "currency": "usd",
-    "fee": "fee_19y6HIAylotNGqt3iEVMbEmJ",
-    "id": "fr_AIhghI4mXRpLEw",
-    "metadata": {
-    },
-    "object": "fee_refund"
-  },
-  "invoice": {
-    "amount_due": 0,
-    "application_fee": 0,
-    "attempt_count": 0,
-    "attempted": false,
-    "billing": "",
-    "charge": "",
-    "closed": false,
-    "currency": "usd",
-    "customer": "cus_AIhgCDhEsqLqXq",
-    "date": 1234567890,
-    "description": "",
-    "discount": {
-    },
-    "due_date": 1234567890,
-    "ending_balance": 0,
-    "forgiven": false,
-    "id": "in_19y6HIAylotNGqt3Kq1NUy5r",
-    "lines": {
-      "data": [
-        {
-          "amount": 2000,
-          "currency": "usd",
-          "description": null,
-          "discountable": true,
-          "id": "sub_AIhgP3KgCUJMuh",
-          "livemode": true,
-          "metadata": {
-          },
-          "object": "line_item",
-          "period": {
-            "end": 1494970619,
-            "start": 1492378619
-          },
-          "plan": {
-            "amount": 2000,
-            "created": 1489700220,
-            "currency": "usd",
-            "id": "gold",
-            "interval": "month",
-            "interval_count": 1,
-            "livemode": false,
-            "metadata": {
-            },
-            "name": "Gold Special",
-            "object": "plan",
-            "statement_descriptor": null,
-            "trial_period_days": null
-          },
-          "proration": false,
-          "quantity": 1,
-          "subscription": null,
-          "subscription_item": "si_19y6HHBBq8Um5VVVeabmVesw",
-          "type": "subscription"
-        }
-      ],
-      "object": "list",
-      "total_count": 1,
-      "url": "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
-    },
-    "livemode": false,
-    "metadata": {
-    },
-    "next_payment_attempt": 1234567890,
-    "number": "",
-    "object": "invoice",
-    "paid": false,
-    "period_end": 1234567890,
-    "period_start": 1234567890,
-    "receipt_number": "",
-    "starting_balance": 0,
-    "statement_descriptor": "",
-    "subscription": "",
-    "subscription_proration_date": 0,
-    "subtotal": 0,
-    "tax": 0,
-    "tax_percent": 0.0,
-    "total": 0,
-    "webhooks_delivered_at": 1234567890
-  },
-  "invoice_item": {
-    "amount": 1000,
-    "currency": "usd",
-    "customer": "cus_AIhgCDhEsqLqXq",
-    "date": 1234567890,
-    "description": "My First Invoice Item (created for API docs)",
-    "discountable": true,
-    "id": "ii_19y6HIAylotNGqt36BYYgGHq",
-    "invoice": "",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "invoiceitem",
-    "period": {
-      "end": 1489700220,
-      "start": 1489700220
-    },
-    "plan": {
-    },
-    "proration": false,
-    "quantity": 0,
-    "subscription": "",
-    "subscription_item": ""
-  },
-  "invoice_line_item": {
-    "amount": 1000,
-    "currency": "usd",
-    "description": "My First Invoice Item (created for API docs)",
-    "discountable": true,
-    "id": "ii_19y6HIAylotNGqt36BYYgGHq",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "line_item",
-    "period": {
-      "end": 1489700220,
-      "start": 1489700220
-    },
-    "plan": {
-    },
-    "proration": false,
-    "quantity": 0,
-    "subscription": "",
-    "subscription_item": "",
-    "type": "invoiceitem"
-  },
-  "legacy_transfer": {
-    "amount": 1100,
-    "amount_reversed": 0,
-    "application_fee": "",
-    "auto": false,
-    "balance_transaction": "",
-    "bank_account": {
-    },
-    "card": {
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "date": 1234567890,
-    "delay_reason": "",
-    "description": "Transfer to test@example.com",
-    "destination": "ba_19y6HIAylotNGqt3Tk6btLgn",
-    "destination_payment": "",
-    "failure_code": "",
-    "failure_message": "",
-    "id": "tr_19y6HIAylotNGqt3ph4EjS38",
-    "legacy_date": 1234567890,
-    "livemode": false,
-    "metadata": {
-    },
-    "method": "standard",
-    "object": "transfer",
-    "recipient": "",
-    "reversals": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
-    },
-    "reversed": false,
-    "source_transaction": "",
-    "source_type": "card",
-    "statement_descriptor": "",
-    "status": "in_transit",
-    "transfer_group": "",
-    "type": "bank_account",
-    "user_visible_date": 1234567890
-  },
-  "order": {
-    "amount": 1500,
-    "amount_returned": 0,
-    "application": "",
-    "application_fee": 0,
-    "charge": "",
-    "created": 1234567890,
-    "currency": "usd",
-    "customer": "",
-    "email": "",
-    "external_coupon_code": "",
-    "external_sku_ids": [
-
-    ],
-    "id": "or_19y6HJAylotNGqt3bov4Z4DC",
-    "items": [
-      {
-        "amount": 1500,
-        "currency": "usd",
-        "description": "T-shirt",
-        "object": "order_item",
-        "parent": "sk_19y6HJAylotNGqt3oddcLh9L",
-        "quantity": null,
-        "type": "sku"
-      }
-    ],
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "order",
-    "returns": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/order_returns?order=or_19y6HJAylotNGqt3bov4Z4DC"
-    },
-    "selected_shipping_method": "",
-    "shipping": {
-      "address": {
-        "city": "Anytown",
-        "country": "US",
-        "line1": "1234 Main street",
-        "line2": null,
-        "postal_code": "123456",
-        "state": null
       },
-      "carrier": null,
-      "name": "Jenny Rosen",
-      "phone": null,
-      "tracking_number": null
+      "quantity": 1,
+      "retains_own_balance": false,
+      "start": 1234567890,
+      "status": "active",
+      "tax_percent": 0.0,
+      "trial_end": 1234567890,
+      "trial_start": 1234567890
     },
-    "shipping_methods": {
-    },
-    "signature": "",
-    "status": "created",
-    "status_transitions": {
-    },
-    "updated": 1234567890,
-    "upstream_id": ""
-  },
-  "order_return": {
-    "amount": 1500,
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "orret_19y6HJAylotNGqt3bd5YsAXz",
-    "items": [
-      {
-        "amount": 1500,
+    "subscription_item": {
+      "created": 1490133192,
+      "id": "si_19zuuiDSlTMT26MkkbqEeSG7",
+      "object": "subscription_item",
+      "plan": {
+        "amount": 2000,
+        "created": 1488566449,
         "currency": "usd",
-        "description": "T-shirt",
-        "object": "order_item",
-        "parent": "sk_19y6HJAylotNGqt3oddcLh9L",
-        "quantity": null,
-        "type": "sku"
-      }
-    ],
-    "livemode": false,
-    "object": "order_return",
-    "order": "or_19y6HJAylotNGqt36m18HzRj",
-    "refund": "re_19y6HJAylotNGqt3rTe2A05C"
-  },
-  "plan": {
-    "amount": 2000,
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "gold",
-    "interval": "month",
-    "interval_count": 1,
-    "livemode": false,
-    "metadata": {
+        "id": "gold",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+        },
+        "name": "Gold Special",
+        "object": "plan",
+        "statement_descriptor": null,
+        "trial_period_days": null
+      },
+      "quantity": 1
     },
-    "name": "Gold Special",
-    "object": "plan",
-    "statement_descriptor": "",
-    "trial_period_days": 0
-  },
-  "platform_earning": {
-    "account": "acct_19y6HAAylotNGqt3",
-    "amount": 100,
-    "amount_refunded": 0,
-    "application": "ca_AIhgFq8kWIDlYSeaCcuycCoERZL0J0ls",
-    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
-    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "fee_19y6HIAylotNGqt3iEVMbEmJ",
-    "livemode": false,
-    "object": "application_fee",
-    "originating_transaction": "",
-    "refunded": false,
-    "refunds": {
-      "data": [
+    "three_d_secure": {
+      "amount": 1500,
+      "authenticated": false,
+      "card": {
+        "address_city": null,
+        "address_country": null,
+        "address_line1": null,
+        "address_line1_check": null,
+        "address_line2": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_zip_check": null,
+        "brand": "Visa",
+        "country": null,
+        "customer": null,
+        "cvc_check": null,
+        "dynamic_last4": null,
+        "exp_month": 8,
+        "exp_year": 2018,
+        "funding": "unknown",
+        "id": "card_19tLKYDSlTMT26Mkl7bixGYc",
+        "last4": "4242",
+        "metadata": {
+        },
+        "name": null,
+        "object": "card",
+        "tokenization_method": null
+      },
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "tdsrc_AKa4JYO98pZnbv",
+      "livemode": false,
+      "object": "three_d_secure",
+      "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AKa4JYO98pZnbv",
+      "status": "redirect_pending"
+    },
+    "token": {
+      "account_details": {
+      },
+      "alipay_account": {
+      },
+      "bank_account": {
+      },
+      "card": {
+        "address_city": null,
+        "address_country": null,
+        "address_line1": null,
+        "address_line1_check": null,
+        "address_line2": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_zip_check": null,
+        "brand": "Visa",
+        "country": null,
+        "cvc_check": null,
+        "dynamic_last4": null,
+        "exp_month": 8,
+        "exp_year": 2018,
+        "funding": "unknown",
+        "id": "card_19tLKYDSlTMT26MkxAeJBsQn",
+        "last4": "4242",
+        "metadata": {
+        },
+        "name": null,
+        "object": "card",
+        "tokenization_method": null
+      },
+      "client_ip": "",
+      "created": 1234567890,
+      "description": "",
+      "email": "",
+      "id": "tok_19tLKYDSlTMT26MkK7YyXpCy",
+      "livemode": false,
+      "object": "token",
+      "type": "card",
+      "usage": "",
+      "used": false
+    },
+    "transfer": {
+      "amount": 1100,
+      "amount_reversed": 0,
+      "balance_transaction": "txn_19zuuhDSlTMT26Mk2gJnG0ti",
+      "created": 1234567890,
+      "currency": "usd",
+      "destination": "ba_19zuujDSlTMT26MkRkpqv9Ud",
+      "destination_payment": "",
+      "id": "tr_19zuujDSlTMT26Mk81npuLjT",
+      "livemode": false,
+      "metadata": {
+      },
+      "object": "transfer",
+      "reversals": {
+        "data": [
 
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/application_fees/fee_19y6HIAylotNGqt3iEVMbEmJ/refunds"
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/transfers/tr_19zuujDSlTMT26Mk81npuLjT/reversals"
+      },
+      "reversed": false,
+      "transfer_group": ""
+    },
+    "transfer_recipient": {
+      "active_account": {
+      },
+      "address_city": "",
+      "address_country": "",
+      "address_line1": "",
+      "address_line2": "",
+      "address_state": "",
+      "address_zip": "",
+      "cards": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/recipients/rp_19zuujDSlTMT26MkZ3ZnkXL2/cards"
+      },
+      "country": "",
+      "created": 1234567890,
+      "default_card": "",
+      "description": "Recipient for John Doe",
+      "dob_day": "",
+      "dob_month": "",
+      "dob_year": "",
+      "email": "test@example.com",
+      "id": "rp_19zuujDSlTMT26MkZ3ZnkXL2",
+      "livemode": false,
+      "metadata": {
+      },
+      "migrated_to": "",
+      "name": "John Doe",
+      "object": "recipient",
+      "tin": "",
+      "tin_verification_pending": false,
+      "type": "individual",
+      "verified": false
+    },
+    "transfer_reversal": {
+      "amount": 1100,
+      "balance_transaction": "",
+      "created": 1234567890,
+      "currency": "usd",
+      "id": "trr_19zuujDSlTMT26Mkg0q2NfQu",
+      "metadata": {
+      },
+      "object": "transfer_reversal",
+      "transfer": "tr_19zuujDSlTMT26Mk81npuLjT"
+    },
+    "upcoming_invoice": {
+      "amount_due": 0,
+      "application_fee": 0,
+      "attempt_count": 0,
+      "attempted": false,
+      "billing": "",
+      "charge": "",
+      "closed": false,
+      "currency": "usd",
+      "customer": "cus_ADmuABetLS15eF",
+      "date": 1234567890,
+      "description": "",
+      "discount": {
+      },
+      "due_date": 1234567890,
+      "ending_balance": 0,
+      "forgiven": false,
+      "lines": {
+        "data": [
+
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/invoices/in_19zuuiDSlTMT26Mk1XitxqCb/lines"
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "next_payment_attempt": 1234567890,
+      "number": "",
+      "object": "invoice",
+      "paid": false,
+      "period_end": 1234567890,
+      "period_start": 1234567890,
+      "receipt_number": "",
+      "send_next_at": 1234567890,
+      "starting_balance": 0,
+      "statement_descriptor": "",
+      "subscription": "",
+      "subscription_proration_date": 0,
+      "subtotal": 0,
+      "tax": 0,
+      "tax_percent": 0.0,
+      "total": 0,
+      "webhooks_delivered_at": 1234567890
     }
-  },
-  "product": {
-    "active": true,
-    "attributes": [
-      "gender",
-      "size"
-    ],
-    "caption": "",
-    "created": 1234567890,
-    "deactivate_on": [
-
-    ],
-    "description": "Comfortable gray cotton t-shirts",
-    "donation": false,
-    "id": "prod_AIhgWPx5D86mh1",
-    "images": [
-
-    ],
-    "livemode": false,
-    "metadata": {
-    },
-    "name": "T-shirt",
-    "object": "product",
-    "package_dimensions": {
-    },
-    "reason_product_not_tweetable": "",
-    "shippable": true,
-    "skus": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/skus?product=prod_AIhgWPx5D86mh1\u0026active=true"
-    },
-    "tweetable_url": "",
-    "updated": 1234567890,
-    "url": ""
-  },
-  "refund": {
-    "amount": 100,
-    "balance_transaction": "",
-    "charge": "ch_19y6HHAylotNGqt3dguVG1mI",
-    "created": 1234567890,
-    "currency": "usd",
-    "description": "",
-    "fee_balance_transactions": {
-    },
-    "id": "re_19y6HHAylotNGqt3o9CUC2fJ",
-    "metadata": {
-    },
-    "object": "refund",
-    "reason": "",
-    "receipt_number": "",
-    "status": "succeeded",
-    "type": ""
-  },
-  "sku": {
-    "active": true,
-    "attributes": {
-      "gender": "Unisex",
-      "size": "Medium"
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "sku_AIhgANg1XshOPI",
-    "image": "",
-    "inventory": {
-      "quantity": 50,
-      "type": "finite",
-      "value": null
-    },
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "sku",
-    "package_dimensions": {
-    },
-    "price": 1500,
-    "product": "prod_AIhgWPx5D86mh1",
-    "updated": 1234567890
-  },
-  "source": {
-    "amount": 1000,
-    "client_secret": "src_client_secret_UxYHcfjreLYKMVWptfFyAsxp",
-    "code_verification": {
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "customer": "",
-    "flow": "receiver",
-    "id": "src_19y6HJAylotNGqt3wfuVnNWw",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "source",
-    "order": "",
-    "owner": {
-      "address": null,
-      "email": "jenny.rosen@example.com",
-      "name": null,
-      "phone": null,
-      "verified_address": null,
-      "verified_email": null,
-      "verified_name": null,
-      "verified_phone": null
-    },
-    "receiver": {
-      "address": "test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N",
-      "amount_charged": 0,
-      "amount_received": 0,
-      "amount_returned": 0,
-      "refund_attributes_method": "email",
-      "refund_attributes_status": "missing"
-    },
-    "redirect": {
-    },
-    "status": "pending",
-    "type": "bitcoin",
-    "usage": "single_use"
-  },
-  "subscription": {
-    "account_balance": 0,
-    "application_fee_percent": 0.0,
-    "billing": "",
-    "cancel_at_period_end": false,
-    "canceled_at": 1234567890,
-    "created": 1234567890,
-    "current_period_end": 1234567890,
-    "current_period_start": 1234567890,
-    "customer": "cus_AIhg2AZ0oZn9hq",
-    "days_until_due": 0,
-    "discount": {
-    },
-    "ended_at": 1234567890,
-    "id": "sub_AIhgP3KgCUJMuh",
-    "items": {
-      "data": [
-        {
-          "created": 1489700220,
-          "id": "si_19y6HHBBq8Um5VVVeabmVesw",
-          "object": "subscription_item",
-          "plan": {
-            "amount": 2000,
-            "created": 1489700219,
-            "currency": "usd",
-            "id": "gold",
-            "interval": "month",
-            "interval_count": 1,
-            "livemode": false,
-            "metadata": {
-            },
-            "name": "Gold Special",
-            "object": "plan",
-            "statement_descriptor": null,
-            "trial_period_days": null
-          },
-          "quantity": 1
-        }
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 1,
-      "url": "/v1/subscription_items?subscription=sub_AIhgP3KgCUJMuh"
-    },
-    "livemode": false,
-    "max_occurrences": 0,
-    "metadata": {
-    },
-    "object": "subscription",
-    "on_behalf_of": "",
-    "plan": {
-      "amount": 2000,
-      "created": 1489700219,
-      "currency": "usd",
-      "id": "gold",
-      "interval": "month",
-      "interval_count": 1,
-      "livemode": false,
-      "metadata": {
-      },
-      "name": "Gold Special",
-      "object": "plan",
-      "statement_descriptor": null,
-      "trial_period_days": null
-    },
-    "quantity": 1,
-    "retains_own_balance": false,
-    "start": 1234567890,
-    "status": "active",
-    "tax_percent": 0.0,
-    "trial_end": 1234567890,
-    "trial_start": 1234567890
-  },
-  "subscription_item": {
-    "created": 1489700220,
-    "id": "si_19y6HHBBq8Um5VVVWtAse22Z",
-    "object": "subscription_item",
-    "plan": {
-      "amount": 2000,
-      "created": 1489700219,
-      "currency": "usd",
-      "id": "gold",
-      "interval": "month",
-      "interval_count": 1,
-      "livemode": false,
-      "metadata": {
-      },
-      "name": "Gold Special",
-      "object": "plan",
-      "statement_descriptor": null,
-      "trial_period_days": null
-    },
-    "quantity": 1
-  },
-  "three_d_secure": {
-    "amount": 1500,
-    "authenticated": false,
-    "card": {
-      "address_city": null,
-      "address_country": null,
-      "address_line1": null,
-      "address_line1_check": null,
-      "address_line2": null,
-      "address_state": null,
-      "address_zip": null,
-      "address_zip_check": null,
-      "brand": "Visa",
-      "country": null,
-      "customer": null,
-      "cvc_check": null,
-      "dynamic_last4": null,
-      "exp_month": 8,
-      "exp_year": 2018,
-      "funding": "unknown",
-      "id": "card_19y6HIAylotNGqt3tSobdlid",
-      "last4": "4242",
-      "metadata": {
-      },
-      "name": null,
-      "object": "card",
-      "tokenization_method": null
-    },
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "tdsrc_AIhge8Euw6YKbc",
-    "livemode": false,
-    "object": "three_d_secure",
-    "redirect_url": "http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AIhge8Euw6YKbc",
-    "status": "redirect_pending"
-  },
-  "token": {
-    "account_details": {
-    },
-    "alipay_account": {
-    },
-    "bank_account": {
-    },
-    "card": {
-      "address_city": null,
-      "address_country": null,
-      "address_line1": null,
-      "address_line1_check": null,
-      "address_line2": null,
-      "address_state": null,
-      "address_zip": null,
-      "address_zip_check": null,
-      "brand": "Visa",
-      "country": null,
-      "cvc_check": null,
-      "dynamic_last4": null,
-      "exp_month": 8,
-      "exp_year": 2018,
-      "funding": "unknown",
-      "id": "card_19y6HIAylotNGqt3tSobdlid",
-      "last4": "4242",
-      "metadata": {
-      },
-      "name": null,
-      "object": "card",
-      "tokenization_method": null
-    },
-    "client_ip": "",
-    "created": 1234567890,
-    "description": "",
-    "email": "",
-    "id": "tok_19y6HIAylotNGqt3RgAWCZVp",
-    "livemode": false,
-    "object": "token",
-    "type": "card",
-    "usage": "",
-    "used": false
-  },
-  "transfer": {
-    "amount": 1100,
-    "amount_reversed": 0,
-    "balance_transaction": "txn_19y6HHAylotNGqt33AMqhSaS",
-    "created": 1234567890,
-    "currency": "usd",
-    "destination": "ba_19y6HIAylotNGqt3Tk6btLgn",
-    "destination_payment": "",
-    "id": "tr_19y6HIAylotNGqt3ph4EjS38",
-    "livemode": false,
-    "metadata": {
-    },
-    "object": "transfer",
-    "reversals": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
-    },
-    "reversed": false,
-    "transfer_group": ""
-  },
-  "transfer_recipient": {
-    "active_account": {
-    },
-    "address_city": "",
-    "address_country": "",
-    "address_line1": "",
-    "address_line2": "",
-    "address_state": "",
-    "address_zip": "",
-    "cards": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/recipients/rp_19y6HIAylotNGqt3CTykthsz/cards"
-    },
-    "country": "",
-    "created": 1234567890,
-    "default_card": "",
-    "description": "Recipient for John Doe",
-    "dob_day": "",
-    "dob_month": "",
-    "dob_year": "",
-    "email": "test@example.com",
-    "id": "rp_19y6HIAylotNGqt3CTykthsz",
-    "livemode": false,
-    "metadata": {
-    },
-    "migrated_to": "",
-    "name": "John Doe",
-    "object": "recipient",
-    "tin": "",
-    "tin_verification_pending": false,
-    "type": "individual",
-    "verified": false
-  },
-  "transfer_reversal": {
-    "amount": 1100,
-    "balance_transaction": "",
-    "created": 1234567890,
-    "currency": "usd",
-    "id": "trr_19y6HIAylotNGqt3nITPrdUW",
-    "metadata": {
-    },
-    "object": "transfer_reversal",
-    "transfer": "tr_19y6HIAylotNGqt3ph4EjS38"
-  },
-  "upcoming_invoice": {
-    "amount_due": 0,
-    "application_fee": 0,
-    "attempt_count": 0,
-    "attempted": false,
-    "billing": "",
-    "charge": "",
-    "closed": false,
-    "currency": "usd",
-    "customer": "cus_AIhgCDhEsqLqXq",
-    "date": 1234567890,
-    "description": "",
-    "discount": {
-    },
-    "due_date": 1234567890,
-    "ending_balance": 0,
-    "forgiven": false,
-    "lines": {
-      "data": [
-
-      ],
-      "has_more": false,
-      "object": "list",
-      "total_count": 0,
-      "url": "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
-    },
-    "livemode": false,
-    "metadata": {
-    },
-    "next_payment_attempt": 1234567890,
-    "number": "",
-    "object": "invoice",
-    "paid": false,
-    "period_end": 1234567890,
-    "period_start": 1234567890,
-    "receipt_number": "",
-    "starting_balance": 0,
-    "statement_descriptor": "",
-    "subscription": "",
-    "subscription_proration_date": 0,
-    "subtotal": 0,
-    "tax": 0,
-    "tax_percent": 0.0,
-    "total": 0,
-    "webhooks_delivered_at": 1234567890
   }
 }

--- a/openapi/fixtures.yaml
+++ b/openapi/fixtures.yaml
@@ -1,515 +1,977 @@
 ---
-account:
-  active_payment_methods: []
-  bank_accounts: {}
-  business_logo: ''
-  business_name: ''
-  business_primary_color: ''
-  business_url: ''
-  charges_enabled: false
-  country: US
-  debit_negative_balances: true
-  decline_charge_on:
-    avs_failure: false
-    cvc_failure: false
-  default_currency: usd
-  details_submitted: false
-  display_name: ''
-  email: foo+os4pphkove@example.com
-  external_accounts:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/accounts/acct_19y6HAAylotNGqt3/external_accounts"
-  fake_account: false
-  id: acct_19y6HAAylotNGqt3
-  legal_entity:
-    additional_owners: 
-    address:
-      city: 
-      country: US
-      line1: 
-      line2: 
-      postal_code: 
-      state: 
-    business_name: 
-    business_name_kana: 
-    business_name_kanji: 
-    business_tax_id_provided: false
-    business_vat_id_provided: false
-    dob:
-      day: 
-      month: 
-      year: 
-    first_name: 
-    first_name_kana: 
-    first_name_kanji: 
-    gender: 
-    last_name: 
-    last_name_kana: 
-    last_name_kanji: 
-    maiden_name: 
-    personal_address:
-      city: 
-      country: US
-      line1: 
-      line2: 
-      postal_code: 
-      state: 
-    personal_id_number_provided: false
-    phone_number: 
-    ssn_last_4_provided: false
-    type: 
+resources:
+  account:
+    active_payment_methods: []
+    bank_accounts: {}
+    business_logo: ''
+    business_name: ''
+    business_primary_color: ''
+    business_url: ''
+    charges_enabled: false
+    country: US
+    debit_negative_balances: true
+    decline_charge_on:
+      avs_failure: true
+      cvc_failure: true
+    default_currency: usd
+    details_submitted: false
+    display_name: ''
+    email: site@stripe.com
+    external_accounts:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/accounts/acct_19tLK7DSlTMT26Mk/external_accounts"
+    fake_account: false
+    id: acct_19tLK7DSlTMT26Mk
+    legal_entity:
+      address:
+        city: 
+        country: US
+        line1: 
+        line2: 
+        postal_code: 
+        state: 
+      business_name: 
+      business_tax_id_provided: false
+      dob:
+        day: 
+        month: 
+        year: 
+      first_name: 
+      last_name: 
+      personal_address:
+        city: 
+        country: US
+        line1: 
+        line2: 
+        postal_code: 
+        state: 
+      ssn_last_4_provided: false
+      type: 
+      verification:
+        details: 
+        details_code: 
+        document: 
+        status: unverified
+    light: false
+    managed: true
+    mcc: ''
+    metadata: {}
+    object: account
+    orders: {}
+    product_description: ''
+    risk_details: {}
+    statement_descriptor: ''
+    support_address: {}
+    support_email: ''
+    support_phone: ''
+    support_url: ''
+    timezone: Etc/UTC
+    tos_acceptance:
+      date: 
+      ip: 
+      user_agent: 
+    transfer_schedule:
+      delay_days: 2
+      interval: daily
+    transfer_statement_descriptor: ''
+    transfers_enabled: false
     verification:
-      details: 
-      details_code: 
-      document: 
-      status: unverified
-  light: false
-  managed: true
-  mcc: ''
-  metadata: {}
-  object: account
-  orders: {}
-  product_description: ''
-  risk_details: {}
-  statement_descriptor: ''
-  support_address: {}
-  support_email: ''
-  support_phone: ''
-  support_url: ''
-  timezone: Etc/UTC
-  tos_acceptance:
-    date: 
-    ip: 
-    user_agent: 
-  transfer_schedule:
-    delay_days: 7
-    interval: daily
-  transfer_statement_descriptor: ''
-  transfers_enabled: false
-  verification:
-    disabled_reason: fields_needed
-    due_by: 
-    fields_needed:
-    - business_url
-    - external_account
-    - product_description
-    - support_phone
-    - tos_acceptance.date
-    - tos_acceptance.ip
-account_with_keys:
-  active_payment_methods: []
-  bank_accounts: {}
-  business_logo: ''
-  business_name: ''
-  business_primary_color: ''
-  business_url: ''
-  charges_enabled: false
-  country: US
-  debit_negative_balances: false
-  decline_charge_on: {}
-  default_currency: usd
-  details_submitted: false
-  display_name: ''
-  email: foo+os4pphkove@example.com
-  external_accounts: {}
-  fake_account: false
-  id: acct_19y6HAAylotNGqt3
-  keys: {}
-  legal_entity: {}
-  light: false
-  managed: false
-  mcc: ''
-  metadata: {}
-  object: account
-  orders: {}
-  product_description: ''
-  risk_details: {}
-  statement_descriptor: ''
-  support_address: {}
-  support_email: ''
-  support_phone: ''
-  support_url: ''
-  timezone: Etc/UTC
-  tos_acceptance: {}
-  transfer_schedule: {}
-  transfer_statement_descriptor: ''
-  transfers_enabled: false
-  verification: {}
-alipay_account:
-  created: 1234567890
-  customer: ''
-  fingerprint: eiRpjVAne6V7vzjH
-  id: aliacc_19y6HIAylotNGqt3CWxIarua
-  livemode: false
-  metadata: {}
-  object: alipay_account
-  payment_amount: 1000
-  payment_currency: usd
-  reusable: false
-  used: false
-  username: test@example.com
-apple_pay_domain:
-  created: 1234567890
-  domain_name: example.com
-  id: apwc_19y6HHAylotNGqt3514QiFTd
-  livemode: true
-  object: apple_pay_domain
-balance:
-  available:
-  - amount: 0
+      disabled_reason: fields_needed
+      due_by: 
+      fields_needed:
+      - business_url
+      - external_account
+      - product_description
+      - support_phone
+      - tos_acceptance.date
+      - tos_acceptance.ip
+  account_with_keys:
+    active_payment_methods: []
+    bank_accounts: {}
+    business_logo: ''
+    business_name: ''
+    business_primary_color: ''
+    business_url: ''
+    charges_enabled: false
+    country: US
+    debit_negative_balances: false
+    decline_charge_on: {}
+    default_currency: usd
+    details_submitted: false
+    display_name: ''
+    email: site@stripe.com
+    external_accounts: {}
+    fake_account: false
+    id: acct_19tLK7DSlTMT26Mk
+    keys: {}
+    legal_entity: {}
+    light: false
+    managed: false
+    mcc: ''
+    metadata: {}
+    object: account
+    orders: {}
+    product_description: ''
+    risk_details: {}
+    statement_descriptor: ''
+    support_address: {}
+    support_email: ''
+    support_phone: ''
+    support_url: ''
+    timezone: Etc/UTC
+    tos_acceptance: {}
+    transfer_schedule: {}
+    transfer_statement_descriptor: ''
+    transfers_enabled: false
+    verification: {}
+  alipay_account:
+    created: 1234567890
+    customer: ''
+    fingerprint: NYUNwalrZGyUB5WV
+    id: aliacc_19zuujDSlTMT26MkefiECdjT
+    livemode: false
+    metadata: {}
+    object: alipay_account
+    payment_amount: 1000
+    payment_currency: usd
+    reusable: false
+    used: false
+    username: test@example.com
+  apple_pay_domain:
+    created: 1234567890
+    domain_name: example.com
+    id: apwc_19zuugDSlTMT26MkaEqesPjq
+    livemode: true
+    object: apple_pay_domain
+  balance:
+    available:
+    - amount: 0
+      currency: usd
+      source_types:
+        card: 0
+    connect_reserved: []
+    livemode: false
+    object: balance
+    pending:
+    - amount: 0
+      currency: usd
+      source_types:
+        card: 0
+  balance_transaction:
+    amount: 100
+    automatic_transfer: {}
+    available_on: 1234567890
+    created: 1234567890
     currency: usd
-    source_types:
-      card: 0
-  connect_reserved: []
-  livemode: false
-  object: balance
-  pending:
-  - amount: 0
+    description: ''
+    fee: 0
+    fee_details: []
+    id: txn_19zuuhDSlTMT26Mk2gJnG0ti
+    net: 100
+    object: balance_transaction
+    source: ch_19zuuhDSlTMT26MkKLSiekJ9
+    sourced_transfers: {}
+    status: pending
+    type: charge
+  bank_account:
+    account: acct_19tLK7DSlTMT26Mk
+    account_holder_name: Jane Austen
+    account_holder_type: individual
+    address_city: ''
+    address_line1: ''
+    address_line2: ''
+    address_state: ''
+    address_zip: ''
+    allows_debits: false
+    bank_name: STRIPE TEST BANK
+    bank_phone_number: ''
+    country: US
     currency: usd
-    source_types:
-      card: 0
-balance_transaction:
-  amount: 100
-  automatic_transfer: {}
-  available_on: 1234567890
-  created: 1234567890
-  currency: usd
-  description: ''
-  fee: 0
-  fee_details: []
-  id: txn_19y6HHAylotNGqt33AMqhSaS
-  net: 100
-  object: balance_transaction
-  source: ch_19y6HHAylotNGqt3dguVG1mI
-  sourced_transfers: {}
-  status: pending
-  type: charge
-bank_account:
-  account: acct_19y6HAAylotNGqt3
-  account_holder_name: Jane Austen
-  account_holder_type: individual
-  address_city: ''
-  address_line1: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  allows_debits: false
-  bank_name: STRIPE TEST BANK
-  bank_phone_number: ''
-  country: US
-  currency: usd
-  customer: ''
-  customer_reference: ''
-  default_for_currency: false
-  fingerprint: G8AlCiZpIixKrovm
-  id: ba_19y6HIAylotNGqt37Bbh2BEi
-  last4: '6789'
-  metadata: {}
-  object: bank_account
-  reusable: false
-  routing_number: '110000000'
-  status: new
-  used: false
-bitcoin_receiver:
-  active: false
-  amount: 100
-  amount_received: 0
-  bitcoin_amount: 1757908
-  bitcoin_amount_received: 0
-  bitcoin_uri: bitcoin:test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1?amount=0.01757908
-  created: 1234567890
-  currency: usd
-  customer: ''
-  description: Receiver for John Doe
-  email: test@example.com
-  filled: false
-  id: btcrcv_19y6HIAylotNGqt3PPrzs2zr
-  inbound_address: test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1
-  livemode: false
-  metadata: {}
-  object: bitcoin_receiver
-  payment: ''
-  refund_address: ''
-  transactions: {}
-  uncaptured_funds: false
-  used_for_payment: false
-bitcoin_transaction:
-  amount: 100
-  bitcoin_amount: 1757908
-  created: 1234567890
-  currency: usd
-  id: btctxn_19y6HIAylotNGqt3ufx7IrFQ
-  object: bitcoin_transaction
-  receiver: btcrcv_19y6HIBBq8Um5VVVjcO0R7nU
-card:
-  3d_secure: {}
-  account: ''
-  address_city: ''
-  address_country: ''
-  address_line1: ''
-  address_line1_check: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  address_zip_check: ''
-  available_payout_methods: []
-  brand: Visa
-  country: ''
-  currency: ''
-  customer: ''
-  cvc_check: ''
-  default_for_currency: false
-  description: ''
-  dynamic_last4: ''
-  emv_auth_data: ''
-  estimated_availability: ''
-  exp_month: 8
-  exp_year: 2018
-  fingerprint: ''
-  funding: unknown
-  google_reference: ''
-  id: card_19y6HHAylotNGqt3SvYv7I1c
-  iin: ''
-  issuer: ''
-  last4: '4242'
-  metadata: {}
-  name: ''
-  object: card
-  recipient: ''
-  three_d_secure: {}
-  tokenization_method: ''
-charge:
-  alternate_statement_descriptors: {}
-  amount: 100
-  amount_authorized: 0
-  amount_captured: 0
-  amount_refunded: 0
-  application: ''
-  application_fee: ''
-  application_fees_refunded: 0
-  authorization_code: ''
-  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
-  captured: true
-  card: {}
-  created: 1234567890
-  currency: usd
-  customer: ''
-  description: My First Test Charge (created for API docs)
-  destination: ''
-  dispute: ''
-  failure_code: ''
-  failure_message: ''
-  fee_balance_transactions: {}
-  fraud_details: {}
-  id: ch_19y6HHAylotNGqt3dguVG1mI
-  invoice: ''
-  level3: {}
-  livemode: false
-  metadata: {}
-  object: charge
-  on_behalf_of: ''
-  order: ''
-  outcome: {}
-  paid: true
-  receipt_email: ''
-  receipt_number: ''
-  refunded: false
-  refunds:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/charges/ch_19y6HHAylotNGqt3dguVG1mI/refunds"
-  review: ''
-  shipping: {}
-  source:
-    address_city: 
-    address_country: 
-    address_line1: 
-    address_line1_check: 
-    address_line2: 
-    address_state: 
-    address_zip: 
-    address_zip_check: 
+    customer: ''
+    customer_reference: ''
+    default_for_currency: false
+    fingerprint: ryfzKJTPWAUfw2iL
+    id: ba_19zuuiDSlTMT26Mk8HQCpGLE
+    last4: '6789'
+    metadata: {}
+    object: bank_account
+    reusable: false
+    routing_number: '110000000'
+    status: new
+    used: false
+  bitcoin_receiver:
+    active: false
+    amount: 100
+    amount_received: 0
+    bitcoin_amount: 1757908
+    bitcoin_amount_received: 0
+    bitcoin_uri: bitcoin:test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1?amount=0.01757908
+    created: 1234567890
+    currency: usd
+    customer: ''
+    description: Receiver for John Doe
+    email: test@example.com
+    filled: false
+    id: btcrcv_19zYqFDSlTMT26Mk31J1pMex
+    inbound_address: test_7i9Fo4b5wXcUAuoVBFrc7nc9HDxD1
+    livemode: false
+    metadata: {}
+    object: bitcoin_receiver
+    payment: ''
+    refund_address: ''
+    transactions: {}
+    uncaptured_funds: false
+    used_for_payment: false
+  bitcoin_transaction:
+    amount: 100
+    bitcoin_amount: 1757908
+    created: 1234567890
+    currency: usd
+    id: btctxn_19zuujDSlTMT26MkHOZALNf7
+    object: bitcoin_transaction
+    receiver: btcrcv_19zYqFDSlTMT26Mk31J1pMex
+  card:
+    3d_secure: {}
+    account: ''
+    address_city: ''
+    address_country: ''
+    address_line1: ''
+    address_line1_check: ''
+    address_line2: ''
+    address_state: ''
+    address_zip: ''
+    address_zip_check: ''
+    available_payout_methods: []
     brand: Visa
-    country: 
-    customer: 
-    cvc_check: 
-    dynamic_last4: 
+    country: ''
+    currency: ''
+    customer: ''
+    cvc_check: ''
+    default_for_currency: false
+    description: ''
+    dynamic_last4: ''
+    emv_auth_data: ''
+    estimated_availability: ''
     exp_month: 8
     exp_year: 2018
+    fingerprint: ''
     funding: unknown
-    id: card_19y6HHAylotNGqt3SvYv7I1c
+    google_reference: ''
+    id: card_19tLKYDSlTMT26Mkl7bixGYc
+    iin: ''
+    issuer: ''
     last4: '4242'
     metadata: {}
-    name: 
+    name: ''
     object: card
-    tokenization_method: 
-  source_transfer: ''
-  statement_descriptor: ''
-  status: succeeded
-  transfer: ''
-  transfer_group: ''
-  trust: {}
-country_spec:
-  default_currency: usd
-  field_schemas: {}
-  id: US
-  object: country_spec
-  supported_bank_account_currencies:
-    usd:
-    - US
-  supported_payment_currencies:
-  - "..."
-  - aed
-  - afn
-  - usd
-  supported_payment_methods:
-  - alipay
-  - card
-  - stripe
-  verification_fields:
-    company:
-      additional: []
-      minimum: []
-    individual:
-      additional: []
-      minimum: []
-coupon:
-  amount_off: 0
-  created: 1234567890
-  currency: usd
-  duration: repeating
-  duration_in_months: 3
-  id: 25OFF
-  livemode: false
-  max_redemptions: 0
-  metadata: {}
-  object: coupon
-  percent_off: 25
-  redeem_by: 1234567890
-  times_redeemed: 0
-  valid: true
-customer:
-  account_balance: 0
-  alipay_accounts: {}
-  bank_accounts: {}
-  business_vat_id: ''
-  cards: {}
-  created: 1234567890
-  currency: usd
-  default_bank_account: ''
-  default_card: ''
-  default_source: ''
-  default_source_type: ''
-  delinquent: false
-  description: ''
-  discount: {}
-  email: ''
-  id: cus_AIhgCDhEsqLqXq
-  livemode: false
-  metadata: {}
-  object: customer
-  shipping: {}
-  sources:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/customers/cus_AIhgCDhEsqLqXq/sources"
-  subscription: {}
-  subscriptions: {}
-  trust: {}
-customer_source:
-  customer: ''
-  id: ba_19y6HIAylotNGqt37Bbh2BEi
-  metadata: {}
-  object: bank_account
-discount:
+    recipient: ''
+    three_d_secure: {}
+    tokenization_method: ''
+  charge:
+    alternate_statement_descriptors: {}
+    amount: 100
+    amount_authorized: 0
+    amount_captured: 0
+    amount_refunded: 0
+    application: ''
+    application_fee: ''
+    application_fees_refunded: 0
+    authorization_code: ''
+    balance_transaction: txn_19zuuhDSlTMT26Mk2gJnG0ti
+    captured: true
+    card: {}
+    created: 1234567890
+    currency: usd
+    customer: ''
+    description: My First Test Charge (created for API docs)
+    destination: ''
+    dispute: ''
+    failure_code: ''
+    failure_message: ''
+    fee_balance_transactions: {}
+    fraud_details: {}
+    id: ch_19zuuhDSlTMT26MkKLSiekJ9
+    invoice: ''
+    level3: {}
+    livemode: false
+    metadata: {}
+    object: charge
+    on_behalf_of: ''
+    order: ''
+    outcome: {}
+    paid: true
+    receipt_email: ''
+    receipt_number: ''
+    refunded: false
+    refunds:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/charges/ch_19zuuhDSlTMT26MkKLSiekJ9/refunds"
+    review: ''
+    shipping: {}
+    source:
+      address_city: 
+      address_country: 
+      address_line1: 
+      address_line1_check: 
+      address_line2: 
+      address_state: 
+      address_zip: 
+      address_zip_check: 
+      brand: Visa
+      country: 
+      customer: 
+      cvc_check: 
+      dynamic_last4: 
+      exp_month: 8
+      exp_year: 2018
+      funding: unknown
+      id: card_19tLKYDSlTMT26Mkl7bixGYc
+      last4: '4242'
+      metadata: {}
+      name: 
+      object: card
+      tokenization_method: 
+    source_transfer: ''
+    statement_descriptor: ''
+    status: succeeded
+    transfer: ''
+    transfer_group: ''
+    trust: {}
+  country_spec:
+    default_currency: usd
+    field_schemas: {}
+    id: US
+    object: country_spec
+    supported_bank_account_currencies:
+      usd:
+      - US
+    supported_payment_currencies:
+    - "..."
+    - aed
+    - afn
+    - usd
+    supported_payment_methods:
+    - alipay
+    - card
+    - stripe
+    verification_fields:
+      company:
+        additional:
+        - legal_entity.verification.document
+        minimum:
+        - external_account
+        - legal_entity.address.city
+        - legal_entity.address.line1
+        - legal_entity.address.postal_code
+        - legal_entity.address.state
+        - legal_entity.business_name
+        - legal_entity.business_tax_id
+        - legal_entity.dob.day
+        - legal_entity.dob.month
+        - legal_entity.dob.year
+        - legal_entity.first_name
+        - legal_entity.last_name
+        - legal_entity.ssn_last_4
+        - legal_entity.type
+        - tos_acceptance.date
+        - tos_acceptance.ip
+      individual:
+        additional:
+        - legal_entity.verification.document
+        minimum:
+        - external_account
+        - legal_entity.address.city
+        - legal_entity.address.line1
+        - legal_entity.address.postal_code
+        - legal_entity.address.state
+        - legal_entity.dob.day
+        - legal_entity.dob.month
+        - legal_entity.dob.year
+        - legal_entity.first_name
+        - legal_entity.last_name
+        - legal_entity.ssn_last_4
+        - legal_entity.type
+        - tos_acceptance.date
+        - tos_acceptance.ip
   coupon:
-    amount_off: 
-    created: 1489700220
+    amount_off: 0
+    created: 1234567890
     currency: usd
     duration: repeating
     duration_in_months: 3
     id: 25OFF
     livemode: false
-    max_redemptions: 
+    max_redemptions: 0
     metadata: {}
     object: coupon
     percent_off: 25
-    redeem_by: 
+    redeem_by: 1234567890
     times_redeemed: 0
     valid: true
-  customer: cus_AIhgCDhEsqLqXq
-  end: 1234567890
-  object: discount
-  start: 1234567890
-  subscription: ''
-dispute:
-  accepted_at: 1234567890
-  amount: 1000
-  balance_transaction: ''
-  balance_transactions: []
-  charge: ch_19y6HHAylotNGqt3dguVG1mI
-  closed_at: 1234567890
-  created: 1234567890
-  currency: usd
-  escalated_at: 1234567890
-  evidence:
-    access_activity_log: 
-    billing_address: 
-    cancellation_policy: 
-    cancellation_policy_disclosure: 
-    cancellation_rebuttal: 
-    customer_communication: 
-    customer_email_address: 
-    customer_name: 
-    customer_purchase_ip: 
-    customer_signature: 
-    duplicate_charge_documentation: 
-    duplicate_charge_explanation: 
-    duplicate_charge_id: 
-    product_description: 
-    receipt: 
-    refund_policy: 
-    refund_policy_disclosure: 
-    refund_refusal_explanation: 
-    service_date: 
-    service_documentation: 
-    shipping_address: 
-    shipping_carrier: 
-    shipping_date: 
-    shipping_documentation: 
-    shipping_tracking_number: 
-    uncategorized_file: 
-    uncategorized_text: 
-  evidence_details:
-    due_by: 1491350399
-    has_evidence: false
-    past_due: false
-    submission_count: 0
-  evidence_submitted_at: []
-  id: dp_19y6HHAylotNGqt3bvR7ZOnH
-  is_charge_refundable: false
-  is_protected: false
-  livemode: false
-  metadata: {}
-  network_reason_code: ''
-  object: dispute
-  reason: general
-  status: needs_response
-event:
-  api_version: ''
-  created: 1234567890
-  customer_email: ''
-  data:
-    object:
+  customer:
+    account_balance: 0
+    alipay_accounts: {}
+    bank_accounts: {}
+    business_vat_id: ''
+    cards: {}
+    created: 1234567890
+    currency: usd
+    default_bank_account: ''
+    default_card: ''
+    default_source: ''
+    default_source_type: ''
+    delinquent: false
+    description: ''
+    discount: {}
+    email: ''
+    id: cus_ADmuABetLS15eF
+    livemode: false
+    metadata: {}
+    object: customer
+    shipping: {}
+    sources:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/customers/cus_ADmuABetLS15eF/sources"
+    subscription: {}
+    subscriptions: {}
+    trust: {}
+  customer_source:
+    customer: ''
+    id: ba_19zuuiDSlTMT26Mk8HQCpGLE
+    metadata: {}
+    object: bank_account
+  discount:
+    coupon:
+      amount_off: 
+      created: 1490133192
+      currency: usd
+      duration: repeating
+      duration_in_months: 3
+      id: 25OFF
+      livemode: false
+      max_redemptions: 
+      metadata: {}
+      object: coupon
+      percent_off: 25
+      redeem_by: 
+      times_redeemed: 0
+      valid: true
+    customer: cus_ADmuABetLS15eF
+    end: 1234567890
+    object: discount
+    start: 1234567890
+    subscription: ''
+  dispute:
+    accepted_at: 1234567890
+    amount: 1000
+    balance_transaction: ''
+    balance_transactions: []
+    charge: ch_19zuuhDSlTMT26MkKLSiekJ9
+    closed_at: 1234567890
+    created: 1234567890
+    currency: usd
+    escalated_at: 1234567890
+    evidence:
+      access_activity_log: 
+      billing_address: 
+      cancellation_policy: 
+      cancellation_policy_disclosure: 
+      cancellation_rebuttal: 
+      customer_communication: 
+      customer_email_address: 
+      customer_name: 
+      customer_purchase_ip: 
+      customer_signature: 
+      duplicate_charge_documentation: 
+      duplicate_charge_explanation: 
+      duplicate_charge_id: 
+      product_description: 
+      receipt: 
+      refund_policy: 
+      refund_policy_disclosure: 
+      refund_refusal_explanation: 
+      service_date: 
+      service_documentation: 
+      shipping_address: 
+      shipping_carrier: 
+      shipping_date: 
+      shipping_documentation: 
+      shipping_tracking_number: 
+      uncategorized_file: 
+      uncategorized_text: 
+    evidence_details:
+      due_by: 1491782399
+      has_evidence: false
+      past_due: false
+      submission_count: 0
+    evidence_submitted_at: []
+    id: dp_19zuuhDSlTMT26Mkp7PHaa4O
+    is_charge_refundable: false
+    is_protected: false
+    livemode: false
+    metadata: {}
+    network_reason_code: ''
+    object: dispute
+    reason: general
+    status: needs_response
+  event:
+    api_version: '2017-02-14'
+    created: 1234567890
+    customer_email: ''
+    data:
+      object:
+        account_balance: 0
+        created: 1488566449
+        currency: usd
+        default_source: 
+        delinquent: false
+        description: 
+        discount: 
+        email: 
+        id: cus_ADmuABetLS15eF
+        livemode: false
+        metadata: {}
+        object: customer
+        shipping: 
+        sources:
+          data: []
+          has_more: false
+          object: list
+          total_count: 0
+          url: "/v1/customers/cus_ADmuABetLS15eF/sources"
+        subscriptions:
+          data: []
+          has_more: false
+          object: list
+          total_count: 0
+          url: "/v1/customers/cus_ADmuABetLS15eF/subscriptions"
+    id: evt_19tLKfDSlTMT26MkKD3pohqX
+    livemode: false
+    object: event
+    pending_webhooks: 0
+    recipient_best_description: ''
+    request: ''
+    type: customer.created
+  external_account_source:
+    account: acct_19tLK7DSlTMT26Mk
+    address_city: ''
+    address_line1: ''
+    address_line2: ''
+    address_state: ''
+    address_zip: ''
+    country: US
+    currency: usd
+    customer: ''
+    default_for_currency: false
+    fingerprint: ryfzKJTPWAUfw2iL
+    id: ba_19zuuiDSlTMT26Mk8HQCpGLE
+    last4: '6789'
+    metadata: {}
+    object: bank_account
+  fee_refund:
+    amount: 100
+    balance_transaction: ''
+    created: 1234567890
+    currency: usd
+    fee: fee_19zuujDSlTMT26MkEMvXUsIx
+    id: fr_AKa4dv904Dvl5q
+    metadata: {}
+    object: fee_refund
+  invoice:
+    amount_due: 0
+    application_fee: 0
+    attempt_count: 0
+    attempted: false
+    billing: ''
+    charge: ''
+    closed: false
+    currency: usd
+    customer: cus_ADmuABetLS15eF
+    date: 1234567890
+    description: ''
+    discount: {}
+    due_date: 1234567890
+    ending_balance: 0
+    forgiven: false
+    id: in_19zuuiDSlTMT26Mk1XitxqCb
+    lines:
+      data:
+      - amount: 2000
+        currency: usd
+        description: 
+        discountable: true
+        id: sub_AKa4uss8vCMAZC
+        livemode: true
+        metadata: {}
+        object: line_item
+        period:
+          end: 1495403592
+          start: 1492811592
+        plan:
+          amount: 2000
+          created: 1488566449
+          currency: usd
+          id: gold
+          interval: month
+          interval_count: 1
+          livemode: false
+          metadata: {}
+          name: Gold Special
+          object: plan
+          statement_descriptor: 
+          trial_period_days: 
+        proration: false
+        quantity: 1
+        subscription: 
+        subscription_item: si_19zuuiDSlTMT26Mk9HayBPe9
+        type: subscription
+      object: list
+      total_count: 1
+      url: "/v1/invoices/in_19zuuiDSlTMT26Mk1XitxqCb/lines"
+    livemode: false
+    metadata: {}
+    next_payment_attempt: 1234567890
+    number: ''
+    object: invoice
+    paid: false
+    period_end: 1234567890
+    period_start: 1234567890
+    receipt_number: ''
+    send_next_at: 1234567890
+    starting_balance: 0
+    statement_descriptor: ''
+    subscription: ''
+    subscription_proration_date: 0
+    subtotal: 0
+    tax: 0
+    tax_percent: 0.0
+    total: 0
+    webhooks_delivered_at: 1234567890
+  invoice_item:
+    amount: 1000
+    currency: usd
+    customer: cus_ADmuABetLS15eF
+    date: 1234567890
+    description: My First Invoice Item (created for API docs)
+    discountable: true
+    id: ii_19zuuiDSlTMT26MkvsaAgAi7
+    invoice: ''
+    livemode: false
+    metadata: {}
+    object: invoiceitem
+    period:
+      end: 1490133192
+      start: 1490133192
+    plan: {}
+    proration: false
+    quantity: 0
+    subscription: ''
+    subscription_item: ''
+  invoice_line_item:
+    amount: 1000
+    currency: usd
+    description: My First Invoice Item (created for API docs)
+    discountable: true
+    id: ii_19zuuiDSlTMT26MkvsaAgAi7
+    livemode: false
+    metadata: {}
+    object: line_item
+    period:
+      end: 1490133192
+      start: 1490133192
+    plan: {}
+    proration: false
+    quantity: 0
+    subscription: ''
+    subscription_item: ''
+    type: invoiceitem
+  legacy_transfer:
+    amount: 1100
+    amount_reversed: 0
+    application_fee: ''
+    auto: false
+    balance_transaction: ''
+    bank_account: {}
+    card: {}
+    created: 1234567890
+    currency: usd
+    date: 1234567890
+    delay_reason: ''
+    description: Transfer to test@example.com
+    destination: ba_19zuujDSlTMT26MkRkpqv9Ud
+    destination_payment: ''
+    failure_code: ''
+    failure_message: ''
+    id: tr_19zuujDSlTMT26Mk81npuLjT
+    legacy_date: 1234567890
+    livemode: false
+    metadata: {}
+    method: standard
+    object: transfer
+    recipient: ''
+    reversals:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/transfers/tr_19zuujDSlTMT26Mk81npuLjT/reversals"
+    reversed: false
+    source_transaction: ''
+    source_type: card
+    statement_descriptor: ''
+    status: in_transit
+    transfer_group: ''
+    type: bank_account
+    user_visible_date: 1234567890
+  order:
+    amount: 1500
+    amount_returned: 0
+    application: ''
+    application_fee: 0
+    charge: ''
+    created: 1234567890
+    currency: usd
+    customer: ''
+    email: ''
+    external_coupon_code: ''
+    external_sku_ids: []
+    id: or_19zuukDSlTMT26MktR8hwCzJ
+    items:
+    - amount: 1500
+      currency: usd
+      description: T-shirt
+      object: order_item
+      parent: sk_19tLKeDSlTMT26MkWafeCAS4
+      quantity: 
+      type: sku
+    livemode: false
+    metadata: {}
+    object: order
+    returns:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/order_returns?order=or_19zuukDSlTMT26MktR8hwCzJ"
+    selected_shipping_method: ''
+    shipping:
+      address:
+        city: Anytown
+        country: US
+        line1: 1234 Main street
+        line2: 
+        postal_code: '123456'
+        state: 
+      carrier: 
+      name: Jenny Rosen
+      phone: 
+      tracking_number: 
+    shipping_methods: {}
+    signature: ''
+    status: created
+    status_transitions: {}
+    updated: 1234567890
+    upstream_id: ''
+  order_return:
+    amount: 1500
+    created: 1234567890
+    currency: usd
+    id: orret_19zuukDSlTMT26Mkxjz1bcqv
+    items:
+    - amount: 1500
+      currency: usd
+      description: T-shirt
+      object: order_item
+      parent: sk_19zuukDSlTMT26MkepWkJtmm
+      quantity: 
+      type: sku
+    livemode: false
+    object: order_return
+    order: or_19zuukDSlTMT26MkL38GRWYx
+    refund: re_19zuukDSlTMT26MkKx6aokup
+  plan:
+    amount: 2000
+    created: 1234567890
+    currency: usd
+    id: gold
+    interval: month
+    interval_count: 1
+    livemode: false
+    metadata: {}
+    name: Gold Special
+    object: plan
+    statement_descriptor: ''
+    trial_period_days: 0
+  platform_earning:
+    account: acct_19tLK7DSlTMT26Mk
+    amount: 100
+    amount_refunded: 0
+    application: ca_AKa4xbTjCsfO9n8mgC6PyMNf6FCnXMyM
+    balance_transaction: txn_19zuuhDSlTMT26Mk2gJnG0ti
+    charge: ch_19zuuhDSlTMT26MkKLSiekJ9
+    created: 1234567890
+    currency: usd
+    id: fee_19zuujDSlTMT26MkEMvXUsIx
+    livemode: false
+    object: application_fee
+    originating_transaction: ''
+    refunded: false
+    refunds:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/application_fees/fee_19zuujDSlTMT26MkEMvXUsIx/refunds"
+  product:
+    active: true
+    attributes:
+    - gender
+    - size
+    caption: ''
+    created: 1234567890
+    deactivate_on: []
+    description: Comfortable gray cotton t-shirts
+    donation: false
+    id: prod_AKa4nDYkPszdDl
+    images: []
+    livemode: false
+    metadata: {}
+    name: T-shirt
+    object: product
+    package_dimensions: {}
+    reason_product_not_tweetable: ''
+    shippable: true
+    skus:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/skus?product=prod_AKa4nDYkPszdDl&active=true"
+    tweetable_url: ''
+    updated: 1234567890
+    url: ''
+  refund:
+    amount: 100
+    balance_transaction: ''
+    charge: ch_19zuuhDSlTMT26MkKLSiekJ9
+    created: 1234567890
+    currency: usd
+    description: ''
+    fee_balance_transactions: {}
+    id: re_19zuuhDSlTMT26MkpLosorvD
+    metadata: {}
+    object: refund
+    reason: ''
+    receipt_number: ''
+    status: succeeded
+    type: ''
+  sku:
+    active: true
+    attributes:
+      gender: Unisex
+      size: Medium
+    created: 1234567890
+    currency: usd
+    id: sku_AKa48dqsB87bsK
+    image: ''
+    inventory:
+      quantity: 50
+      type: finite
+      value: 
+    livemode: false
+    metadata: {}
+    object: sku
+    package_dimensions: {}
+    price: 1500
+    product: prod_AKa4nDYkPszdDl
+    updated: 1234567890
+  source:
+    amount: 1000
+    client_secret: src_client_secret_G7TlNFAGB2mThKeaF9jOBdWt
+    code_verification: {}
+    created: 1234567890
+    currency: usd
+    customer: ''
+    flow: receiver
+    id: src_19zuukDSlTMT26MkL5AZBjwf
+    livemode: false
+    metadata: {}
+    object: source
+    order: ''
+    owner:
+      address: 
+      email: jenny.rosen@example.com
+      name: 
+      phone: 
+      verified_address: 
+      verified_email: 
+      verified_name: 
+      verified_phone: 
+    receiver:
+      address: test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N
+      amount_charged: 0
+      amount_received: 0
+      amount_returned: 0
+      refund_attributes_method: email
+      refund_attributes_status: missing
+    redirect: {}
+    status: pending
+    type: bitcoin
+    usage: single_use
+  subscription:
+    account_balance: 0
+    application_fee_percent: 0.0
+    billing: ''
+    cancel_at_period_end: false
+    canceled_at: 1234567890
+    created: 1234567890
+    current_period_end: 1234567890
+    current_period_start: 1234567890
+    customer: cus_ADmuABetLS15eF
+    days_until_due: 0
+    discount: {}
+    ended_at: 1234567890
+    id: sub_AKa4uss8vCMAZC
+    items:
+      data:
+      - created: 1490133192
+        id: si_19zuuiDSlTMT26Mk9HayBPe9
+        object: subscription_item
+        plan:
+          amount: 2000
+          created: 1488566449
+          currency: usd
+          id: gold
+          interval: month
+          interval_count: 1
+          livemode: false
+          metadata: {}
+          name: Gold Special
+          object: plan
+          statement_descriptor: 
+          trial_period_days: 
+        quantity: 1
+      has_more: false
+      object: list
+      total_count: 1
+      url: "/v1/subscription_items?subscription=sub_AKa4uss8vCMAZC"
+    livemode: false
+    max_occurrences: 0
+    metadata: {}
+    object: subscription
+    on_behalf_of: ''
+    plan:
       amount: 2000
-      created: 1489700220
+      created: 1488566449
       currency: usd
       id: gold
       interval: month
@@ -520,625 +982,199 @@ event:
       object: plan
       statement_descriptor: 
       trial_period_days: 
-  id: evt_19y6HIAylotNGqt349zSXYCk
-  livemode: false
-  object: event
-  pending_webhooks: 0
-  recipient_best_description: ''
-  request: ''
-  type: plan.created
-external_account_source:
-  account: acct_19y6HAAylotNGqt3
-  address_city: ''
-  address_line1: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  country: US
-  currency: usd
-  customer: ''
-  default_for_currency: false
-  fingerprint: G8AlCiZpIixKrovm
-  id: ba_19y6HIAylotNGqt37Bbh2BEi
-  last4: '6789'
-  metadata: {}
-  object: bank_account
-fee_refund:
-  amount: 100
-  balance_transaction: ''
-  created: 1234567890
-  currency: usd
-  fee: fee_19y6HIAylotNGqt3iEVMbEmJ
-  id: fr_AIhghI4mXRpLEw
-  metadata: {}
-  object: fee_refund
-invoice:
-  amount_due: 0
-  application_fee: 0
-  attempt_count: 0
-  attempted: false
-  billing: ''
-  charge: ''
-  closed: false
-  currency: usd
-  customer: cus_AIhgCDhEsqLqXq
-  date: 1234567890
-  description: ''
-  discount: {}
-  due_date: 1234567890
-  ending_balance: 0
-  forgiven: false
-  id: in_19y6HIAylotNGqt3Kq1NUy5r
-  lines:
-    data:
-    - amount: 2000
+    quantity: 1
+    retains_own_balance: false
+    start: 1234567890
+    status: active
+    tax_percent: 0.0
+    trial_end: 1234567890
+    trial_start: 1234567890
+  subscription_item:
+    created: 1490133192
+    id: si_19zuuiDSlTMT26MkkbqEeSG7
+    object: subscription_item
+    plan:
+      amount: 2000
+      created: 1488566449
       currency: usd
-      description: 
-      discountable: true
-      id: sub_AIhgP3KgCUJMuh
-      livemode: true
+      id: gold
+      interval: month
+      interval_count: 1
+      livemode: false
       metadata: {}
-      object: line_item
-      period:
-        end: 1494970619
-        start: 1492378619
-      plan:
-        amount: 2000
-        created: 1489700220
-        currency: usd
-        id: gold
-        interval: month
-        interval_count: 1
-        livemode: false
-        metadata: {}
-        name: Gold Special
-        object: plan
-        statement_descriptor: 
-        trial_period_days: 
-      proration: false
-      quantity: 1
-      subscription: 
-      subscription_item: si_19y6HHBBq8Um5VVVeabmVesw
-      type: subscription
-    object: list
-    total_count: 1
-    url: "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
-  livemode: false
-  metadata: {}
-  next_payment_attempt: 1234567890
-  number: ''
-  object: invoice
-  paid: false
-  period_end: 1234567890
-  period_start: 1234567890
-  receipt_number: ''
-  starting_balance: 0
-  statement_descriptor: ''
-  subscription: ''
-  subscription_proration_date: 0
-  subtotal: 0
-  tax: 0
-  tax_percent: 0.0
-  total: 0
-  webhooks_delivered_at: 1234567890
-invoice_item:
-  amount: 1000
-  currency: usd
-  customer: cus_AIhgCDhEsqLqXq
-  date: 1234567890
-  description: My First Invoice Item (created for API docs)
-  discountable: true
-  id: ii_19y6HIAylotNGqt36BYYgGHq
-  invoice: ''
-  livemode: false
-  metadata: {}
-  object: invoiceitem
-  period:
-    end: 1489700220
-    start: 1489700220
-  plan: {}
-  proration: false
-  quantity: 0
-  subscription: ''
-  subscription_item: ''
-invoice_line_item:
-  amount: 1000
-  currency: usd
-  description: My First Invoice Item (created for API docs)
-  discountable: true
-  id: ii_19y6HIAylotNGqt36BYYgGHq
-  livemode: false
-  metadata: {}
-  object: line_item
-  period:
-    end: 1489700220
-    start: 1489700220
-  plan: {}
-  proration: false
-  quantity: 0
-  subscription: ''
-  subscription_item: ''
-  type: invoiceitem
-legacy_transfer:
-  amount: 1100
-  amount_reversed: 0
-  application_fee: ''
-  auto: false
-  balance_transaction: ''
-  bank_account: {}
-  card: {}
-  created: 1234567890
-  currency: usd
-  date: 1234567890
-  delay_reason: ''
-  description: Transfer to test@example.com
-  destination: ba_19y6HIAylotNGqt3Tk6btLgn
-  destination_payment: ''
-  failure_code: ''
-  failure_message: ''
-  id: tr_19y6HIAylotNGqt3ph4EjS38
-  legacy_date: 1234567890
-  livemode: false
-  metadata: {}
-  method: standard
-  object: transfer
-  recipient: ''
-  reversals:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
-  reversed: false
-  source_transaction: ''
-  source_type: card
-  statement_descriptor: ''
-  status: in_transit
-  transfer_group: ''
-  type: bank_account
-  user_visible_date: 1234567890
-order:
-  amount: 1500
-  amount_returned: 0
-  application: ''
-  application_fee: 0
-  charge: ''
-  created: 1234567890
-  currency: usd
-  customer: ''
-  email: ''
-  external_coupon_code: ''
-  external_sku_ids: []
-  id: or_19y6HJAylotNGqt3bov4Z4DC
-  items:
-  - amount: 1500
+      name: Gold Special
+      object: plan
+      statement_descriptor: 
+      trial_period_days: 
+    quantity: 1
+  three_d_secure:
+    amount: 1500
+    authenticated: false
+    card:
+      address_city: 
+      address_country: 
+      address_line1: 
+      address_line1_check: 
+      address_line2: 
+      address_state: 
+      address_zip: 
+      address_zip_check: 
+      brand: Visa
+      country: 
+      customer: 
+      cvc_check: 
+      dynamic_last4: 
+      exp_month: 8
+      exp_year: 2018
+      funding: unknown
+      id: card_19tLKYDSlTMT26Mkl7bixGYc
+      last4: '4242'
+      metadata: {}
+      name: 
+      object: card
+      tokenization_method: 
+    created: 1234567890
     currency: usd
-    description: T-shirt
-    object: order_item
-    parent: sk_19y6HJAylotNGqt3oddcLh9L
-    quantity: 
-    type: sku
-  livemode: false
-  metadata: {}
-  object: order
-  returns:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/order_returns?order=or_19y6HJAylotNGqt3bov4Z4DC"
-  selected_shipping_method: ''
-  shipping:
-    address:
-      city: Anytown
-      country: US
-      line1: 1234 Main street
-      line2: 
-      postal_code: '123456'
-      state: 
-    carrier: 
-    name: Jenny Rosen
-    phone: 
-    tracking_number: 
-  shipping_methods: {}
-  signature: ''
-  status: created
-  status_transitions: {}
-  updated: 1234567890
-  upstream_id: ''
-order_return:
-  amount: 1500
-  created: 1234567890
-  currency: usd
-  id: orret_19y6HJAylotNGqt3bd5YsAXz
-  items:
-  - amount: 1500
+    id: tdsrc_AKa4JYO98pZnbv
+    livemode: false
+    object: three_d_secure
+    redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AKa4JYO98pZnbv
+    status: redirect_pending
+  token:
+    account_details: {}
+    alipay_account: {}
+    bank_account: {}
+    card:
+      address_city: 
+      address_country: 
+      address_line1: 
+      address_line1_check: 
+      address_line2: 
+      address_state: 
+      address_zip: 
+      address_zip_check: 
+      brand: Visa
+      country: 
+      cvc_check: 
+      dynamic_last4: 
+      exp_month: 8
+      exp_year: 2018
+      funding: unknown
+      id: card_19tLKYDSlTMT26MkxAeJBsQn
+      last4: '4242'
+      metadata: {}
+      name: 
+      object: card
+      tokenization_method: 
+    client_ip: ''
+    created: 1234567890
+    description: ''
+    email: ''
+    id: tok_19tLKYDSlTMT26MkK7YyXpCy
+    livemode: false
+    object: token
+    type: card
+    usage: ''
+    used: false
+  transfer:
+    amount: 1100
+    amount_reversed: 0
+    balance_transaction: txn_19zuuhDSlTMT26Mk2gJnG0ti
+    created: 1234567890
     currency: usd
-    description: T-shirt
-    object: order_item
-    parent: sk_19y6HJAylotNGqt3oddcLh9L
-    quantity: 
-    type: sku
-  livemode: false
-  object: order_return
-  order: or_19y6HJAylotNGqt36m18HzRj
-  refund: re_19y6HJAylotNGqt3rTe2A05C
-plan:
-  amount: 2000
-  created: 1234567890
-  currency: usd
-  id: gold
-  interval: month
-  interval_count: 1
-  livemode: false
-  metadata: {}
-  name: Gold Special
-  object: plan
-  statement_descriptor: ''
-  trial_period_days: 0
-platform_earning:
-  account: acct_19y6HAAylotNGqt3
-  amount: 100
-  amount_refunded: 0
-  application: ca_AIhgFq8kWIDlYSeaCcuycCoERZL0J0ls
-  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
-  charge: ch_19y6HHAylotNGqt3dguVG1mI
-  created: 1234567890
-  currency: usd
-  id: fee_19y6HIAylotNGqt3iEVMbEmJ
-  livemode: false
-  object: application_fee
-  originating_transaction: ''
-  refunded: false
-  refunds:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/application_fees/fee_19y6HIAylotNGqt3iEVMbEmJ/refunds"
-product:
-  active: true
-  attributes:
-  - gender
-  - size
-  caption: ''
-  created: 1234567890
-  deactivate_on: []
-  description: Comfortable gray cotton t-shirts
-  donation: false
-  id: prod_AIhgWPx5D86mh1
-  images: []
-  livemode: false
-  metadata: {}
-  name: T-shirt
-  object: product
-  package_dimensions: {}
-  reason_product_not_tweetable: ''
-  shippable: true
-  skus:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/skus?product=prod_AIhgWPx5D86mh1&active=true"
-  tweetable_url: ''
-  updated: 1234567890
-  url: ''
-refund:
-  amount: 100
-  balance_transaction: ''
-  charge: ch_19y6HHAylotNGqt3dguVG1mI
-  created: 1234567890
-  currency: usd
-  description: ''
-  fee_balance_transactions: {}
-  id: re_19y6HHAylotNGqt3o9CUC2fJ
-  metadata: {}
-  object: refund
-  reason: ''
-  receipt_number: ''
-  status: succeeded
-  type: ''
-sku:
-  active: true
-  attributes:
-    gender: Unisex
-    size: Medium
-  created: 1234567890
-  currency: usd
-  id: sku_AIhgANg1XshOPI
-  image: ''
-  inventory:
-    quantity: 50
-    type: finite
-    value: 
-  livemode: false
-  metadata: {}
-  object: sku
-  package_dimensions: {}
-  price: 1500
-  product: prod_AIhgWPx5D86mh1
-  updated: 1234567890
-source:
-  amount: 1000
-  client_secret: src_client_secret_UxYHcfjreLYKMVWptfFyAsxp
-  code_verification: {}
-  created: 1234567890
-  currency: usd
-  customer: ''
-  flow: receiver
-  id: src_19y6HJAylotNGqt3wfuVnNWw
-  livemode: false
-  metadata: {}
-  object: source
-  order: ''
-  owner:
-    address: 
-    email: jenny.rosen@example.com
-    name: 
-    phone: 
-    verified_address: 
-    verified_email: 
-    verified_name: 
-    verified_phone: 
-  receiver:
-    address: test_1MBhWS3uv4ynCfQXF3xQjJkzFPukr4K56N
-    amount_charged: 0
-    amount_received: 0
-    amount_returned: 0
-    refund_attributes_method: email
-    refund_attributes_status: missing
-  redirect: {}
-  status: pending
-  type: bitcoin
-  usage: single_use
-subscription:
-  account_balance: 0
-  application_fee_percent: 0.0
-  billing: ''
-  cancel_at_period_end: false
-  canceled_at: 1234567890
-  created: 1234567890
-  current_period_end: 1234567890
-  current_period_start: 1234567890
-  customer: cus_AIhg2AZ0oZn9hq
-  days_until_due: 0
-  discount: {}
-  ended_at: 1234567890
-  id: sub_AIhgP3KgCUJMuh
-  items:
-    data:
-    - created: 1489700220
-      id: si_19y6HHBBq8Um5VVVeabmVesw
-      object: subscription_item
-      plan:
-        amount: 2000
-        created: 1489700219
-        currency: usd
-        id: gold
-        interval: month
-        interval_count: 1
-        livemode: false
-        metadata: {}
-        name: Gold Special
-        object: plan
-        statement_descriptor: 
-        trial_period_days: 
-      quantity: 1
-    has_more: false
-    object: list
-    total_count: 1
-    url: "/v1/subscription_items?subscription=sub_AIhgP3KgCUJMuh"
-  livemode: false
-  max_occurrences: 0
-  metadata: {}
-  object: subscription
-  on_behalf_of: ''
-  plan:
-    amount: 2000
-    created: 1489700219
-    currency: usd
-    id: gold
-    interval: month
-    interval_count: 1
+    destination: ba_19zuujDSlTMT26MkRkpqv9Ud
+    destination_payment: ''
+    id: tr_19zuujDSlTMT26Mk81npuLjT
     livemode: false
     metadata: {}
-    name: Gold Special
-    object: plan
-    statement_descriptor: 
-    trial_period_days: 
-  quantity: 1
-  retains_own_balance: false
-  start: 1234567890
-  status: active
-  tax_percent: 0.0
-  trial_end: 1234567890
-  trial_start: 1234567890
-subscription_item:
-  created: 1489700220
-  id: si_19y6HHBBq8Um5VVVWtAse22Z
-  object: subscription_item
-  plan:
-    amount: 2000
-    created: 1489700219
-    currency: usd
-    id: gold
-    interval: month
-    interval_count: 1
+    object: transfer
+    reversals:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/transfers/tr_19zuujDSlTMT26Mk81npuLjT/reversals"
+    reversed: false
+    transfer_group: ''
+  transfer_recipient:
+    active_account: {}
+    address_city: ''
+    address_country: ''
+    address_line1: ''
+    address_line2: ''
+    address_state: ''
+    address_zip: ''
+    cards:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/recipients/rp_19zuujDSlTMT26MkZ3ZnkXL2/cards"
+    country: ''
+    created: 1234567890
+    default_card: ''
+    description: Recipient for John Doe
+    dob_day: ''
+    dob_month: ''
+    dob_year: ''
+    email: test@example.com
+    id: rp_19zuujDSlTMT26MkZ3ZnkXL2
     livemode: false
     metadata: {}
-    name: Gold Special
-    object: plan
-    statement_descriptor: 
-    trial_period_days: 
-  quantity: 1
-three_d_secure:
-  amount: 1500
-  authenticated: false
-  card:
-    address_city: 
-    address_country: 
-    address_line1: 
-    address_line1_check: 
-    address_line2: 
-    address_state: 
-    address_zip: 
-    address_zip_check: 
-    brand: Visa
-    country: 
-    customer: 
-    cvc_check: 
-    dynamic_last4: 
-    exp_month: 8
-    exp_year: 2018
-    funding: unknown
-    id: card_19y6HIAylotNGqt3tSobdlid
-    last4: '4242'
+    migrated_to: ''
+    name: John Doe
+    object: recipient
+    tin: ''
+    tin_verification_pending: false
+    type: individual
+    verified: false
+  transfer_reversal:
+    amount: 1100
+    balance_transaction: ''
+    created: 1234567890
+    currency: usd
+    id: trr_19zuujDSlTMT26Mkg0q2NfQu
     metadata: {}
-    name: 
-    object: card
-    tokenization_method: 
-  created: 1234567890
-  currency: usd
-  id: tdsrc_AIhge8Euw6YKbc
-  livemode: false
-  object: three_d_secure
-  redirect_url: http://127.0.0.1:6080/3d_secure/authenticate/tdsrc_AIhge8Euw6YKbc
-  status: redirect_pending
-token:
-  account_details: {}
-  alipay_account: {}
-  bank_account: {}
-  card:
-    address_city: 
-    address_country: 
-    address_line1: 
-    address_line1_check: 
-    address_line2: 
-    address_state: 
-    address_zip: 
-    address_zip_check: 
-    brand: Visa
-    country: 
-    cvc_check: 
-    dynamic_last4: 
-    exp_month: 8
-    exp_year: 2018
-    funding: unknown
-    id: card_19y6HIAylotNGqt3tSobdlid
-    last4: '4242'
+    object: transfer_reversal
+    transfer: tr_19zuujDSlTMT26Mk81npuLjT
+  upcoming_invoice:
+    amount_due: 0
+    application_fee: 0
+    attempt_count: 0
+    attempted: false
+    billing: ''
+    charge: ''
+    closed: false
+    currency: usd
+    customer: cus_ADmuABetLS15eF
+    date: 1234567890
+    description: ''
+    discount: {}
+    due_date: 1234567890
+    ending_balance: 0
+    forgiven: false
+    lines:
+      data: []
+      has_more: false
+      object: list
+      total_count: 0
+      url: "/v1/invoices/in_19zuuiDSlTMT26Mk1XitxqCb/lines"
+    livemode: false
     metadata: {}
-    name: 
-    object: card
-    tokenization_method: 
-  client_ip: ''
-  created: 1234567890
-  description: ''
-  email: ''
-  id: tok_19y6HIAylotNGqt3RgAWCZVp
-  livemode: false
-  object: token
-  type: card
-  usage: ''
-  used: false
-transfer:
-  amount: 1100
-  amount_reversed: 0
-  balance_transaction: txn_19y6HHAylotNGqt33AMqhSaS
-  created: 1234567890
-  currency: usd
-  destination: ba_19y6HIAylotNGqt3Tk6btLgn
-  destination_payment: ''
-  id: tr_19y6HIAylotNGqt3ph4EjS38
-  livemode: false
-  metadata: {}
-  object: transfer
-  reversals:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/transfers/tr_19y6HIAylotNGqt3ph4EjS38/reversals"
-  reversed: false
-  transfer_group: ''
-transfer_recipient:
-  active_account: {}
-  address_city: ''
-  address_country: ''
-  address_line1: ''
-  address_line2: ''
-  address_state: ''
-  address_zip: ''
-  cards:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/recipients/rp_19y6HIAylotNGqt3CTykthsz/cards"
-  country: ''
-  created: 1234567890
-  default_card: ''
-  description: Recipient for John Doe
-  dob_day: ''
-  dob_month: ''
-  dob_year: ''
-  email: test@example.com
-  id: rp_19y6HIAylotNGqt3CTykthsz
-  livemode: false
-  metadata: {}
-  migrated_to: ''
-  name: John Doe
-  object: recipient
-  tin: ''
-  tin_verification_pending: false
-  type: individual
-  verified: false
-transfer_reversal:
-  amount: 1100
-  balance_transaction: ''
-  created: 1234567890
-  currency: usd
-  id: trr_19y6HIAylotNGqt3nITPrdUW
-  metadata: {}
-  object: transfer_reversal
-  transfer: tr_19y6HIAylotNGqt3ph4EjS38
-upcoming_invoice:
-  amount_due: 0
-  application_fee: 0
-  attempt_count: 0
-  attempted: false
-  billing: ''
-  charge: ''
-  closed: false
-  currency: usd
-  customer: cus_AIhgCDhEsqLqXq
-  date: 1234567890
-  description: ''
-  discount: {}
-  due_date: 1234567890
-  ending_balance: 0
-  forgiven: false
-  lines:
-    data: []
-    has_more: false
-    object: list
-    total_count: 0
-    url: "/v1/invoices/in_19y6HIAylotNGqt3Kq1NUy5r/lines"
-  livemode: false
-  metadata: {}
-  next_payment_attempt: 1234567890
-  number: ''
-  object: invoice
-  paid: false
-  period_end: 1234567890
-  period_start: 1234567890
-  receipt_number: ''
-  starting_balance: 0
-  statement_descriptor: ''
-  subscription: ''
-  subscription_proration_date: 0
-  subtotal: 0
-  tax: 0
-  tax_percent: 0.0
-  total: 0
-  webhooks_delivered_at: 1234567890
+    next_payment_attempt: 1234567890
+    number: ''
+    object: invoice
+    paid: false
+    period_end: 1234567890
+    period_start: 1234567890
+    receipt_number: ''
+    send_next_at: 1234567890
+    starting_balance: 0
+    statement_descriptor: ''
+    subscription: ''
+    subscription_proration_date: 0
+    subtotal: 0
+    tax: 0
+    tax_percent: 0.0
+    total: 0
+    webhooks_delivered_at: 1234567890

--- a/openapi/spec2.json
+++ b/openapi/spec2.json
@@ -87,7 +87,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -120,7 +120,7 @@
           ]
         },
         "id": {
-          "description": "A unique identifier for the account.",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -141,13 +141,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -180,7 +180,7 @@
           ]
         },
         "timezone": {
-          "description": "The timezone used in the Stripe dashboard for this account. A list of possible timezone values is maintained at the [IANA Timezone Database](http://www.iana.org/time-zones).",
+          "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
           "type": [
             "string"
           ]
@@ -397,7 +397,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -430,7 +430,7 @@
           ]
         },
         "id": {
-          "description": "A unique identifier for the account.",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -457,13 +457,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -496,7 +496,7 @@
           ]
         },
         "timezone": {
-          "description": "The timezone used in the Stripe dashboard for this account. A list of possible timezone values is maintained at the [IANA Timezone Database](http://www.iana.org/time-zones).",
+          "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
           "type": [
             "string"
           ]
@@ -596,7 +596,7 @@
     "alipay_account": {
       "properties": {
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -614,25 +614,25 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a customer object. It can be useful for storing additional information about the customer in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -688,7 +688,7 @@
     "apple_pay_domain": {
       "properties": {
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -700,19 +700,19 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -776,13 +776,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -821,19 +821,19 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -848,7 +848,7 @@
           "$ref": "#/definitions/fee"
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -860,7 +860,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -972,7 +972,7 @@
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) paid out to the bank account.",
           "type": [
             "string"
           ]
@@ -1002,7 +1002,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -1014,13 +1014,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a bank account object. It can be useful for storing additional information about the bank account in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1103,13 +1103,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency to which the bitcoin will be converted.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) to which the bitcoin will be converted.",
           "type": [
             "string"
           ]
@@ -1121,7 +1121,7 @@
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -1139,7 +1139,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -1151,19 +1151,19 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a customer object. It can be useful for storing additional information about the customer in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1175,7 +1175,7 @@
           ]
         },
         "refund_address": {
-          "description": "The refund address for these bitcoin, if communicated by the customer.",
+          "description": "",
           "type": [
             "string"
           ]
@@ -1197,7 +1197,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -1281,25 +1281,25 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "The currency to which this transaction was converted.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) to which this transaction was converted.",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1335,7 +1335,7 @@
           ]
         },
         "address_city": {
-          "description": "",
+          "description": "City/District/Suburb/Town/Village.",
           "type": [
             "string"
           ]
@@ -1347,7 +1347,7 @@
           ]
         },
         "address_line1": {
-          "description": "",
+          "description": "Address line 1 (Street address/PO Box/Company name).",
           "type": [
             "string"
           ]
@@ -1359,19 +1359,19 @@
           ]
         },
         "address_line2": {
-          "description": "",
+          "description": "Address line 2 (Apartment/Suite/Unit/Building).",
           "type": [
             "string"
           ]
         },
         "address_state": {
-          "description": "",
+          "description": "State/County/Province/Region.",
           "type": [
             "string"
           ]
         },
         "address_zip": {
-          "description": "",
+          "description": "Zip/Postal Code.",
           "type": [
             "string"
           ]
@@ -1401,7 +1401,7 @@
           ]
         },
         "currency": {
-          "description": "Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency.",
+          "description": "Three-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support). Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency.",
           "type": [
             "string"
           ]
@@ -1437,13 +1437,13 @@
           ]
         },
         "exp_month": {
-          "description": "",
+          "description": "Two digit number representing the card's expiration month.",
           "type": [
             "integer"
           ]
         },
         "exp_year": {
-          "description": "",
+          "description": "Four digit number representing the card's expiration year.",
           "type": [
             "integer"
           ]
@@ -1467,19 +1467,19 @@
           ]
         },
         "id": {
-          "description": "ID of card (used in conjunction with a customer or recipient ID).",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "last4": {
-          "description": "",
+          "description": "The last 4 digits of the card.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -1491,7 +1491,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1597,13 +1597,13 @@
           "$ref": "#/definitions/card"
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency in which the charge was made.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -1615,7 +1615,7 @@
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -1651,7 +1651,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -1663,19 +1663,19 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a charge object. It can be useful for storing additional information about the charge in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1736,7 +1736,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -1887,13 +1887,13 @@
           ]
         },
         "id": {
-          "description": "The ISO Country code for this country.",
+          "description": "Unique identifier for the object. Represented as the ISO country code for this country.",
           "type": [
             "string"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -1947,13 +1947,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "If `amount_off` has been set, the currency of the amount to take off.",
+          "description": "If `amount_off` has been set, the three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) of the amount to take off.",
           "type": [
             "string"
           ]
@@ -1971,13 +1971,13 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
@@ -1989,13 +1989,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a coupon object. It can be useful for storing additional information about the coupon in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2066,7 +2066,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -2115,7 +2115,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -2170,7 +2170,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -2203,13 +2203,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "The currency the customer can be charged in for recurring billing purposes.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) the customer can be charged in for recurring billing purposes.",
           "type": [
             "string"
           ]
@@ -2239,7 +2239,7 @@
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -2248,31 +2248,31 @@
           "$ref": "#/definitions/discount"
         },
         "email": {
-          "description": "",
+          "description": "The customer's email address.",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a customer object. It can be useful for storing additional information about the customer in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2299,7 +2299,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -2348,7 +2348,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -2435,19 +2435,19 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a bank account object. It can be useful for storing additional information about the bank account in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2517,7 +2517,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2564,13 +2564,13 @@
           ]
         },
         "created": {
-          "description": "Date dispute was opened.",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency of the amount that was disputed.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -2588,7 +2588,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -2600,19 +2600,19 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a dispute object. It can be useful for storing additional information about the dispute in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2716,7 +2716,7 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -2725,19 +2725,19 @@
           "$ref": "#/definitions/event_data"
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2779,7 +2779,7 @@
     "event_data": {
       "properties": {
         "object": {
-          "description": "describes the object the event is about. For example, an `invoice.created` event will have a full invoice object as the value of the object key.",
+          "description": "Static string describing the type of the object described by this change. For example, an `invoice.created` event will have a full invoice object as the value of the object key.",
           "type": [
             "object"
           ]
@@ -2845,7 +2845,7 @@
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) paid out to the bank account.",
           "type": [
             "string"
           ]
@@ -2869,7 +2869,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -2881,13 +2881,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a bank account object. It can be useful for storing additional information about the bank account in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -2909,7 +2909,7 @@
     "fee": {
       "properties": {
         "amount": {
-          "description": "",
+          "description": "Amount of the fee, in cents.",
           "type": [
             "integer"
           ]
@@ -2921,13 +2921,13 @@
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -2965,13 +2965,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO code representing the currency.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -2983,19 +2983,19 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to the object. It can be useful for storing additional information in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -3091,7 +3091,7 @@
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -3103,13 +3103,13 @@
           ]
         },
         "date": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -3136,7 +3136,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -3158,7 +3158,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -3191,13 +3191,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an invoice object. It can be useful for storing additional information about the invoice in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -3215,7 +3215,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -3328,19 +3328,19 @@
     "invoice_item": {
       "properties": {
         "amount": {
-          "description": "",
+          "description": "Amount (in the `currency` specified) of the invoice item.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "customer": {
-          "description": "",
+          "description": "The ID of the customer who will be billed when this invoice item is billed.",
           "type": [
             "string"
           ]
@@ -3352,7 +3352,7 @@
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -3364,31 +3364,31 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "invoice": {
-          "description": "",
+          "description": "The ID of the invoice this invoice item belongs to.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an invoice item object. It can be useful for storing additional information about the invoice item in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -3454,13 +3454,13 @@
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "A text description of the line item, if the line item is an invoice item.",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -3472,7 +3472,7 @@
           ]
         },
         "id": {
-          "description": "The ID of the source of this line item, either an invoice item or a subscription.",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -3484,13 +3484,13 @@
           ]
         },
         "metadata": {
-          "description": "Key-value pairs attached to object that underlies this line item (either subscription or invoice item).",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "The type of object. Always has the value \"line_item\".",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -3580,13 +3580,13 @@
           ]
         },
         "created": {
-          "description": "Time that this record of the transfer was first created.",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -3628,7 +3628,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -3640,13 +3640,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a transfer object. It can be useful for storing additional information about the transfer in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -3658,7 +3658,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -3680,7 +3680,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -4151,13 +4151,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency in which the order was made.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -4181,7 +4181,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -4190,19 +4190,19 @@
           "$ref": "#/definitions/order_item"
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an order object. It can be useful for storing additional information about the order in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4224,7 +4224,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -4316,7 +4316,7 @@
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency of the line item.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -4328,7 +4328,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4398,19 +4398,19 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency of the return.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -4419,13 +4419,13 @@
           "$ref": "#/definitions/order_item"
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4506,19 +4506,19 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Currency in which subscription will be charged.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -4536,13 +4536,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a plan object. It can be useful for storing additional information about the plan in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -4554,7 +4554,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4629,31 +4629,31 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO code representing the currency of the charge.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4687,7 +4687,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -4762,7 +4762,7 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -4780,7 +4780,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -4792,13 +4792,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a product object. It can be useful for storing additional information about the product in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -4810,7 +4810,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -4841,7 +4841,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -4926,37 +4926,37 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO code representing the currency.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to the object. It can be useful for storing additional information in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5086,7 +5086,7 @@
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency of the line item.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -5095,13 +5095,13 @@
           "$ref": "#/definitions/delivery_estimate"
         },
         "description": {
-          "description": "Description of the line item, meant to be displayable to the user (e.g., `\"Express shipping\"`).",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -5128,13 +5128,13 @@
           ]
         },
         "currency": {
-          "description": "Currency in which shipping cost will be assessed. Present when `type` is `flat_rate`.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) in which shipping cost will be assessed. Present when `type` is `flat_rate`.",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -5194,13 +5194,13 @@
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency of the line item.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "description": {
-          "description": "Description of the line item, meant to be displayable to the user (e.g., `\"Express shipping\"`).",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -5232,19 +5232,19 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) for currency.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -5259,19 +5259,19 @@
           "$ref": "#/definitions/inventory"
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a SKU object. It can be useful for storing additional information about the SKU in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5336,13 +5336,13 @@
           "$ref": "#/definitions/source_code_verification_flow"
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "The currency associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single-use` sources.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single-use` sources.",
           "type": [
             "string"
           ]
@@ -5354,25 +5354,25 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5633,7 +5633,7 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -5672,7 +5672,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -5694,7 +5694,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -5727,7 +5727,7 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
@@ -5739,13 +5739,13 @@
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5822,19 +5822,19 @@
     "subscription_item": {
       "properties": {
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5865,7 +5865,7 @@
     "tax_settings": {
       "properties": {
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -5922,31 +5922,31 @@
           "$ref": "#/definitions/card"
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -5996,25 +5996,25 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6115,7 +6115,7 @@
           ]
         },
         "currency": {
-          "description": "Three-letter ISO currency code representing the currency paid out to the bank account.",
+          "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) paid out to the bank account.",
           "type": [
             "string"
           ]
@@ -6127,7 +6127,7 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
@@ -6139,7 +6139,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6186,7 +6186,7 @@
     "token_card": {
       "properties": {
         "address_city": {
-          "description": "",
+          "description": "City/District/Suburb/Town/Village.",
           "type": [
             "string"
           ]
@@ -6198,7 +6198,7 @@
           ]
         },
         "address_line1": {
-          "description": "",
+          "description": "Address line 1 (Street address/PO Box/Company name).",
           "type": [
             "string"
           ]
@@ -6210,19 +6210,19 @@
           ]
         },
         "address_line2": {
-          "description": "",
+          "description": "Address line 2 (Apartment/Suite/Unit/Building).",
           "type": [
             "string"
           ]
         },
         "address_state": {
-          "description": "",
+          "description": "State/County/Province/Region.",
           "type": [
             "string"
           ]
         },
         "address_zip": {
-          "description": "",
+          "description": "Zip/Postal Code.",
           "type": [
             "string"
           ]
@@ -6246,7 +6246,7 @@
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -6264,13 +6264,13 @@
           ]
         },
         "exp_month": {
-          "description": "",
+          "description": "Two digit number representing the card's expiration month.",
           "type": [
             "integer"
           ]
         },
         "exp_year": {
-          "description": "",
+          "description": "Four digit number representing the card's expiration year.",
           "type": [
             "integer"
           ]
@@ -6294,19 +6294,19 @@
           ]
         },
         "id": {
-          "description": "ID of card (used in conjunction with a customer or recipient ID).",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "last4": {
-          "description": "",
+          "description": "The last 4 digits of the card.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -6318,7 +6318,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6373,13 +6373,13 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -6397,25 +6397,25 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6437,7 +6437,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -6473,6 +6473,12 @@
           "description": "",
           "type": [
             "boolean"
+          ]
+        },
+        "source_type": {
+          "description": "",
+          "type": [
+            "string"
           ]
         },
         "transfer_group": {
@@ -6522,7 +6528,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -6555,7 +6561,7 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
@@ -6567,7 +6573,7 @@
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -6579,19 +6585,19 @@
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to a recipient object. It can be useful for storing additional information about the recipient in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -6609,7 +6615,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6663,31 +6669,31 @@
           ]
         },
         "created": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "currency": {
-          "description": "Three-letter ISO code representing the currency.",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
         },
         "id": {
-          "description": "",
+          "description": "Unique identifier for the object.",
           "type": [
             "string"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to the object. It can be useful for storing additional information in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -6871,7 +6877,7 @@
           ]
         },
         "currency": {
-          "description": "",
+          "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
           "type": [
             "string"
           ]
@@ -6883,13 +6889,13 @@
           ]
         },
         "date": {
-          "description": "",
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
           "type": [
             "integer"
           ]
         },
         "description": {
-          "description": "",
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
           "type": [
             "string"
           ]
@@ -6932,7 +6938,7 @@
               ]
             },
             "object": {
-              "description": "The type of object. Always has the value \"list\".",
+              "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
               "enum": [
                 "list"
               ],
@@ -6965,13 +6971,13 @@
           ]
         },
         "livemode": {
-          "description": "",
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
           "type": [
             "boolean"
           ]
         },
         "metadata": {
-          "description": "A set of key/value pairs that you can attach to an invoice object. It can be useful for storing additional information about the invoice in a structured format.",
+          "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": [
             "object"
           ]
@@ -6989,7 +6995,7 @@
           ]
         },
         "object": {
-          "description": "",
+          "description": "String representing the object's type. Objects of the same type share the same value.",
           "type": [
             "string"
           ]
@@ -7139,7 +7145,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "Currency of the charge that you will create when authentication completes.",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -7186,7 +7192,7 @@
     },
     "/v1/3d_secure/{three_d_secure}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves a 3D Secure object.\u003C/p\u003E",
+        "description": "<p>Retrieves a 3D Secure object.</p>",
         "operationId": "Retrieve3DSecure",
         "parameters": [
           {
@@ -7215,7 +7221,7 @@
     },
     "/v1/account": {
       "delete": {
-        "description": "\u003Cp\u003EWith \u003Ca href=\"/docs/connect\"\u003EConnect\u003C/a\u003E, you may delete Stripe accounts you manage.\u003C/p\u003E\n\n\u003Cp\u003EManaged accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.\u003C/p\u003E\n\n\u003Cp\u003EIf you are looking to close your own account, use the \u003Ca href=\"http://dashboard:6090/account/data\"\u003Edata tab in your account settings\u003C/a\u003E instead.\u003C/p\u003E",
+        "description": "<p>With <a href=\"/docs/connect\">Connect</a>, you may delete Stripe accounts you manage.</p><p>Managed accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.</p><p>If you are looking to close your own account, use the <a href=\"https://dashboard.stripe.com/account/data\">data tab in your account settings</a> instead.</p>",
         "operationId": "AccountDelete",
         "parameters": [
           {
@@ -7252,7 +7258,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of the account.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of the account.</p>",
         "operationId": "AccountRetrieve",
         "parameters": [
           {
@@ -7279,7 +7285,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003E\u003Cstrong\u003EYou may only update accounts that you \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanage\u003C/a\u003E\u003C/strong\u003E. To update your own account, you can currently only do so via the \u003Ca href=\"http://dashboard:6090/account\"\u003Edashboard\u003C/a\u003E. For more information on updating Managed Accounts, see \u003Ca href=\"/docs/connect/updating-accounts\"\u003Eour guide\u003C/a\u003E.\u003C/p\u003E",
+        "description": "<p>Updates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p><strong>You may only update accounts that you <a href=\"/docs/connect/managed-accounts\">manage</a></strong>. To update your own account, you can currently only do so via the <a href=\"https://dashboard.stripe.com/account\">dashboard</a>. For more information on updating Managed Accounts, see <a href=\"/docs/connect/updating-accounts\">our guide</a>.</p>",
         "operationId": "AccountUpdate",
         "parameters": [
           {
@@ -7318,7 +7324,7 @@
                   ]
                 },
                 "debit_negative_balances": {
-                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances) for more information.",
+                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/account-balances) for more information.",
                   "title": "debit_negative_balances",
                   "type": [
                     "boolean"
@@ -7332,7 +7338,7 @@
                   ]
                 },
                 "default_currency": {
-                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).",
+                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "default_currency",
                   "type": [
                     "string"
@@ -7346,7 +7352,7 @@
                   ]
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. \u003Cbr\u003E\u003Cbr\u003EThis will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
                   "title": "external_account",
                   "type": [
                     "object",
@@ -7417,7 +7423,7 @@
                   ]
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance) for more information.",
+                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
                   "title": "tos_acceptance",
                   "type": [
                     "object"
@@ -7543,7 +7549,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the metadata of a bank account belonging to a \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanaged accounts\u003C/a\u003E, and optionally sets it as the default for its currency. Other bank account details are not editable by design.\u003C/p\u003E",
+        "description": "<p>Updates the metadata of a bank account belonging to a <a href=\"/docs/connect/managed-accounts\">managed accounts</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>",
         "operationId": "UpdateAccountBankAccount",
         "parameters": [
           {
@@ -7643,7 +7649,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -7769,7 +7775,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the metadata of a bank account belonging to a \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanaged accounts\u003C/a\u003E, and optionally sets it as the default for its currency. Other bank account details are not editable by design.\u003C/p\u003E",
+        "description": "<p>Updates the metadata of a bank account belonging to a <a href=\"/docs/connect/managed-accounts\">managed accounts</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>",
         "operationId": "UpdateAccountBankAccount",
         "parameters": [
           {
@@ -7822,7 +7828,7 @@
     },
     "/v1/accounts": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of accounts connected to your platform via \u003Ca href=\"/docs/connect\"\u003EConnect\u003C/a\u003E. If you’re not a platform, the list will be empty.\u003C/p\u003E",
+        "description": "<p>Returns a list of accounts connected to your platform via <a href=\"/docs/connect\">Connect</a>. If you’re not a platform, the list will be empty.</p>",
         "operationId": "AllAccount",
         "parameters": [
           {
@@ -7867,7 +7873,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -7957,7 +7963,7 @@
                   ]
                 },
                 "debit_negative_balances": {
-                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances) for more information.",
+                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/account-balances) for more information.",
                   "title": "debit_negative_balances",
                   "type": [
                     "boolean"
@@ -7971,7 +7977,7 @@
                   ]
                 },
                 "default_currency": {
-                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).",
+                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "default_currency",
                   "type": [
                     "string"
@@ -7985,7 +7991,7 @@
                   ]
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. \u003Cbr\u003E\u003Cbr\u003EThis will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
                   "title": "external_account",
                   "type": [
                     "object",
@@ -8070,7 +8076,7 @@
                   ]
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance) for more information.",
+                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
                   "title": "tos_acceptance",
                   "type": [
                     "object"
@@ -8112,7 +8118,7 @@
     },
     "/v1/accounts/{account}": {
       "delete": {
-        "description": "\u003Cp\u003EWith \u003Ca href=\"/docs/connect\"\u003EConnect\u003C/a\u003E, you may delete Stripe accounts you manage.\u003C/p\u003E\n\n\u003Cp\u003EManaged accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.\u003C/p\u003E\n\n\u003Cp\u003EIf you are looking to close your own account, use the \u003Ca href=\"http://dashboard:6090/account/data\"\u003Edata tab in your account settings\u003C/a\u003E instead.\u003C/p\u003E",
+        "description": "<p>With <a href=\"/docs/connect\">Connect</a>, you may delete Stripe accounts you manage.</p><p>Managed accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.</p><p>If you are looking to close your own account, use the <a href=\"https://dashboard.stripe.com/account/data\">data tab in your account settings</a> instead.</p>",
         "operationId": "AccountDelete",
         "parameters": [
           {
@@ -8139,7 +8145,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of the account.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of the account.</p>",
         "operationId": "AccountRetrieve",
         "parameters": [
           {
@@ -8166,7 +8172,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003E\u003Cstrong\u003EYou may only update accounts that you \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanage\u003C/a\u003E\u003C/strong\u003E. To update your own account, you can currently only do so via the \u003Ca href=\"http://dashboard:6090/account\"\u003Edashboard\u003C/a\u003E. For more information on updating Managed Accounts, see \u003Ca href=\"/docs/connect/updating-accounts\"\u003Eour guide\u003C/a\u003E.\u003C/p\u003E",
+        "description": "<p>Updates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p><strong>You may only update accounts that you <a href=\"/docs/connect/managed-accounts\">manage</a></strong>. To update your own account, you can currently only do so via the <a href=\"https://dashboard.stripe.com/account\">dashboard</a>. For more information on updating Managed Accounts, see <a href=\"/docs/connect/updating-accounts\">our guide</a>.</p>",
         "operationId": "AccountUpdate",
         "parameters": [
           {
@@ -8205,7 +8211,7 @@
                   ]
                 },
                 "debit_negative_balances": {
-                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances) for more information.",
+                  "description": "A boolean for whether or not Stripe should try to reclaim negative balances from the account holder's bank account. See our [managed account bank transfer guide](/docs/connect/account-balances) for more information.",
                   "title": "debit_negative_balances",
                   "type": [
                     "boolean"
@@ -8219,7 +8225,7 @@
                   ]
                 },
                 "default_currency": {
-                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).",
+                  "description": "Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "default_currency",
                   "type": [
                     "string"
@@ -8233,7 +8239,7 @@
                   ]
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. \u003Cbr\u003E\u003Cbr\u003EThis will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the external_account parameter for either [card](/docs/api#account_create_card) or [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API.",
                   "title": "external_account",
                   "type": [
                     "object",
@@ -8304,7 +8310,7 @@
                   ]
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance) for more information.",
+                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
                   "title": "tos_acceptance",
                   "type": [
                     "object"
@@ -8430,7 +8436,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the metadata of a bank account belonging to a \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanaged accounts\u003C/a\u003E, and optionally sets it as the default for its currency. Other bank account details are not editable by design.\u003C/p\u003E",
+        "description": "<p>Updates the metadata of a bank account belonging to a <a href=\"/docs/connect/managed-accounts\">managed accounts</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>",
         "operationId": "UpdateAccountBankAccount",
         "parameters": [
           {
@@ -8530,7 +8536,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -8656,7 +8662,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the metadata of a bank account belonging to a \u003Ca href=\"/docs/connect/managed-accounts\"\u003Emanaged accounts\u003C/a\u003E, and optionally sets it as the default for its currency. Other bank account details are not editable by design.\u003C/p\u003E",
+        "description": "<p>Updates the metadata of a bank account belonging to a <a href=\"/docs/connect/managed-accounts\">managed accounts</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>",
         "operationId": "UpdateAccountBankAccount",
         "parameters": [
           {
@@ -8709,7 +8715,7 @@
     },
     "/v1/accounts/{account}/reject": {
       "post": {
-        "description": "\u003Cp\u003EWith \u003Ca href=\"/docs/connect\"\u003EConnect\u003C/a\u003E, you may flag managed accounts as suspicious.\u003C/p\u003E\n\n\u003Cp\u003EManaged accounts created using test-mode keys can be rejected at any time. Managed accounts created using live-mode keys may only be rejected once all balances are zero.\u003C/p\u003E",
+        "description": "<p>With <a href=\"/docs/connect\">Connect</a>, you may flag managed accounts as suspicious.</p><p>Managed accounts created using test-mode keys can be rejected at any time. Managed accounts created using live-mode keys may only be rejected once all balances are zero.</p>",
         "operationId": "AccountReject",
         "parameters": [
           {
@@ -8810,7 +8816,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -8953,7 +8959,7 @@
     },
     "/v1/application_fees": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.</p>",
         "operationId": "AllPlatformEarnings",
         "parameters": [
           {
@@ -9012,7 +9018,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -9058,7 +9064,7 @@
     },
     "/v1/application_fees/{fee}/refunds/{id}": {
       "get": {
-        "description": "\u003Cp\u003EBy default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.\u003C/p\u003E",
+        "description": "<p>By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.</p>",
         "operationId": "RetrievePlatformEarningRefund",
         "parameters": [
           {
@@ -9092,7 +9098,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003EThis request only accepts metadata as an argument.\u003C/p\u003E",
+        "description": "<p>Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request only accepts metadata as an argument.</p>",
         "operationId": "UpdatePlatformEarningRefund",
         "parameters": [
           {
@@ -9131,7 +9137,7 @@
     },
     "/v1/application_fees/{id}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.</p>",
         "operationId": "RetrievePlatformEarning",
         "parameters": [
           {
@@ -9213,7 +9219,7 @@
     },
     "/v1/application_fees/{id}/refunds": {
       "get": {
-        "description": "\u003Cp\u003EYou can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the \u003Ccode\u003Elimit\u003C/code\u003E and \u003Ccode\u003Estarting_after\u003C/code\u003E parameters to page through additional refunds.\u003C/p\u003E",
+        "description": "<p>You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p>",
         "operationId": "AllPlatformEarningsRefunds",
         "parameters": [
           {
@@ -9265,7 +9271,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -9367,7 +9373,7 @@
     },
     "/v1/balance": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the current account balance, based on the authentication that was used to make the request.\u003C/p\u003E",
+        "description": "<p>Retrieves the current account balance, based on the authentication that was used to make the request.</p>",
         "operationId": "BalanceRetrieve",
         "parameters": [
 
@@ -9390,7 +9396,7 @@
     },
     "/v1/balance/history": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.</p>",
         "operationId": "AllBalanceTransactions",
         "parameters": [
           {
@@ -9477,7 +9483,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -9524,7 +9530,7 @@
     },
     "/v1/balance/history/{id}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the balance transaction with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the balance transaction with the given ID.</p>",
         "operationId": "RetrieveBalanceTransaction",
         "parameters": [
           {
@@ -9648,7 +9654,7 @@
     },
     "/v1/bitcoin/receivers": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your receivers. Receivers are returned sorted by creation date, with the most recently created receivers appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your receivers. Receivers are returned sorted by creation date, with the most recently created receivers appearing first.</p>",
         "operationId": "AllReceivers",
         "parameters": [
           {
@@ -9714,7 +9720,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -9758,7 +9764,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a Bitcoin receiver object that can be used to accept bitcoin payments from your customer. The receiver exposes a Bitcoin address and is created with a bitcoin to USD exchange rate that is valid for 10 minutes.\u003C/p\u003E",
+        "description": "<p>Creates a Bitcoin receiver object that can be used to accept bitcoin payments from your customer. The receiver exposes a Bitcoin address and is created with a bitcoin to USD exchange rate that is valid for 10 minutes.</p>",
         "operationId": "CreateReceiver",
         "parameters": [
           {
@@ -9776,7 +9782,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "The currency to which the bitcoin will be converted. You will be paid out in this currency. Only USD is currently supported.",
+                  "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) to which the bitcoin will be converted. You will be paid out in this currency. Only USD is currently supported.",
                   "title": "currency",
                   "type": [
                     "string"
@@ -9863,7 +9869,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the Bitcoin receiver with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the Bitcoin receiver with the given ID.</p>",
         "operationId": "RetrieveReceiver",
         "parameters": [
           {
@@ -10062,7 +10068,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -10165,7 +10171,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -10238,7 +10244,7 @@
     },
     "/v1/charges": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of charges you’ve previously created. The charges are returned in sorted order, with the most recent charges appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of charges you’ve previously created. The charges are returned in sorted order, with the most recent charges appearing first.</p>",
         "operationId": "AllCharges",
         "parameters": [
           {
@@ -10311,7 +10317,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -10596,7 +10602,7 @@
     },
     "/v1/charges/{charge}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.</p>",
         "operationId": "RetrieveCharge",
         "parameters": [
           {
@@ -10623,7 +10629,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003EThis request accepts only the \u003Ccode\u003Edescription\u003C/code\u003E, \u003Ccode\u003Emetadata\u003C/code\u003E, \u003Ccode\u003Ereceipt_email\u003C/code\u003E, \u003Ccode\u003Efraud_details\u003C/code\u003E, and \u003Ccode\u003Eshipping\u003C/code\u003E as arguments.\u003C/p\u003E",
+        "description": "<p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>, <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>",
         "operationId": "UpdateCharge",
         "parameters": [
           {
@@ -10648,7 +10654,7 @@
                   ]
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to a charge object. It can be useful for storing additional information about the charge in a structured format.",
+                  "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to metadata.",
                   "title": "metadata",
                   "type": [
                     "object"
@@ -10697,7 +10703,7 @@
     },
     "/v1/charges/{charge}/capture": {
       "post": {
-        "description": "\u003Cp\u003ECapture the payment of an existing, uncaptured, charge. This is the second half of the two-step payment flow, where first you \u003Ca href=\"#create_charge\"\u003Ecreated a charge\u003C/a\u003E with the capture option set to false.\u003C/p\u003E\n\n\u003Cp\u003EUncaptured payments expire exactly seven days after they are created. If they are not captured by that point in time, they will be marked as refunded and will no longer be capturable.\u003C/p\u003E",
+        "description": "<p>Capture the payment of an existing, uncaptured, charge. This is the second half of the two-step payment flow, where first you <a href=\"#create_charge\">created a charge</a> with the capture option set to false.</p><p>Uncaptured payments expire exactly seven days after they are created. If they are not captured by that point in time, they will be marked as refunded and will no longer be capturable.</p>",
         "operationId": "ChargeCapture",
         "parameters": [
           {
@@ -10736,7 +10742,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to *22 characters*. As an example, if your website is `RunClub` and the item you're charging for is a race ticket, you may want to specify a `statement_descriptor` of `RunClub 5K race ticket`. The statement description may not include `\u003C\u003E\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. Updating this value will overwrite the previous statement descriptor of this charge. While most banks display this information consistently, some may display it incorrectly or not at all.",
+                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to *22 characters*. As an example, if your website is `RunClub` and the item you're charging for is a race ticket, you may want to specify a `statement_descriptor` of `RunClub 5K race ticket`. The statement description may not include `<>\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. Updating this value will overwrite the previous statement descriptor of this charge. While most banks display this information consistently, some may display it incorrectly or not at all.",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -10968,7 +10974,7 @@
     },
     "/v1/charges/{charge}/refunds": {
       "get": {
-        "description": "\u003Cp\u003EYou can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the \u003Ccode\u003Elimit\u003C/code\u003E and \u003Ccode\u003Estarting_after\u003C/code\u003E parameters to page through additional refunds.\u003C/p\u003E",
+        "description": "<p>You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p>",
         "operationId": "AllChargeRefunds",
         "parameters": [
           {
@@ -11020,7 +11026,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -11223,7 +11229,7 @@
     },
     "/v1/country_specs": {
       "get": {
-        "description": "\u003Cp\u003ELists all Country Spec objects available in the API.\u003C/p\u003E",
+        "description": "<p>Lists all Country Spec objects available in the API.</p>",
         "operationId": "AllCountrySpecs",
         "parameters": [
           {
@@ -11268,7 +11274,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -11314,7 +11320,7 @@
     },
     "/v1/country_specs/{country}": {
       "get": {
-        "description": "\u003Cp\u003EReturns a Country Spec for a given Country code.\u003C/p\u003E",
+        "description": "<p>Returns a Country Spec for a given Country code.</p>",
         "operationId": "RetrieveCountrySpec",
         "parameters": [
           {
@@ -11343,7 +11349,7 @@
     },
     "/v1/coupons": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your coupons.\u003C/p\u003E",
+        "description": "<p>Returns a list of your coupons.</p>",
         "operationId": "AllCoupons",
         "parameters": [
           {
@@ -11395,7 +11401,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -11439,7 +11445,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EYou can create coupons easily via the \u003Ca href=\"https://dashboard.stripe.com/coupons\"\u003Ecoupon management\u003C/a\u003E page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.\u003C/p\u003E\n\n\u003Cp\u003EA coupon has either a \u003Ccode\u003Epercent_off\u003C/code\u003E or an \u003Ccode\u003Eamount_off\u003C/code\u003E and \u003Ccode\u003Ecurrency\u003C/code\u003E. If you set an \u003Ccode\u003Eamount_off\u003C/code\u003E, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of \u003Ccurrency\u003E100\u003C/currency\u003E will have a final total of \u003Ccurrency\u003E0\u003C/currency\u003E if a coupon with an \u003Ccode\u003Eamount_off\u003C/code\u003E of \u003Camount\u003E200\u003C/amount\u003E is applied to it and an invoice with a subtotal of \u003Ccurrency\u003E300\u003C/currency\u003E will have a final total of \u003Ccurrency\u003E100\u003C/currency\u003E if a coupon with an \u003Ccode\u003Eamount_off\u003C/code\u003E of \u003Camount\u003E200\u003C/amount\u003E is applied to it.\u003C/p\u003E",
+        "description": "<p>You can create coupons easily via the <a href=\"https://dashboard.stripe.com/coupons\">coupon management</a> page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.</p><p>A coupon has either a <code>percent_off</code> or an <code>amount_off</code> and <code>currency</code>. If you set an <code>amount_off</code>, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of <currency>100</currency> will have a final total of <currency>0</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it and an invoice with a subtotal of <currency>300</currency> will have a final total of <currency>100</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it.</p>",
         "operationId": "CreateCoupon",
         "parameters": [
           {
@@ -11457,7 +11463,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "Currency of the `amount_off` parameter (required if `amount_off` is passed).",
+                  "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) of the `amount_off` parameter (required if `amount_off` is passed).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -11537,7 +11543,7 @@
     },
     "/v1/coupons/{coupon}": {
       "delete": {
-        "description": "\u003Cp\u003EYou can delete coupons via the \u003Ca href=\"http://dashboard:6090/coupons\"\u003Ecoupon management\u003C/a\u003E page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon. You can also delete coupons via the API.\u003C/p\u003E",
+        "description": "<p>You can delete coupons via the <a href=\"https://dashboard.stripe.com/coupons\">coupon management</a> page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon. You can also delete coupons via the API.</p>",
         "operationId": "DeleteCoupon",
         "parameters": [
           {
@@ -11564,7 +11570,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the coupon with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the coupon with the given ID.</p>",
         "operationId": "RetrieveCoupon",
         "parameters": [
           {
@@ -11591,7 +11597,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.\u003C/p\u003E",
+        "description": "<p>Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.</p>",
         "operationId": "UpdateCoupon",
         "parameters": [
           {
@@ -11637,7 +11643,7 @@
     },
     "/v1/customers": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.</p>",
         "operationId": "AllCustomers",
         "parameters": [
           {
@@ -11696,7 +11702,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -11740,7 +11746,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a new customer object.\u003C/p\u003E",
+        "description": "<p>Creates a new customer object.</p>",
         "operationId": "CustomerCreateWithPlan",
         "parameters": [
           {
@@ -11857,7 +11863,7 @@
     },
     "/v1/customers/{customer}": {
       "delete": {
-        "description": "\u003Cp\u003EPermanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.\u003C/p\u003E",
+        "description": "<p>Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.</p>",
         "operationId": "DeleteCustomer",
         "parameters": [
           {
@@ -11884,7 +11890,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing customer. You need only supply the unique customer identifier that was returned upon customer creation.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing customer. You need only supply the unique customer identifier that was returned upon customer creation.</p>",
         "operationId": "RetrieveCustomer",
         "parameters": [
           {
@@ -12087,7 +12093,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -12235,7 +12241,7 @@
     },
     "/v1/customers/{customer}/bank_accounts": {
       "get": {
-        "description": "\u003Cp\u003EYou can see a list of the bank accounts belonging to a Customer. Note that the 10 most recent sources are always available by default on the Customer. If you need more than those 10, you can use this API method and the \u003Ccode\u003Elimit\u003C/code\u003E and \u003Ccode\u003Estarting_after\u003C/code\u003E parameters to page through additional bank accounts.\u003C/p\u003E",
+        "description": "<p>You can see a list of the bank accounts belonging to a Customer. Note that the 10 most recent sources are always available by default on the Customer. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional bank accounts.</p>",
         "operationId": "AllCustomerBankAccounts",
         "parameters": [
           {
@@ -12287,7 +12293,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -12406,7 +12412,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003EBy default, you can see the 10 most recent sources stored on a Customer directly on the object, but you can also retrieve details about a specific bank account stored on the Stripe account.\u003C/p\u003E",
+        "description": "<p>By default, you can see the 10 most recent sources stored on a Customer directly on the object, but you can also retrieve details about a specific bank account stored on the Stripe account.</p>",
         "operationId": "RetrieveCustomerBankAccount",
         "parameters": [
           {
@@ -12675,7 +12681,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -12944,7 +12950,7 @@
     },
     "/v1/customers/{customer}/discount": {
       "delete": {
-        "description": "\u003Cp\u003ERemoves the currently applied discount on a customer.\u003C/p\u003E",
+        "description": "<p>Removes the currently applied discount on a customer.</p>",
         "operationId": "DeleteCustomerDiscount",
         "parameters": [
 
@@ -13048,7 +13054,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -13377,7 +13383,7 @@
     },
     "/v1/customers/{customer}/subscriptions": {
       "get": {
-        "description": "\u003Cp\u003EYou can see a list of the customer’s active subscriptions. Note that the 10 most recent active subscriptions are always available by default on the customer object. If you need more than those 10, you can use the limit and starting_after parameters to page through additional subscriptions.\u003C/p\u003E",
+        "description": "<p>You can see a list of the customer’s active subscriptions. Note that the 10 most recent active subscriptions are always available by default on the customer object. If you need more than those 10, you can use the limit and starting_after parameters to page through additional subscriptions.</p>",
         "operationId": "AllCustomerSubscriptions",
         "parameters": [
           {
@@ -13429,7 +13435,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -13471,7 +13477,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a new subscription on an existing customer.\u003C/p\u003E",
+        "description": "<p>Creates a new subscription on an existing customer.</p>",
         "operationId": "CreateCustomerSubscription",
         "parameters": [
           {
@@ -13496,7 +13502,7 @@
                   ]
                 },
                 "application_fee_percent": {
-                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation]('https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).",
                   "title": "application_fee_percent",
                   "type": [
                     "number"
@@ -13559,7 +13565,7 @@
                   ]
                 },
                 "quantity": {
-                  "description": "The quantity you'd like to apply to the subscription you're creating. For example, if your plan is \u003Ccurrency\u003E10\u003C/currency\u003E/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged \u003Ccurrency\u003E50\u003C/currency\u003E (5 x \u003Ccurrency\u003E10\u003C/currency\u003E) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
+                  "description": "The quantity you'd like to apply to the subscription you're creating. For example, if your plan is <currency>10</currency>/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged <currency>50</currency> (5 x <currency>10</currency>) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
                   "title": "quantity",
                   "type": [
                     "integer"
@@ -13573,7 +13579,7 @@
                   ]
                 },
                 "source": {
-                  "description": "The source can either be a token, like the ones returned by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card) to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
+                  "description": "The source can either be a token, like the ones returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
                   "title": "source",
                   "type": [
                     "object",
@@ -13624,7 +13630,7 @@
     },
     "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}": {
       "delete": {
-        "description": "\u003Cp\u003ECancels a customer’s subscription. If you set the \u003Ccode\u003Eat_period_end\u003C/code\u003E parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually \u003Ca href=\"#delete_invoiceitem\"\u003Edeleted\u003C/a\u003E. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.\u003C/p\u003E\n\n\u003Cp\u003EBy default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.\u003C/p\u003E",
+        "description": "<p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually <a href=\"#delete_invoiceitem\">deleted</a>. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.</p><p>By default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.</p>",
         "operationId": "DeleteCustomerSubscription",
         "parameters": [
           {
@@ -13661,7 +13667,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the subscription with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the subscription with the given ID.</p>",
         "operationId": "RetrieveCustomerSubscription",
         "parameters": [
 
@@ -13682,7 +13688,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the \u003Ca href=\"#upcoming_invoice\"\u003Eupcoming invoice\u003C/a\u003E endpoint.\u003C/p\u003E",
+        "description": "<p>Updates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the <a href=\"#upcoming_invoice\">upcoming invoice</a> endpoint.</p>",
         "operationId": "UpdateCustomerSubscription",
         "parameters": [
           {
@@ -13700,7 +13706,7 @@
                   ]
                 },
                 "application_fee_percent": {
-                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions')}).",
                   "title": "application_fee_percent",
                   "type": [
                     "number"
@@ -13777,7 +13783,7 @@
                   ]
                 },
                 "quantity": {
-                  "description": "The quantity you'd like to apply to the subscription you're updating. For example, if your plan is \u003Ccurrency\u003E10\u003C/currency\u003E/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged \u003Ccurrency\u003E50\u003C/currency\u003E (5 x \u003Ccurrency\u003E10\u003C/currency\u003E) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
+                  "description": "The quantity you'd like to apply to the subscription you're updating. For example, if your plan is <currency>10</currency>/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged <currency>50</currency> (5 x <currency>10</currency>) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
                   "title": "quantity",
                   "type": [
                     "integer"
@@ -13791,7 +13797,7 @@
                   ]
                 },
                 "source": {
-                  "description": "The source can either be a token, like the ones returned by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card) to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
+                  "description": "The source can either be a token, like the ones returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
                   "title": "source",
                   "type": [
                     "object",
@@ -13835,7 +13841,7 @@
     },
     "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}/discount": {
       "delete": {
-        "description": "\u003Cp\u003ERemoves the currently applied discount on a customer.\u003C/p\u003E",
+        "description": "<p>Removes the currently applied discount on a customer.</p>",
         "operationId": "DeleteCustomerDiscount",
         "parameters": [
 
@@ -13885,7 +13891,7 @@
     },
     "/v1/disputes": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your disputes.\u003C/p\u003E",
+        "description": "<p>Returns a list of your disputes.</p>",
         "operationId": "AllDisputes",
         "parameters": [
           {
@@ -13937,7 +13943,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -13983,7 +13989,7 @@
     },
     "/v1/disputes/{dispute}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the dispute with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the dispute with the given ID.</p>",
         "operationId": "RetrieveDispute",
         "parameters": [
           {
@@ -14010,7 +14016,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EWhen you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence in order to help us resolve the dispute in your favor. You can do this in your \u003Ca href=\"http://dashboard:6090/disputes\"\u003Edashboard\u003C/a\u003E, but if you prefer, you can use the API to submit evidence programmatically.\u003C/p\u003E\n\n\u003Cp\u003EDepending on your dispute type, different evidence fields will give you a better chance of winning your dispute. You may want to consult our \u003Ca href=\"http://127.0.0.1:6040/help/dispute-types\"\u003Eguide to dispute types\u003C/a\u003E to help you figure out which evidence fields to provide.\u003C/p\u003E",
+        "description": "<p>When you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence in order to help us resolve the dispute in your favor. You can do this in your <a href=\"https://dashboard.stripe.com/disputes\">dashboard</a>, but if you prefer, you can use the API to submit evidence programmatically.</p><p>Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. You may want to consult our <a href=\"https://stripe.com/help/dispute-types\">guide to dispute types</a> to help you figure out which evidence fields to provide.</p>",
         "operationId": "UpdateDispute",
         "parameters": [
           {
@@ -14063,7 +14069,7 @@
     },
     "/v1/disputes/{dispute}/close": {
       "post": {
-        "description": "\u003Cp\u003EClosing the dispute for a charge indicates that you do not have any evidence to submit and are essentially ‘dismissing’ the dispute, acknowledging it as lost\u003C/p\u003E\n\n\u003Cp\u003EThe status of the dispute will change from \u003Ccode\u003Eneeds_response\u003C/code\u003E to \u003Ccode\u003Elost\u003C/code\u003E. \u003Cstrong\u003EClosing a dispute is irreversible\u003C/strong\u003E.\u003C/p\u003E",
+        "description": "<p>Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially ‘dismissing’ the dispute, acknowledging it as lost</p><p>The status of the dispute will change from <code>needs_response</code> to <code>lost</code>. <strong>Closing a dispute is irreversible</strong>.</p>",
         "operationId": "CloseDispute",
         "parameters": [
           {
@@ -14092,7 +14098,7 @@
     },
     "/v1/events": {
       "get": {
-        "description": "\u003Cp\u003EList events, going back up to 30 days.\u003C/p\u003E",
+        "description": "<p>List events, going back up to 30 days.</p>",
         "operationId": "AllEvents",
         "parameters": [
           {
@@ -14158,7 +14164,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -14204,7 +14210,7 @@
     },
     "/v1/events/{id}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.</p>",
         "operationId": "RetrieveEvent",
         "parameters": [
           {
@@ -14233,7 +14239,7 @@
     },
     "/v1/events/{id}/retry": {
       "post": {
-        "description": "\u003Cp\u003EResend an event. This only works in testmode\u003C/p\u003E",
+        "description": "<p>Resend an event. This only works in testmode</p>",
         "operationId": "RetryEvent",
         "parameters": [
           {
@@ -14262,7 +14268,7 @@
     },
     "/v1/invoiceitems": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.</p>",
         "operationId": "AllInvoiceItems",
         "parameters": [
           {
@@ -14321,7 +14327,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -14365,7 +14371,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EAdds an arbitrary charge or credit to the customer’s upcoming invoice.\u003C/p\u003E",
+        "description": "<p>Adds an arbitrary charge or credit to the customer’s upcoming invoice.</p>",
         "operationId": "CreateInvoiceItem",
         "parameters": [
           {
@@ -14383,7 +14389,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "3-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -14458,7 +14464,7 @@
     },
     "/v1/invoiceitems/{invoiceitem}": {
       "delete": {
-        "description": "\u003Cp\u003ERemoves an invoice item from the upcoming invoice. Removing an invoice item is only possible before the invoice it’s attached to is closed.\u003C/p\u003E",
+        "description": "<p>Removes an invoice item from the upcoming invoice. Removing an invoice item is only possible before the invoice it’s attached to is closed.</p>",
         "operationId": "DeleteInvoiceItem",
         "parameters": [
           {
@@ -14485,7 +14491,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the invoice item with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the invoice item with the given ID.</p>",
         "operationId": "RetrieveInvoiceItem",
         "parameters": [
           {
@@ -14512,7 +14518,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it’s attached to is closed.\u003C/p\u003E",
+        "description": "<p>Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it’s attached to is closed.</p>",
         "operationId": "UpdateInvoiceItem",
         "parameters": [
           {
@@ -14572,7 +14578,7 @@
     },
     "/v1/invoices": {
       "get": {
-        "description": "\u003Cp\u003EYou can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.\u003C/p\u003E",
+        "description": "<p>You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.</p>",
         "operationId": "AllInvoices",
         "parameters": [
           {
@@ -14638,7 +14644,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -14682,7 +14688,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EIf you need to invoice your customer outside the regular billing cycle, you can create an invoice that pulls in all pending invoice items, including prorations. The customer’s billing cycle and regular subscription won’t be affected.\u003C/p\u003E\n\n\u003Cp\u003EOnce you create the invoice, it’ll be picked up and paid automatically, though you can choose to \u003Ca href=\"#pay_invoice\"\u003Epay it right\u003C/a\u003E away.\u003C/p\u003E",
+        "description": "<p>If you need to invoice your customer outside the regular billing cycle, you can create an invoice that pulls in all pending invoice items, including prorations. The customer’s billing cycle and regular subscription won’t be affected.</p><p>Once you create the invoice, it’ll be picked up and paid automatically, though you can choose to <a href=\"#pay_invoice\">pay it right</a> away.</p>",
         "operationId": "CreateInvoice",
         "parameters": [
           {
@@ -14693,7 +14699,7 @@
             "schema": {
               "properties": {
                 "application_fee": {
-                  "description": "A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](/docs/connect/subscriptions#working-with-invoices).",
                   "title": "application_fee",
                   "type": [
                     "integer"
@@ -14787,7 +14793,7 @@
     },
     "/v1/invoices/upcoming": {
       "get": {
-        "description": "\u003Cp\u003EAt any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discount that is applicable to the customer.\u003C/p\u003E\n\n\u003Cp\u003ENote that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer’s discount.\u003C/p\u003E\n\n\u003Cp\u003EYou can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass a \u003Ccode\u003Eproration_date\u003C/code\u003E parameter when doing the actual subscription update. The value passed in should be the same as the \u003Ccode\u003Esubscription_proration_date\u003C/code\u003E returned on the upcoming invoice resource. The recommended way to get only the prorations being previewed is to consider only proration line items where \u003Ccode\u003Eperiod[start]\u003C/code\u003E is equal to the \u003Ccode\u003Esubscription_proration_date\u003C/code\u003E on the upcoming invoice resource.\u003C/p\u003E",
+        "description": "<p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discount that is applicable to the customer.</p><p>Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer’s discount.</p><p>You can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass a <code>proration_date</code> parameter when doing the actual subscription update. The value passed in should be the same as the <code>subscription_proration_date</code> returned on the upcoming invoice resource. The recommended way to get only the prorations being previewed is to consider only proration line items where <code>period[start]</code> is equal to the <code>subscription_proration_date</code> on the upcoming invoice resource.</p>",
         "operationId": "RetrieveCustomerUpcomingInvoice",
         "parameters": [
           {
@@ -14879,7 +14885,7 @@
     },
     "/v1/invoices/{invoice}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the invoice with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the invoice with the given ID.</p>",
         "operationId": "RetrieveInvoice",
         "parameters": [
           {
@@ -14906,7 +14912,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUntil an invoice is paid, it is marked as open (closed=false). If you’d like to stop Stripe from automatically attempting payment on an invoice or would simply like to close the invoice out as no longer owed by the customer, you can update the closed parameter.\u003C/p\u003E",
+        "description": "<p>Until an invoice is paid, it is marked as open (closed=false). If you’d like to stop Stripe from automatically attempting payment on an invoice or would simply like to close the invoice out as no longer owed by the customer, you can update the closed parameter.</p>",
         "operationId": "UpdateInvoice",
         "parameters": [
           {
@@ -14917,7 +14923,7 @@
             "schema": {
               "properties": {
                 "application_fee": {
-                  "description": "A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](/docs/connect/subscriptions#working-with-invoices).",
                   "title": "application_fee",
                   "type": [
                     "integer"
@@ -14994,7 +15000,7 @@
     },
     "/v1/invoices/{invoice}/lines": {
       "get": {
-        "description": "\u003Cp\u003EWhen retrieving an invoice, you’ll get a \u003Cstrong\u003Elines\u003C/strong\u003E property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.\u003C/p\u003E",
+        "description": "<p>When retrieving an invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>",
         "operationId": "AllInvoiceLines",
         "parameters": [
           {
@@ -15116,7 +15122,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -15160,7 +15166,7 @@
     },
     "/v1/invoices/{invoice}/pay": {
       "post": {
-        "description": "\u003Cp\u003EStripe automatically creates and then attempts to pay invoices for customers on subscriptions. We’ll also retry unpaid invoices according to your \u003Ca href=\"http://dashboard:6090/account/recurring\"\u003Eretry settings\u003C/a\u003E. However, if you’d like to attempt to collect payment on an invoice out of the normal retry schedule or for some other reason, you can do so.\u003C/p\u003E",
+        "description": "<p>Stripe automatically creates and then attempts to pay invoices for customers on subscriptions. We’ll also retry unpaid invoices according to your <a href=\"https://dashboard.stripe.com/account/recurring\">retry settings</a>. However, if you’d like to attempt to collect payment on an invoice out of the normal retry schedule or for some other reason, you can do so.</p>",
         "operationId": "PayInvoice",
         "parameters": [
           {
@@ -15189,7 +15195,7 @@
     },
     "/v1/order_returns": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your order returns. The returns are returned sorted by creation date, with the most recently created return appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your order returns. The returns are returned sorted by creation date, with the most recently created return appearing first.</p>",
         "operationId": "AllOrderReturns",
         "parameters": [
           {
@@ -15248,7 +15254,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -15294,7 +15300,7 @@
     },
     "/v1/order_returns/{id}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing order return. Supply the unique order ID from either an order return creation request or the order return list, and Stripe will return the corresponding order information.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing order return. Supply the unique order ID from either an order return creation request or the order return list, and Stripe will return the corresponding order information.</p>",
         "operationId": "RetrieveOrderReturn",
         "parameters": [
           {
@@ -15323,7 +15329,7 @@
     },
     "/v1/orders": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your orders. The orders are returned sorted by creation date, with the most recently created orders appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your orders. The orders are returned sorted by creation date, with the most recently created orders appearing first.</p>",
         "operationId": "AllOrders",
         "parameters": [
           {
@@ -15410,7 +15416,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -15472,7 +15478,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) representing the currency in which the order should be made. Stripe will validate that all entries in `items` match the currency specified here.",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -15538,7 +15544,7 @@
     },
     "/v1/orders/{id}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing order. Supply the unique order ID from either an order creation request or the order list, and Stripe will return the corresponding order information.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing order. Supply the unique order ID from either an order creation request or the order list, and Stripe will return the corresponding order information.</p>",
         "operationId": "RetrieveOrder",
         "parameters": [
           {
@@ -15565,7 +15571,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specific order by setting the values of the parameters passed. Any parameters not provided will be left unchanged. This request accepts only the \u003Ccode\u003Emetadata\u003C/code\u003E, and \u003Ccode\u003Estatus\u003C/code\u003E as arguments.\u003C/p\u003E",
+        "description": "<p>Updates the specific order by setting the values of the parameters passed. Any parameters not provided will be left unchanged. This request accepts only the <code>metadata</code>, and <code>status</code> as arguments.</p>",
         "operationId": "UpdateOrder",
         "parameters": [
           {
@@ -15721,7 +15727,7 @@
     },
     "/v1/orders/{id}/returns": {
       "post": {
-        "description": "\u003Cp\u003EReturn all or part of an order. The order must have a status of \u003Ccode\u003Epaid\u003C/code\u003E or \u003Ccode\u003Efulfilled\u003C/code\u003E before it can be returned. Once all items have been returned, the order will become \u003Ccode\u003Ecanceled\u003C/code\u003E or \u003Ccode\u003Ereturned\u003C/code\u003E depending on which status the order started in.\u003C/p\u003E",
+        "description": "<p>Return all or part of an order. The order must have a status of <code>paid</code> or <code>fulfilled</code> before it can be returned. Once all items have been returned, the order will become <code>canceled</code> or <code>returned</code> depending on which status the order started in.</p>",
         "operationId": "CreateOrderReturn",
         "parameters": [
           {
@@ -15826,7 +15832,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -15901,7 +15907,7 @@
     },
     "/v1/plans": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your plans.\u003C/p\u003E",
+        "description": "<p>Returns a list of your plans.</p>",
         "operationId": "AllPlans",
         "parameters": [
           {
@@ -15953,7 +15959,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -15997,7 +16003,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EYou can create plans easily via the \u003Ca href=\"https://dashboard.stripe.com/plans\"\u003Eplan management\u003C/a\u003E page of the Stripe dashboard. Plan creation is also accessible via the API if you need to create plans on the fly.\u003C/p\u003E",
+        "description": "<p>You can create plans easily via the <a href=\"https://dashboard.stripe.com/plans\">plan management</a> page of the Stripe dashboard. Plan creation is also accessible via the API if you need to create plans on the fly.</p>",
         "operationId": "CreatePlan",
         "parameters": [
           {
@@ -16015,7 +16021,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "3-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -16057,7 +16063,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to **22 characters**. As an example, if your website is `RunClub` and the item you're charging for is your Silver Plan, you may want to specify a `statement_descriptor` of `RunClub Silver Plan`. The statement description may not include `\u003C\u003E\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.",
+                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to **22 characters**. As an example, if your website is `RunClub` and the item you're charging for is your Silver Plan, you may want to specify a `statement_descriptor` of `RunClub Silver Plan`. The statement description may not include `<>\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -16099,7 +16105,7 @@
     },
     "/v1/plans/{plan}": {
       "delete": {
-        "description": "\u003Cp\u003EYou can delete plans via the \u003Ca href=\"http://dashboard:6090/plans\"\u003Eplan management\u003C/a\u003E page of the Stripe dashboard. However, deleting a plan does not affect any current subscribers to the plan; it merely means that new subscribers can’t be added to that plan. You can also delete plans via the API.\u003C/p\u003E",
+        "description": "<p>You can delete plans via the <a href=\"https://dashboard.stripe.com/plans\">plan management</a> page of the Stripe dashboard. However, deleting a plan does not affect any current subscribers to the plan; it merely means that new subscribers can’t be added to that plan. You can also delete plans via the API.</p>",
         "operationId": "DeletePlan",
         "parameters": [
           {
@@ -16126,7 +16132,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the plan with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the plan with the given ID.</p>",
         "operationId": "RetrievePlan",
         "parameters": [
           {
@@ -16153,7 +16159,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the name of a plan. Other plan details (price, interval, etc.) are, by design, not editable.\u003C/p\u003E",
+        "description": "<p>Updates the name of a plan. Other plan details (price, interval, etc.) are, by design, not editable.</p>",
         "operationId": "UpdatePlan",
         "parameters": [
           {
@@ -16185,7 +16191,7 @@
                   ]
                 },
                 "statement_descriptor": {
-                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to **22 characters**. As an example, if your website is `RunClub` and the item you're charging for is your Silver Plan, you may want to specify a `statement_descriptor` of `RunClub Silver Plan`. The statement description may not include `\u003C\u003E\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.",
+                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to **22 characters**. As an example, if your website is `RunClub` and the item you're charging for is your Silver Plan, you may want to specify a `statement_descriptor` of `RunClub Silver Plan`. The statement description may not include `<>\"'` characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.",
                   "title": "statement_descriptor",
                   "type": [
                     "string"
@@ -16220,7 +16226,7 @@
     },
     "/v1/products": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p>",
         "operationId": "AllProducts",
         "parameters": [
           {
@@ -16293,7 +16299,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -16337,7 +16343,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a new product object.\u003C/p\u003E",
+        "description": "<p>Creates a new product object.</p>",
         "operationId": "CreateProduct",
         "parameters": [
           {
@@ -16456,7 +16462,7 @@
     },
     "/v1/products/{id}": {
       "delete": {
-        "description": "\u003Cp\u003EDelete a product. Deleting a product is only possible if it has no SKUs associated with it.\u003C/p\u003E",
+        "description": "<p>Delete a product. Deleting a product is only possible if it has no SKUs associated with it.</p>",
         "operationId": "DeleteProduct",
         "parameters": [
           {
@@ -16483,7 +16489,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p>",
         "operationId": "RetrieveProduct",
         "parameters": [
           {
@@ -16510,7 +16516,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003ENote that a product’s \u003Ccode\u003Eattributes\u003C/code\u003E are not editable. Instead, you would need to deactivate the existing product and create a new one with the new attribute values.\u003C/p\u003E",
+        "description": "<p>Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to deactivate the existing product and create a new one with the new attribute values.</p>",
         "operationId": "UpdateProduct",
         "parameters": [
           {
@@ -16622,7 +16628,7 @@
     },
     "/v1/recipients": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your recipients. The recipients are returned sorted by creation date, with the most recently created recipients appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your recipients. The recipients are returned sorted by creation date, with the most recently created recipients appearing first.</p>",
         "operationId": "AllTransferRecipients",
         "parameters": [
           {
@@ -16688,7 +16694,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -16889,7 +16895,7 @@
     },
     "/v1/recipients/{id}": {
       "delete": {
-        "description": "\u003Cp\u003EPermanently deletes a recipient. It cannot be undone.\u003C/p\u003E",
+        "description": "<p>Permanently deletes a recipient. It cannot be undone.</p>",
         "operationId": "TransferRecipientDelete",
         "parameters": [
           {
@@ -16916,7 +16922,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing recipient. You need only supply the unique recipient identifier that was returned upon recipient creation.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing recipient. You need only supply the unique recipient identifier that was returned upon recipient creation.</p>",
         "operationId": "RetrieveTransferRecipient",
         "parameters": [
           {
@@ -17162,7 +17168,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -17410,7 +17416,7 @@
     },
     "/v1/refunds": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of all refunds you’ve previously created. The refunds are returned in sorted order, with the most recent refunds appearing first. For convenience, the 10 most recent refunds are always available by default on the charge object.\u003C/p\u003E",
+        "description": "<p>Returns a list of all refunds you’ve previously created. The refunds are returned in sorted order, with the most recent refunds appearing first. For convenience, the 10 most recent refunds are always available by default on the charge object.</p>",
         "operationId": "AllRefunds",
         "parameters": [
           {
@@ -17462,7 +17468,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -17590,7 +17596,7 @@
     },
     "/v1/refunds/{refund}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing refund.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing refund.</p>",
         "operationId": "RetrieveRefund",
         "parameters": [
           {
@@ -17617,7 +17623,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specified refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003EThis request only accepts \u003Ccode\u003Emetadata\u003C/code\u003E as an argument.\u003C/p\u003E",
+        "description": "<p>Updates the specified refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request only accepts <code>metadata</code> as an argument.</p>",
         "operationId": "UpdateRefund",
         "parameters": [
           {
@@ -17656,7 +17662,7 @@
     },
     "/v1/skus": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your SKUs. The SKUs are returned sorted by creation date, with the most recently created SKUs appearing first.\u003C/p\u003E",
+        "description": "<p>Returns a list of your SKUs. The SKUs are returned sorted by creation date, with the most recently created SKUs appearing first.</p>",
         "operationId": "AllSKUs",
         "parameters": [
           {
@@ -17736,7 +17742,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -17780,7 +17786,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a new SKU associated with a product.\u003C/p\u003E",
+        "description": "<p>Creates a new SKU associated with a product.</p>",
         "operationId": "CreateSKU",
         "parameters": [
           {
@@ -17805,7 +17811,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) for currency.",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -17895,7 +17901,7 @@
     },
     "/v1/skus/{id}": {
       "delete": {
-        "description": "\u003Cp\u003EDelete a SKU. Deleting a SKU is only possible until it has been used in an order.\u003C/p\u003E",
+        "description": "<p>Delete a SKU. Deleting a SKU is only possible until it has been used in an order.</p>",
         "operationId": "DeleteSKU",
         "parameters": [
           {
@@ -17922,7 +17928,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the details of an existing SKU. Supply the unique SKU identifier from either a SKU creation request or from the product, and Stripe will return the corresponding SKU information.\u003C/p\u003E",
+        "description": "<p>Retrieves the details of an existing SKU. Supply the unique SKU identifier from either a SKU creation request or from the product, and Stripe will return the corresponding SKU information.</p>",
         "operationId": "RetrieveSKU",
         "parameters": [
           {
@@ -17949,7 +17955,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specific SKU by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003ENote that a SKU’s \u003Ccode\u003Eattributes\u003C/code\u003E are not editable. Instead, you would need to deactivate the existing SKU and create a new one with the new attribute values.\u003C/p\u003E",
+        "description": "<p>Updates the specific SKU by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>Note that a SKU’s <code>attributes</code> are not editable. Instead, you would need to deactivate the existing SKU and create a new one with the new attribute values.</p>",
         "operationId": "UpdateSKU",
         "parameters": [
           {
@@ -17974,7 +17980,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support) for currency.",
+                  "description": "Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1), in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).",
                   "title": "currency",
                   "type": [
                     "string"
@@ -18051,7 +18057,7 @@
     },
     "/v1/sources": {
       "post": {
-        "description": "\u003Cp\u003ECreates a new source object.\u003C/p\u003E",
+        "description": "<p>Creates a new source object.</p>",
         "operationId": "CreateSource",
         "parameters": [
           {
@@ -18061,13 +18067,6 @@
             "required": false,
             "schema": {
               "properties": {
-                "alipay": {
-                  "description": "",
-                  "title": "alipay",
-                  "type": [
-                    "object"
-                  ]
-                },
                 "amount": {
                   "description": "Amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single-use` sources.",
                   "title": "amount",
@@ -18076,7 +18075,7 @@
                   ]
                 },
                 "currency": {
-                  "description": "The currency associated with the source. This is the currency for which the source will be chargeable once ready.",
+                  "description": "Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support) associated with the source. This is the currency for which the source will be chargeable once ready.",
                   "title": "currency",
                   "type": [
                     "string"
@@ -18156,7 +18155,7 @@
     },
     "/v1/sources/{source}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves an existing source object. Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.\u003C/p\u003E",
+        "description": "<p>Retrieves an existing source object. Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.</p>",
         "operationId": "RetrieveSource",
         "parameters": [
           {
@@ -18190,7 +18189,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003EThis request accepts only the \u003Ccode\u003Emetadata\u003C/code\u003E and \u003Ccode\u003Eowner\u003C/code\u003E as arguments.\u003C/p\u003E",
+        "description": "<p>Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>metadata</code> and <code>owner</code> as arguments.</p>",
         "operationId": "SourceUpdate",
         "parameters": [
           {
@@ -18285,7 +18284,7 @@
     },
     "/v1/subscription_items": {
       "get": {
-        "description": "\u003Cp\u003EReturns a list of your subscription items for a given subscription.\u003C/p\u003E",
+        "description": "<p>Returns a list of your subscription items for a given subscription.</p>",
         "operationId": "AllSubscriptionItems",
         "parameters": [
           {
@@ -18337,7 +18336,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -18381,7 +18380,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EAdds a new item to an existing subscription. No existing items will be changed or replaced.\u003C/p\u003E",
+        "description": "<p>Adds a new item to an existing subscription. No existing items will be changed or replaced.</p>",
         "operationId": "CreateSubscriptionItem",
         "parameters": [
           {
@@ -18452,7 +18451,7 @@
     },
     "/v1/subscription_items/{item}": {
       "delete": {
-        "description": "\u003Cp\u003EDeletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.\u003C/p\u003E",
+        "description": "<p>Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.</p>",
         "operationId": "DeleteSubscriptionItem",
         "parameters": [
           {
@@ -18503,7 +18502,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the invoice item with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the invoice item with the given ID.</p>",
         "operationId": "RetrieveSubscriptionItem",
         "parameters": [
           {
@@ -18530,7 +18529,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the plan or quantity of an item on a current subscription.\u003C/p\u003E",
+        "description": "<p>Updates the plan or quantity of an item on a current subscription.</p>",
         "operationId": "UpdateSubscriptionItem",
         "parameters": [
           {
@@ -18597,7 +18596,7 @@
     },
     "/v1/subscriptions": {
       "get": {
-        "description": "\u003Cp\u003EBy default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify \u003Ccode\u003Estatus=canceled\u003C/code\u003E.\u003C/p\u003E",
+        "description": "<p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p>",
         "operationId": "AllSubscriptions",
         "parameters": [
           {
@@ -18670,7 +18669,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -18714,7 +18713,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003ECreates a new subscription on an existing customer.\u003C/p\u003E",
+        "description": "<p>Creates a new subscription on an existing customer.</p>",
         "operationId": "CreateSubscription",
         "parameters": [
           {
@@ -18732,7 +18731,7 @@
                   ]
                 },
                 "application_fee_percent": {
-                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation]('https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).",
                   "title": "application_fee_percent",
                   "type": [
                     "number"
@@ -18802,7 +18801,7 @@
                   ]
                 },
                 "quantity": {
-                  "description": "The quantity you'd like to apply to the subscription you're creating. For example, if your plan is \u003Ccurrency\u003E10\u003C/currency\u003E/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged \u003Ccurrency\u003E50\u003C/currency\u003E (5 x \u003Ccurrency\u003E10\u003C/currency\u003E) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
+                  "description": "The quantity you'd like to apply to the subscription you're creating. For example, if your plan is <currency>10</currency>/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged <currency>50</currency> (5 x <currency>10</currency>) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
                   "title": "quantity",
                   "type": [
                     "integer"
@@ -18816,7 +18815,7 @@
                   ]
                 },
                 "source": {
-                  "description": "The source can either be a token, like the ones returned by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card) to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
+                  "description": "The source can either be a token, like the ones returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
                   "title": "source",
                   "type": [
                     "object",
@@ -18870,7 +18869,7 @@
     },
     "/v1/subscriptions/{subscription_exposed_id}": {
       "delete": {
-        "description": "\u003Cp\u003ECancels a customer’s subscription. If you set the \u003Ccode\u003Eat_period_end\u003C/code\u003E parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually \u003Ca href=\"#delete_invoiceitem\"\u003Edeleted\u003C/a\u003E. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.\u003C/p\u003E\n\n\u003Cp\u003EBy default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.\u003C/p\u003E",
+        "description": "<p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually <a href=\"#delete_invoiceitem\">deleted</a>. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.</p><p>By default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.</p>",
         "operationId": "DeleteCustomerSubscription",
         "parameters": [
           {
@@ -18907,7 +18906,7 @@
         }
       },
       "get": {
-        "description": "\u003Cp\u003ERetrieves the subscription with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the subscription with the given ID.</p>",
         "operationId": "RetrieveCustomerSubscription",
         "parameters": [
 
@@ -18928,7 +18927,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the \u003Ca href=\"#upcoming_invoice\"\u003Eupcoming invoice\u003C/a\u003E endpoint.\u003C/p\u003E",
+        "description": "<p>Updates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the <a href=\"#upcoming_invoice\">upcoming invoice</a> endpoint.</p>",
         "operationId": "UpdateCustomerSubscription",
         "parameters": [
           {
@@ -18946,7 +18945,7 @@
                   ]
                 },
                 "application_fee_percent": {
-                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).",
+                  "description": "A non-negative decimal (with at most two decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions')}).",
                   "title": "application_fee_percent",
                   "type": [
                     "number"
@@ -19023,7 +19022,7 @@
                   ]
                 },
                 "quantity": {
-                  "description": "The quantity you'd like to apply to the subscription you're updating. For example, if your plan is \u003Ccurrency\u003E10\u003C/currency\u003E/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged \u003Ccurrency\u003E50\u003C/currency\u003E (5 x \u003Ccurrency\u003E10\u003C/currency\u003E) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
+                  "description": "The quantity you'd like to apply to the subscription you're updating. For example, if your plan is <currency>10</currency>/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged <currency>50</currency> (5 x <currency>10</currency>) monthly. If you update a subscription but don't change the plan ID (e.g. changing only the trial_end), the subscription will inherit the old subscription's quantity attribute unless you pass a new quantity parameter. If you update a subscription and change the plan ID, the new subscription will not inherit the quantity attribute and will default to 1 unless you pass a quantity parameter.",
                   "title": "quantity",
                   "type": [
                     "integer"
@@ -19037,7 +19036,7 @@
                   ]
                 },
                 "source": {
-                  "description": "The source can either be a token, like the ones returned by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card) to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
+                  "description": "The source can either be a token, like the ones returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source to use with subscriptions, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.",
                   "title": "source",
                   "type": [
                     "object",
@@ -19081,7 +19080,7 @@
     },
     "/v1/subscriptions/{subscription_exposed_id}/discount": {
       "delete": {
-        "description": "\u003Cp\u003ERemoves the currently applied discount on a customer.\u003C/p\u003E",
+        "description": "<p>Removes the currently applied discount on a customer.</p>",
         "operationId": "DeleteCustomerDiscount",
         "parameters": [
 
@@ -19158,7 +19157,7 @@
     },
     "/v1/tokens/{token}": {
       "get": {
-        "description": "\u003Cp\u003ERetrieves the token with the given ID.\u003C/p\u003E",
+        "description": "<p>Retrieves the token with the given ID.</p>",
         "operationId": "RetrieveToken",
         "parameters": [
           {
@@ -19267,7 +19266,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -19353,6 +19352,13 @@
                 "source_transaction": {
                   "description": "",
                   "title": "source_transaction",
+                  "type": [
+                    "string"
+                  ]
+                },
+                "source_type": {
+                  "description": "",
+                  "title": "source_type",
                   "type": [
                     "string"
                   ]
@@ -19492,7 +19498,7 @@
     },
     "/v1/transfers/{id}/reversals": {
       "get": {
-        "description": "\u003Cp\u003EYou can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the \u003Ccode\u003Elimit\u003C/code\u003E and \u003Ccode\u003Estarting_after\u003C/code\u003E parameters to page through additional reversals.\u003C/p\u003E",
+        "description": "<p>You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional reversals.</p>",
         "operationId": "AllTransferReversals",
         "parameters": [
           {
@@ -19544,7 +19550,7 @@
                   ]
                 },
                 "object": {
-                  "description": "The type of object. Always has the value \"list\".",
+                  "description": "String representing the object's type. Objects of the same type share the same value. Always has the value \"list\".",
                   "enum": [
                     "list"
                   ],
@@ -19653,7 +19659,7 @@
     },
     "/v1/transfers/{transfer}/reversals/{id}": {
       "get": {
-        "description": "\u003Cp\u003EBy default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.\u003C/p\u003E",
+        "description": "<p>By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.</p>",
         "operationId": "RetrieveTransferReversal",
         "parameters": [
           {
@@ -19687,7 +19693,7 @@
         }
       },
       "post": {
-        "description": "\u003Cp\u003EUpdates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.\u003C/p\u003E\n\n\u003Cp\u003EThis request only accepts metadata and description as arguments.\u003C/p\u003E",
+        "description": "<p>Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request only accepts metadata and description as arguments.</p>",
         "operationId": "UpdateTransferReversal",
         "parameters": [
           {

--- a/openapi/spec2.yaml
+++ b/openapi/spec2.yaml
@@ -63,7 +63,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -86,7 +87,7 @@ definitions:
         type:
         - object
       id:
-        description: A unique identifier for the account.
+        description: Unique identifier for the object.
         type:
         - string
       legal_entity:
@@ -101,13 +102,14 @@ definitions:
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to an account object.
-          It can be useful for storing additional information about the account in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       orders:
@@ -132,8 +134,9 @@ definitions:
         type:
         - string
       timezone:
-        description: The timezone used in the Stripe dashboard for this account. A
-          list of possible timezone values is maintained at the [IANA Timezone Database](http://www.iana.org/time-zones).
+        description: The time zone used in the Stripe dashboard for this account.
+          A list of possible time zone values is maintained at the [IANA Time Zone
+          Database](http://www.iana.org/time-zones).
         type:
         - string
       tos_acceptance:
@@ -305,7 +308,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -328,7 +332,7 @@ definitions:
         type:
         - object
       id:
-        description: A unique identifier for the account.
+        description: Unique identifier for the object.
         type:
         - string
       keys:
@@ -347,13 +351,14 @@ definitions:
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to an account object.
-          It can be useful for storing additional information about the account in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       orders:
@@ -378,8 +383,9 @@ definitions:
         type:
         - string
       timezone:
-        description: The timezone used in the Stripe dashboard for this account. A
-          list of possible timezone values is maintained at the [IANA Timezone Database](http://www.iana.org/time-zones).
+        description: The time zone used in the Stripe dashboard for this account.
+          A list of possible time zone values is maintained at the [IANA Time Zone
+          Database](http://www.iana.org/time-zones).
         type:
         - string
       tos_acceptance:
@@ -455,7 +461,8 @@ definitions:
   alipay_account:
     properties:
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       customer:
@@ -468,21 +475,23 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a customer object.
-          It can be useful for storing additional information about the customer in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       payment_amount:
@@ -526,7 +535,8 @@ definitions:
   apple_pay_domain:
     properties:
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       domain_name:
@@ -534,15 +544,17 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
     required:
@@ -590,11 +602,13 @@ definitions:
         type:
         - array
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       pending:
@@ -624,15 +638,18 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       fee:
@@ -642,7 +659,7 @@ definitions:
       fee_details:
         "$ref": "#/definitions/fee"
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       net:
@@ -650,7 +667,8 @@ definitions:
         type:
         - integer
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       source:
@@ -735,8 +753,8 @@ definitions:
         type:
         - string
       currency:
-        description: Three-letter ISO currency code representing the currency paid
-          out to the bank account.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          paid out to the bank account.
         type:
         - string
       customer:
@@ -758,7 +776,7 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       last4:
@@ -766,13 +784,14 @@ definitions:
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to a bank account
-          object. It can be useful for storing additional information about the bank
-          account in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reusable:
@@ -844,12 +863,13 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO currency code representing the currency to which
-          the bitcoin will be converted.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          to which the bitcoin will be converted.
         type:
         - string
       customer:
@@ -857,7 +877,8 @@ definitions:
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       email:
@@ -871,7 +892,7 @@ definitions:
         type:
         - boolean
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       inbound_address:
@@ -880,17 +901,19 @@ definitions:
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a customer object.
-          It can be useful for storing additional information about the customer in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       payment:
@@ -899,8 +922,7 @@ definitions:
         type:
         - string
       refund_address:
-        description: The refund address for these bitcoin, if communicated by the
-          customer.
+        description: ''
         type:
         - string
       transactions:
@@ -916,7 +938,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -980,19 +1003,22 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: The currency to which this transaction was converted.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          to which this transaction was converted.
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       receiver:
@@ -1019,7 +1045,7 @@ definitions:
         type:
         - string
       address_city:
-        description: ''
+        description: City/District/Suburb/Town/Village.
         type:
         - string
       address_country:
@@ -1027,7 +1053,7 @@ definitions:
         type:
         - string
       address_line1:
-        description: ''
+        description: Address line 1 (Street address/PO Box/Company name).
         type:
         - string
       address_line1_check:
@@ -1036,15 +1062,15 @@ definitions:
         type:
         - string
       address_line2:
-        description: ''
+        description: Address line 2 (Apartment/Suite/Unit/Building).
         type:
         - string
       address_state:
-        description: ''
+        description: State/County/Province/Region.
         type:
         - string
       address_zip:
-        description: ''
+        description: Zip/Postal Code.
         type:
         - string
       address_zip_check:
@@ -1070,8 +1096,9 @@ definitions:
         type:
         - string
       currency:
-        description: Only applicable on accounts (not customers or recipients). The
-          card can be used as a transfer destination for funds in this currency.
+        description: Three-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
+          Only applicable on accounts (not customers or recipients). The card can
+          be used as a transfer destination for funds in this currency.
         type:
         - string
       customer:
@@ -1100,11 +1127,11 @@ definitions:
         type:
         - string
       exp_month:
-        description: ''
+        description: Two digit number representing the card's expiration month.
         type:
         - integer
       exp_year:
-        description: ''
+        description: Four digit number representing the card's expiration year.
         type:
         - integer
       fingerprint:
@@ -1122,18 +1149,17 @@ definitions:
         type:
         - string
       id:
-        description: ID of card (used in conjunction with a customer or recipient
-          ID).
+        description: Unique identifier for the object.
         type:
         - string
       last4:
-        description: ''
+        description: The last 4 digits of the card.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to a card object.
-          It can be useful for storing additional information about the card in a
-          structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       name:
@@ -1141,7 +1167,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       recipient:
@@ -1223,12 +1250,13 @@ definitions:
       card:
         "$ref": "#/definitions/card"
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO currency code representing the currency in which
-          the charge was made.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       customer:
@@ -1236,7 +1264,8 @@ definitions:
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       destination:
@@ -1267,7 +1296,7 @@ definitions:
         type:
         - object
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       invoice:
@@ -1275,17 +1304,19 @@ definitions:
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a charge object.
-          It can be useful for storing additional information about the charge in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       on_behalf_of:
@@ -1333,7 +1364,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1459,11 +1491,13 @@ definitions:
         type:
         - string
       id:
-        description: The ISO Country code for this country.
+        description: Unique identifier for the object. Represented as the ISO country
+          code for this country.
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       supported_bank_account_currencies:
@@ -1510,12 +1544,14 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: If `amount_off` has been set, the currency of the amount to take
-          off.
+        description: If `amount_off` has been set, the three-letter [ISO code for
+          the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          of the amount to take off.
         type:
         - string
       duration:
@@ -1529,11 +1565,12 @@ definitions:
         type:
         - integer
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       max_redemptions:
@@ -1542,13 +1579,14 @@ definitions:
         type:
         - integer
       metadata:
-        description: A set of key/value pairs that you can attach to a coupon object.
-          It can be useful for storing additional information about the coupon in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       percent_off:
@@ -1608,7 +1646,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1643,7 +1682,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1682,7 +1722,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1705,12 +1746,13 @@ definitions:
         type:
         - object
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: The currency the customer can be charged in for recurring billing
-          purposes.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          the customer can be charged in for recurring billing purposes.
         type:
         - string
       default_bank_account:
@@ -1731,31 +1773,34 @@ definitions:
         type:
         - boolean
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       discount:
         "$ref": "#/definitions/discount"
       email:
-        description: ''
+        description: The customer's email address.
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a customer object.
-          It can be useful for storing additional information about the customer in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       shipping:
@@ -1774,7 +1819,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1809,7 +1855,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -1871,17 +1918,18 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to a bank account
-          object. It can be useful for storing additional information about the bank
-          account in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
     required:
@@ -1933,7 +1981,8 @@ definitions:
         type:
         - integer
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       start:
@@ -1968,12 +2017,13 @@ definitions:
         type:
         - string
       created:
-        description: Date dispute was opened.
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO currency code representing the currency of the
-          amount that was disputed.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       evidence:
@@ -1986,7 +2036,7 @@ definitions:
         type:
         - object
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       is_charge_refundable:
@@ -1996,17 +2046,19 @@ definitions:
         type:
         - boolean
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a dispute object.
-          It can be useful for storing additional information about the dispute in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reason:
@@ -2092,21 +2144,24 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       data:
         "$ref": "#/definitions/event_data"
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       pending_webhooks:
@@ -2142,8 +2197,9 @@ definitions:
   event_data:
     properties:
       object:
-        description: describes the object the event is about. For example, an `invoice.created`
-          event will have a full invoice object as the value of the object key.
+        description: Static string describing the type of the object described by
+          this change. For example, an `invoice.created` event will have a full invoice
+          object as the value of the object key.
         type:
         - object
       previous_attributes:
@@ -2189,8 +2245,8 @@ definitions:
         type:
         - string
       currency:
-        description: Three-letter ISO currency code representing the currency paid
-          out to the bank account.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          paid out to the bank account.
         type:
         - string
       customer:
@@ -2208,7 +2264,7 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       last4:
@@ -2216,13 +2272,14 @@ definitions:
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to a bank account
-          object. It can be useful for storing additional information about the bank
-          account in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
     required:
@@ -2238,7 +2295,7 @@ definitions:
   fee:
     properties:
       amount:
-        description: ''
+        description: Amount of the fee, in cents.
         type:
         - integer
       application:
@@ -2246,11 +2303,13 @@ definitions:
         type:
         - string
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       type:
@@ -2278,11 +2337,13 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO code representing the currency.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       fee:
@@ -2290,16 +2351,18 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to the object. It
-          can be useful for storing additional information in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
     required:
@@ -2388,7 +2451,8 @@ definitions:
         type:
         - boolean
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       customer:
@@ -2396,11 +2460,13 @@ definitions:
         type:
         - string
       date:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       discount:
@@ -2421,7 +2487,7 @@ definitions:
         type:
         - boolean
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       lines:
@@ -2437,7 +2503,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -2460,13 +2527,14 @@ definitions:
         type:
         - object
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to an invoice object.
-          It can be useful for storing additional information about the invoice in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       next_payment_attempt:
@@ -2479,7 +2547,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       paid:
@@ -2577,15 +2646,17 @@ definitions:
   invoice_item:
     properties:
       amount:
-        description: ''
+        description: Amount (in the `currency` specified) of the invoice item.
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       customer:
-        description: ''
+        description: The ID of the customer who will be billed when this invoice item
+          is billed.
         type:
         - string
       date:
@@ -2593,7 +2664,8 @@ definitions:
         type:
         - integer
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       discountable:
@@ -2602,25 +2674,27 @@ definitions:
         type:
         - boolean
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       invoice:
-        description: ''
+        description: The ID of the invoice this invoice item belongs to.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to an invoice item
-          object. It can be useful for storing additional information about the invoice
-          item in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       period:
@@ -2670,12 +2744,13 @@ definitions:
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
-        description: A text description of the line item, if the line item is an invoice
-          item.
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       discountable:
@@ -2684,8 +2759,7 @@ definitions:
         type:
         - boolean
       id:
-        description: The ID of the source of this line item, either an invoice item
-          or a subscription.
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
@@ -2693,12 +2767,14 @@ definitions:
         type:
         - boolean
       metadata:
-        description: Key-value pairs attached to object that underlies this line item
-          (either subscription or invoice item).
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: The type of object. Always has the value "line_item".
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       period:
@@ -2771,11 +2847,13 @@ definitions:
         type:
         - string
       created:
-        description: Time that this record of the transfer was first created.
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       date:
@@ -2809,7 +2887,7 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       legacy_date:
@@ -2817,13 +2895,14 @@ definitions:
         type:
         - integer
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a transfer object.
-          It can be useful for storing additional information about the transfer in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       method:
@@ -2834,7 +2913,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reversals:
@@ -2850,7 +2930,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -3203,12 +3284,13 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          representing the currency in which the order was made.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       customer:
@@ -3224,23 +3306,25 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       items:
         "$ref": "#/definitions/order_item"
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to an order object.
-          It can be useful for storing additional information about the order in a
-          structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       returns:
@@ -3256,7 +3340,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -3328,8 +3413,8 @@ definitions:
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          representing the currency of the line item.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
@@ -3338,7 +3423,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       parent:
@@ -3391,26 +3477,29 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          representing the currency of the return.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       items:
         "$ref": "#/definitions/order_item"
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       order:
@@ -3467,15 +3556,17 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Currency in which subscription will be charged.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       interval:
@@ -3490,13 +3581,14 @@ definitions:
         type:
         - integer
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a plan object.
-          It can be useful for storing additional information about the plan in a
-          structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       name:
@@ -3504,7 +3596,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       statement_descriptor:
@@ -3561,23 +3654,27 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO code representing the currency of the charge.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       originating_transaction:
@@ -3603,7 +3700,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -3660,7 +3758,8 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       deactivate_on:
@@ -3673,7 +3772,7 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       images:
@@ -3682,13 +3781,14 @@ definitions:
         type:
         - array
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a product object.
-          It can be useful for storing additional information about the product in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       name:
@@ -3696,7 +3796,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       package_dimensions:
@@ -3718,7 +3819,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -3780,28 +3882,33 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO code representing the currency.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to the object. It
-          can be useful for storing additional information in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reason:
@@ -3903,19 +4010,19 @@ definitions:
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          representing the currency of the line item.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       delivery_estimate:
         "$ref": "#/definitions/delivery_estimate"
       description:
-        description: Description of the line item, meant to be displayable to the
-          user (e.g., `"Express shipping"`).
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
     required:
@@ -3934,12 +4041,13 @@ definitions:
         type:
         - integer
       currency:
-        description: Currency in which shipping cost will be assessed. Present when
-          `type` is `flat_rate`.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          in which shipping cost will be assessed. Present when `type` is `flat_rate`.
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       free_above:
@@ -3985,13 +4093,13 @@ definitions:
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          representing the currency of the line item.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       description:
-        description: Description of the line item, meant to be displayable to the
-          user (e.g., `"Express shipping"`).
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
     required:
@@ -4016,16 +4124,17 @@ definitions:
         type:
         - object
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-          for currency.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       image:
@@ -4036,17 +4145,19 @@ definitions:
       inventory:
         "$ref": "#/definitions/inventory"
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a SKU object.
-          It can be useful for storing additional information about the SKU in a structured
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
           format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       package_dimensions:
@@ -4098,13 +4209,14 @@ definitions:
       code_verification:
         "$ref": "#/definitions/source_code_verification_flow"
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: The currency associated with the source. This is the currency
-          for which the source will be chargeable once ready. Required for `single-use`
-          sources.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          associated with the source. This is the currency for which the source will
+          be chargeable once ready. Required for `single-use` sources.
         type:
         - string
       flow:
@@ -4113,21 +4225,23 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a source object.
-          It can be useful for storing additional information about the source in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       owner:
@@ -4335,7 +4449,8 @@ definitions:
         type:
         - integer
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       current_period_end:
@@ -4366,7 +4481,7 @@ definitions:
         type:
         - integer
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       items:
@@ -4382,7 +4497,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -4405,7 +4521,8 @@ definitions:
         type:
         - object
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       max_occurrences:
@@ -4413,13 +4530,14 @@ definitions:
         type:
         - integer
       metadata:
-        description: A set of key/value pairs that you can attach to a subscription
-          object. It can be useful for storing additional information about the subscription
-          in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       on_behalf_of:
@@ -4488,15 +4606,17 @@ definitions:
   subscription_item:
     properties:
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       plan:
@@ -4519,7 +4639,8 @@ definitions:
   tax_settings:
     properties:
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       provider:
@@ -4559,23 +4680,27 @@ definitions:
       card:
         "$ref": "#/definitions/card"
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       redirect_url:
@@ -4618,19 +4743,22 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       type:
@@ -4703,8 +4831,8 @@ definitions:
         type:
         - string
       currency:
-        description: Three-letter ISO currency code representing the currency paid
-          out to the bank account.
+        description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+          paid out to the bank account.
         type:
         - string
       fingerprint:
@@ -4713,7 +4841,7 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       last4:
@@ -4721,7 +4849,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reusable:
@@ -4763,7 +4892,7 @@ definitions:
   token_card:
     properties:
       address_city:
-        description: ''
+        description: City/District/Suburb/Town/Village.
         type:
         - string
       address_country:
@@ -4771,7 +4900,7 @@ definitions:
         type:
         - string
       address_line1:
-        description: ''
+        description: Address line 1 (Street address/PO Box/Company name).
         type:
         - string
       address_line1_check:
@@ -4780,15 +4909,15 @@ definitions:
         type:
         - string
       address_line2:
-        description: ''
+        description: Address line 2 (Apartment/Suite/Unit/Building).
         type:
         - string
       address_state:
-        description: ''
+        description: State/County/Province/Region.
         type:
         - string
       address_zip:
-        description: ''
+        description: Zip/Postal Code.
         type:
         - string
       address_zip_check:
@@ -4808,7 +4937,8 @@ definitions:
         type:
         - string
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       cvc_check:
@@ -4822,11 +4952,11 @@ definitions:
         type:
         - string
       exp_month:
-        description: ''
+        description: Two digit number representing the card's expiration month.
         type:
         - integer
       exp_year:
-        description: ''
+        description: Four digit number representing the card's expiration year.
         type:
         - integer
       fingerprint:
@@ -4844,18 +4974,17 @@ definitions:
         type:
         - string
       id:
-        description: ID of card (used in conjunction with a customer or recipient
-          ID).
+        description: Unique identifier for the object.
         type:
         - string
       last4:
-        description: ''
+        description: The last 4 digits of the card.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to a card object.
-          It can be useful for storing additional information about the card in a
-          structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       name:
@@ -4863,7 +4992,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       three_d_secure:
@@ -4903,11 +5033,13 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       destination:
@@ -4919,19 +5051,23 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: ''
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       reversals:
@@ -4947,7 +5083,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -4973,6 +5110,10 @@ definitions:
         description: ''
         type:
         - boolean
+      source_type:
+        description: ''
+        type:
+        - string
       transfer_group:
         description: ''
         type:
@@ -5009,7 +5150,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -5032,7 +5174,8 @@ definitions:
         type:
         - object
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       default_card:
@@ -5040,7 +5183,8 @@ definitions:
         type:
         - string
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       email:
@@ -5048,17 +5192,18 @@ definitions:
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to a recipient object.
-          It can be useful for storing additional information about the recipient
-          in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       migrated_to:
@@ -5072,7 +5217,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       tin:
@@ -5111,24 +5257,28 @@ definitions:
         type:
         - string
       created:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       currency:
-        description: Three-letter ISO code representing the currency.
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       id:
-        description: ''
+        description: Unique identifier for the object.
         type:
         - string
       metadata:
-        description: A set of key/value pairs that you can attach to the object. It
-          can be useful for storing additional information in a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       transfer:
@@ -5277,7 +5427,8 @@ definitions:
         type:
         - boolean
       currency:
-        description: ''
+        description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+          in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
         type:
         - string
       customer:
@@ -5285,11 +5436,13 @@ definitions:
         type:
         - string
       date:
-        description: ''
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
         type:
         - integer
       description:
-        description: ''
+        description: An arbitrary string attached to the object. Often useful for
+          displaying to users.
         type:
         - string
       discount:
@@ -5322,7 +5475,8 @@ definitions:
             type:
             - boolean
           object:
-            description: The type of object. Always has the value "list".
+            description: String representing the object's type. Objects of the same
+              type share the same value. Always has the value "list".
             enum:
             - list
             type:
@@ -5345,13 +5499,14 @@ definitions:
         type:
         - object
       livemode:
-        description: ''
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
         type:
         - boolean
       metadata:
-        description: A set of key/value pairs that you can attach to an invoice object.
-          It can be useful for storing additional information about the invoice in
-          a structured format.
+        description: Set of key/value pairs that you can attach to an object. It can
+          be useful for storing additional information about the object in a structured
+          format.
         type:
         - object
       next_payment_attempt:
@@ -5364,7 +5519,8 @@ definitions:
         type:
         - string
       object:
-        description: ''
+        description: String representing the object's type. Objects of the same type
+          share the same value.
         type:
         - string
       paid:
@@ -5494,8 +5650,8 @@ paths:
               type:
               - string
             currency:
-              description: Currency of the charge that you will create when authentication
-                completes.
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -5544,12 +5700,12 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/account":
     delete:
-      description: |-
-        <p>With <a href="/docs/connect">Connect</a>, you may delete Stripe accounts you manage.</p>
-
-        <p>Managed accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.</p>
-
-        <p>If you are looking to close your own account, use the <a href="http://dashboard:6090/account/data">data tab in your account settings</a> instead.</p>
+      description: <p>With <a href="/docs/connect">Connect</a>, you may delete Stripe
+        accounts you manage.</p><p>Managed accounts created using test-mode keys can
+        be deleted at any time. Managed accounts created using live-mode keys may
+        only be deleted once all balances are zero.</p><p>If you are looking to close
+        your own account, use the <a href="https://dashboard.stripe.com/account/data">data
+        tab in your account settings</a> instead.</p>
       operationId: AccountDelete
       parameters:
       - description: Body parameters for the request.
@@ -5593,10 +5749,12 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p><strong>You may only update accounts that you <a href="/docs/connect/managed-accounts">manage</a></strong>. To update your own account, you can currently only do so via the <a href="http://dashboard:6090/account">dashboard</a>. For more information on updating Managed Accounts, see <a href="/docs/connect/updating-accounts">our guide</a>.</p>
+      description: <p>Updates an account by setting the values of the parameters passed.
+        Any parameters not provided will be left unchanged.</p><p><strong>You may
+        only update accounts that you <a href="/docs/connect/managed-accounts">manage</a></strong>.
+        To update your own account, you can currently only do so via the <a href="https://dashboard.stripe.com/account">dashboard</a>.
+        For more information on updating Managed Accounts, see <a href="/docs/connect/updating-accounts">our
+        guide</a>.</p>
       operationId: AccountUpdate
       parameters:
       - description: Body parameters for the request.
@@ -5630,7 +5788,7 @@ paths:
             debit_negative_balances:
               description: A boolean for whether or not Stripe should try to reclaim
                 negative balances from the account holder's bank account. See our
-                [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances)
+                [managed account bank transfer guide](/docs/connect/account-balances)
                 for more information.
               title: debit_negative_balances
               type:
@@ -5644,7 +5802,7 @@ paths:
             default_currency:
               description: Three-letter ISO currency code representing the default
                 currency for the account. This must be a currency that [Stripe supports
-                in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).
+                in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: default_currency
               type:
               - string
@@ -5726,7 +5884,7 @@ paths:
               - string
             tos_acceptance:
               description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance)
+                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance)
                 for more information.
               title: tos_acceptance
               type:
@@ -5899,7 +6057,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -6069,7 +6228,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -6136,7 +6296,7 @@ paths:
             debit_negative_balances:
               description: A boolean for whether or not Stripe should try to reclaim
                 negative balances from the account holder's bank account. See our
-                [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances)
+                [managed account bank transfer guide](/docs/connect/account-balances)
                 for more information.
               title: debit_negative_balances
               type:
@@ -6150,7 +6310,7 @@ paths:
             default_currency:
               description: Three-letter ISO currency code representing the default
                 currency for the account. This must be a currency that [Stripe supports
-                in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).
+                in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: default_currency
               type:
               - string
@@ -6242,7 +6402,7 @@ paths:
               - string
             tos_acceptance:
               description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance)
+                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance)
                 for more information.
               title: tos_acceptance
               type:
@@ -6273,12 +6433,12 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/accounts/{account}":
     delete:
-      description: |-
-        <p>With <a href="/docs/connect">Connect</a>, you may delete Stripe accounts you manage.</p>
-
-        <p>Managed accounts created using test-mode keys can be deleted at any time. Managed accounts created using live-mode keys may only be deleted once all balances are zero.</p>
-
-        <p>If you are looking to close your own account, use the <a href="http://dashboard:6090/account/data">data tab in your account settings</a> instead.</p>
+      description: <p>With <a href="/docs/connect">Connect</a>, you may delete Stripe
+        accounts you manage.</p><p>Managed accounts created using test-mode keys can
+        be deleted at any time. Managed accounts created using live-mode keys may
+        only be deleted once all balances are zero.</p><p>If you are looking to close
+        your own account, use the <a href="https://dashboard.stripe.com/account/data">data
+        tab in your account settings</a> instead.</p>
       operationId: AccountDelete
       parameters:
       - description: The identifier of the account to be deleted. If none is provided,
@@ -6316,10 +6476,12 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates an account by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p><strong>You may only update accounts that you <a href="/docs/connect/managed-accounts">manage</a></strong>. To update your own account, you can currently only do so via the <a href="http://dashboard:6090/account">dashboard</a>. For more information on updating Managed Accounts, see <a href="/docs/connect/updating-accounts">our guide</a>.</p>
+      description: <p>Updates an account by setting the values of the parameters passed.
+        Any parameters not provided will be left unchanged.</p><p><strong>You may
+        only update accounts that you <a href="/docs/connect/managed-accounts">manage</a></strong>.
+        To update your own account, you can currently only do so via the <a href="https://dashboard.stripe.com/account">dashboard</a>.
+        For more information on updating Managed Accounts, see <a href="/docs/connect/updating-accounts">our
+        guide</a>.</p>
       operationId: AccountUpdate
       parameters:
       - description: Body parameters for the request.
@@ -6353,7 +6515,7 @@ paths:
             debit_negative_balances:
               description: A boolean for whether or not Stripe should try to reclaim
                 negative balances from the account holder's bank account. See our
-                [managed account bank transfer guide](/docs/connect/bank-transfers#negative-balances)
+                [managed account bank transfer guide](/docs/connect/account-balances)
                 for more information.
               title: debit_negative_balances
               type:
@@ -6367,7 +6529,7 @@ paths:
             default_currency:
               description: Three-letter ISO currency code representing the default
                 currency for the account. This must be a currency that [Stripe supports
-                in the account's country](http://127.0.0.1:6041/questions/which-currencies-does-stripe-support).
+                in the account's country](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: default_currency
               type:
               - string
@@ -6449,7 +6611,7 @@ paths:
               - string
             tos_acceptance:
               description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos_acceptance)
+                when they accepted it. See our [updating managed accounts guide](/docs/connect/updating-accounts#tos-acceptance)
                 for more information.
               title: tos_acceptance
               type:
@@ -6622,7 +6784,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -6747,10 +6910,10 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/accounts/{account}/reject":
     post:
-      description: |-
-        <p>With <a href="/docs/connect">Connect</a>, you may flag managed accounts as suspicious.</p>
-
-        <p>Managed accounts created using test-mode keys can be rejected at any time. Managed accounts created using live-mode keys may only be rejected once all balances are zero.</p>
+      description: <p>With <a href="/docs/connect">Connect</a>, you may flag managed
+        accounts as suspicious.</p><p>Managed accounts created using test-mode keys
+        can be rejected at any time. Managed accounts created using live-mode keys
+        may only be rejected once all balances are zero.</p>
       operationId: AccountReject
       parameters:
       - description: The identifier of the account to be rejected.
@@ -6831,7 +6994,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -6980,7 +7144,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7034,10 +7199,9 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>This request only accepts metadata as an argument.</p>
+      description: "<p>Updates the specified application fee refund by setting the
+        values of the parameters passed. Any parameters not provided will be left
+        unchanged.</p><p>This request only accepts metadata as an argument.</p>"
       operationId: UpdatePlatformEarningRefund
       parameters:
       - description: Body parameters for the request.
@@ -7172,7 +7336,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7333,7 +7498,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7507,7 +7673,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7552,8 +7719,9 @@ paths:
               type:
               - integer
             currency:
-              description: The currency to which the bitcoin will be converted. You
-                will be paid out in this currency. Only USD is currently supported.
+              description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+                to which the bitcoin will be converted. You will be paid out in this
+                currency. Only USD is currently supported.
               title: currency
               type:
               - string
@@ -7762,7 +7930,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7845,7 +8014,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -7957,7 +8127,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -8176,10 +8347,10 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>This request accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>, <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>
+      description: "<p>Updates the specified charge by setting the values of the parameters
+        passed. Any parameters not provided will be left unchanged.</p><p>This request
+        accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>,
+        <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>"
       operationId: UpdateCharge
       parameters:
       - description: Body parameters for the request.
@@ -8209,9 +8380,11 @@ paths:
               type:
               - object
             metadata:
-              description: A set of key/value pairs that you can attach to a charge
-                object. It can be useful for storing additional information about
-                the charge in a structured format.
+              description: Set of key/value pairs that you can attach to an object.
+                It can be useful for storing additional information about the object
+                in a structured format. Individual keys can be unset by posting an
+                empty value to them. All keys can be unset by posting an empty value
+                to metadata.
               title: metadata
               type:
               - object
@@ -8247,10 +8420,12 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/charges/{charge}/capture":
     post:
-      description: |-
-        <p>Capture the payment of an existing, uncaptured, charge. This is the second half of the two-step payment flow, where first you <a href="#create_charge">created a charge</a> with the capture option set to false.</p>
-
-        <p>Uncaptured payments expire exactly seven days after they are created. If they are not captured by that point in time, they will be marked as refunded and will no longer be capturable.</p>
+      description: <p>Capture the payment of an existing, uncaptured, charge. This
+        is the second half of the two-step payment flow, where first you <a href="#create_charge">created
+        a charge</a> with the capture option set to false.</p><p>Uncaptured payments
+        expire exactly seven days after they are created. If they are not captured
+        by that point in time, they will be marked as refunded and will no longer
+        be capturable.</p>
       operationId: ChargeCapture
       parameters:
       - description: ''
@@ -8501,7 +8676,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -8681,7 +8857,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -8780,7 +8957,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -8808,10 +8986,17 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>You can create coupons easily via the <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.</p>
-
-        <p>A coupon has either a <code>percent_off</code> or an <code>amount_off</code> and <code>currency</code>. If you set an <code>amount_off</code>, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of <currency>100</currency> will have a final total of <currency>0</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it and an invoice with a subtotal of <currency>300</currency> will have a final total of <currency>100</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it.</p>
+      description: <p>You can create coupons easily via the <a href="https://dashboard.stripe.com/coupons">coupon
+        management</a> page of the Stripe dashboard. Coupon creation is also accessible
+        via the API if you need to create coupons on the fly.</p><p>A coupon has either
+        a <code>percent_off</code> or an <code>amount_off</code> and <code>currency</code>.
+        If you set an <code>amount_off</code>, that amount will be subtracted from
+        any invoice’s subtotal. For example, an invoice with a subtotal of <currency>100</currency>
+        will have a final total of <currency>0</currency> if a coupon with an <code>amount_off</code>
+        of <amount>200</amount> is applied to it and an invoice with a subtotal of
+        <currency>300</currency> will have a final total of <currency>100</currency>
+        if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied
+        to it.</p>
       operationId: CreateCoupon
       parameters:
       - description: Body parameters for the request.
@@ -8827,8 +9012,8 @@ paths:
               type:
               - integer
             currency:
-              description: Currency of the `amount_off` parameter (required if `amount_off`
-                is passed).
+              description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+                of the `amount_off` parameter (required if `amount_off` is passed).
               title: currency
               type:
               - string
@@ -8894,7 +9079,7 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/coupons/{coupon}":
     delete:
-      description: <p>You can delete coupons via the <a href="http://dashboard:6090/coupons">coupon
+      description: <p>You can delete coupons via the <a href="https://dashboard.stripe.com/coupons">coupon
         management</a> page of the Stripe dashboard. However, deleting a coupon does
         not affect any customers who have already applied the coupon; it means that
         new customers can’t redeem the coupon. You can also delete coupons via the
@@ -9021,7 +9206,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -9328,7 +9514,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -9479,7 +9666,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -9758,7 +9946,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -10022,7 +10211,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -10297,7 +10487,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -10349,7 +10540,7 @@ paths:
                 invoice subtotal that will be transferred to the application owner's
                 Stripe account. The request must be made with an OAuth key in order
                 to set an application fee percentage. For more information, see the
-                application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).
+                application fees [documentation]('https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
               title: application_fee_percent
               type:
               - number
@@ -10423,15 +10614,15 @@ paths:
               - boolean
             source:
               description: The source can either be a token, like the ones returned
-                by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary
-                containing a user's credit card details (with the options shown below).
-                You must provide a source if the customer does not already have a
-                valid source attached, and you are subscribing the customer for a
-                plan that is not free. Passing `source` will create a new source object,
-                make it the customer default source, and delete the old customer default
-                if one exists. If you want to add an additional source to use with
-                subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card)
-                to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update
+                by [Elements](https://stripe.com/docs/elements), or a dictionary containing
+                a user's credit card details (with the options shown below). You must
+                provide a source if the customer does not already have a valid source
+                attached, and you are subscribing the customer for a plan that is
+                not free. Passing `source` will create a new source object, make it
+                the customer default source, and delete the old customer default if
+                one exists. If you want to add an additional source to use with subscriptions,
+                instead use the [card creation API](https://stripe.com/docs/api#create_card)
+                to add the card and then the [customer update API](https://stripe.com/docs/api#update
                 customer) to set it as the default. Whenever you attach a card to
                 a customer, Stripe will automatically validate the card.
               title: source
@@ -10476,10 +10667,22 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/customers/{customer}/subscriptions/{subscription_exposed_id}":
     delete:
-      description: |-
-        <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.</p>
-
-        <p>By default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.</p>
+      description: <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code>
+        parameter to true, the subscription will remain active until the end of the
+        period, at which point it will be canceled and not renewed. By default, the
+        subscription is terminated immediately. In either case, the customer will
+        not be charged again for the subscription. Note, however, that any pending
+        invoice items that you’ve created will still be charged for at the end of
+        the period unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve
+        set the subscription to cancel at period end, any pending prorations will
+        also be left in place and collected at the end of the period, but if the subscription
+        is set to cancel immediately, pending prorations will be removed.</p><p>By
+        default, all unpaid invoices for the customer will be closed upon subscription
+        cancellation. We do this in order to prevent unexpected payment retries once
+        the customer has canceled a subscription. However, you can reopen the invoices
+        manually after subscription cancellation to have us proceed with automatic
+        retries, or you could even re-attempt payment yourself on all unpaid invoices
+        before allowing the customer to cancel the subscription at all.</p>
       operationId: DeleteCustomerSubscription
       parameters:
       - description: Body parameters for the request.
@@ -10541,7 +10744,7 @@ paths:
                 invoice subtotal that will be transferred to the application owner's
                 Stripe account. The request must be made with an OAuth key in order
                 to set an application fee percentage. For more information, see the
-                application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).
+                application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions')}).
               title: application_fee_percent
               type:
               - number
@@ -10632,15 +10835,15 @@ paths:
               - boolean
             source:
               description: The source can either be a token, like the ones returned
-                by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary
-                containing a user's credit card details (with the options shown below).
-                You must provide a source if the customer does not already have a
-                valid source attached, and you are subscribing the customer for a
-                plan that is not free. Passing `source` will create a new source object,
-                make it the customer default source, and delete the old customer default
-                if one exists. If you want to add an additional source to use with
-                subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card)
-                to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update
+                by [Elements](https://stripe.com/docs/elements), or a dictionary containing
+                a user's credit card details (with the options shown below). You must
+                provide a source if the customer does not already have a valid source
+                attached, and you are subscribing the customer for a plan that is
+                not free. Passing `source` will create a new source object, make it
+                the customer default source, and delete the old customer default if
+                one exists. If you want to add an additional source to use with subscriptions,
+                instead use the [card creation API](https://stripe.com/docs/api#create_card)
+                to add the card and then the [customer update API](https://stripe.com/docs/api#update
                 customer) to set it as the default. Whenever you attach a card to
                 a customer, Stripe will automatically validate the card.
               title: source
@@ -10757,7 +10960,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -10804,10 +11008,13 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>When you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence in order to help us resolve the dispute in your favor. You can do this in your <a href="http://dashboard:6090/disputes">dashboard</a>, but if you prefer, you can use the API to submit evidence programmatically.</p>
-
-        <p>Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. You may want to consult our <a href="http://127.0.0.1:6040/help/dispute-types">guide to dispute types</a> to help you figure out which evidence fields to provide.</p>
+      description: <p>When you get a dispute, contacting your customer is always the
+        best first step. If that doesn’t work, you can submit evidence in order to
+        help us resolve the dispute in your favor. You can do this in your <a href="https://dashboard.stripe.com/disputes">dashboard</a>,
+        but if you prefer, you can use the API to submit evidence programmatically.</p><p>Depending
+        on your dispute type, different evidence fields will give you a better chance
+        of winning your dispute. You may want to consult our <a href="https://stripe.com/help/dispute-types">guide
+        to dispute types</a> to help you figure out which evidence fields to provide.</p>
       operationId: UpdateDispute
       parameters:
       - description: ID of the dispute to update.
@@ -10845,10 +11052,11 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/disputes/{dispute}/close":
     post:
-      description: |-
-        <p>Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially ‘dismissing’ the dispute, acknowledging it as lost</p>
-
-        <p>The status of the dispute will change from <code>needs_response</code> to <code>lost</code>. <strong>Closing a dispute is irreversible</strong>.</p>
+      description: "<p>Closing the dispute for a charge indicates that you do not
+        have any evidence to submit and are essentially ‘dismissing’ the dispute,
+        acknowledging it as lost</p><p>The status of the dispute will change from
+        <code>needs_response</code> to <code>lost</code>. <strong>Closing a dispute
+        is irreversible</strong>.</p>"
       operationId: CloseDispute
       parameters:
       - description: ID of dispute to close.
@@ -10929,7 +11137,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -11053,7 +11262,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -11099,7 +11309,8 @@ paths:
               type:
               - integer
             currency:
-              description: 3-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -11309,7 +11520,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -11337,10 +11549,12 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>If you need to invoice your customer outside the regular billing cycle, you can create an invoice that pulls in all pending invoice items, including prorations. The customer’s billing cycle and regular subscription won’t be affected.</p>
-
-        <p>Once you create the invoice, it’ll be picked up and paid automatically, though you can choose to <a href="#pay_invoice">pay it right</a> away.</p>
+      description: <p>If you need to invoice your customer outside the regular billing
+        cycle, you can create an invoice that pulls in all pending invoice items,
+        including prorations. The customer’s billing cycle and regular subscription
+        won’t be affected.</p><p>Once you create the invoice, it’ll be picked up and
+        paid automatically, though you can choose to <a href="#pay_invoice">pay it
+        right</a> away.</p>
       operationId: CreateInvoice
       parameters:
       - description: Body parameters for the request.
@@ -11353,7 +11567,7 @@ paths:
               description: A fee in %s that will be applied to the invoice and transferred
                 to the application owner's Stripe account. The request must be made
                 with an OAuth key or the Stripe-Account header in order to take an
-                application fee. For more information, see the application fees [documentation](/docs/connect/collecting-fees#subscriptions).
+                application fee. For more information, see the application fees [documentation](/docs/connect/subscriptions#working-with-invoices).
               title: application_fee
               type:
               - integer
@@ -11424,12 +11638,24 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/invoices/upcoming":
     get:
-      description: |-
-        <p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discount that is applicable to the customer.</p>
-
-        <p>Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer’s discount.</p>
-
-        <p>You can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass a <code>proration_date</code> parameter when doing the actual subscription update. The value passed in should be the same as the <code>subscription_proration_date</code> returned on the upcoming invoice resource. The recommended way to get only the prorations being previewed is to consider only proration line items where <code>period[start]</code> is equal to the <code>subscription_proration_date</code> on the upcoming invoice resource.</p>
+      description: "<p>At any time, you can preview the upcoming invoice for a customer.
+        This will show you all the charges that are pending, including subscription
+        renewal charges, invoice item charges, etc. It will also show you any discount
+        that is applicable to the customer.</p><p>Note that when you are viewing an
+        upcoming invoice, you are simply viewing a preview – the invoice has not yet
+        been created. As such, the upcoming invoice will not show up in invoice listing
+        calls, and you cannot use the API to pay or edit the invoice. If you want
+        to change the amount that your customer will be billed, you can add, remove,
+        or update pending invoice items, or update the customer’s discount.</p><p>You
+        can preview the effects of updating a subscription, including a preview of
+        what proration will take place. To ensure that the actual proration is calculated
+        exactly the same as the previewed proration, you should pass a <code>proration_date</code>
+        parameter when doing the actual subscription update. The value passed in should
+        be the same as the <code>subscription_proration_date</code> returned on the
+        upcoming invoice resource. The recommended way to get only the prorations
+        being previewed is to consider only proration line items where <code>period[start]</code>
+        is equal to the <code>subscription_proration_date</code> on the upcoming invoice
+        resource.</p>"
       operationId: RetrieveCustomerUpcomingInvoice
       parameters:
       - description: The identifier of the customer whose upcoming invoice you'd like
@@ -11552,7 +11778,7 @@ paths:
               description: A fee in %s that will be applied to the invoice and transferred
                 to the application owner's Stripe account. The request must be made
                 with an OAuth key or the Stripe-Account header in order to take an
-                application fee. For more information, see the application fees [documentation](/docs/connect/collecting-fees#subscriptions).
+                application fee. For more information, see the application fees [documentation](/docs/connect/subscriptions#working-with-invoices).
               title: application_fee
               type:
               - integer
@@ -11734,7 +11960,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -11764,7 +11991,7 @@ paths:
     post:
       description: <p>Stripe automatically creates and then attempts to pay invoices
         for customers on subscriptions. We’ll also retry unpaid invoices according
-        to your <a href="http://dashboard:6090/account/recurring">retry settings</a>.
+        to your <a href="https://dashboard.stripe.com/account/recurring">retry settings</a>.
         However, if you’d like to attempt to collect payment on an invoice out of
         the normal retry schedule or for some other reason, you can do so.</p>
       operationId: PayInvoice
@@ -11839,7 +12066,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -11965,7 +12193,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -12010,10 +12239,8 @@ paths:
               type:
               - string
             currency:
-              description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-                representing the currency in which the order should be made. Stripe
-                will validate that all entries in `items` match the currency specified
-                here.
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -12297,7 +12524,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -12395,7 +12623,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -12441,7 +12670,8 @@ paths:
               type:
               - integer
             currency:
-              description: 3-letter [ISO code for currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -12517,7 +12747,7 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/plans/{plan}":
     delete:
-      description: <p>You can delete plans via the <a href="http://dashboard:6090/plans">plan
+      description: <p>You can delete plans via the <a href="https://dashboard.stripe.com/plans">plan
         management</a> page of the Stripe dashboard. However, deleting a plan does
         not affect any current subscribers to the plan; it merely means that new subscribers
         can’t be added to that plan. You can also delete plans via the API.</p>
@@ -12683,7 +12913,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -12844,10 +13075,11 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to deactivate the existing product and create a new one with the new attribute values.</p>
+      description: "<p>Updates the specific product by setting the values of the parameters
+        passed. Any parameters not provided will be left unchanged.</p><p>Note that
+        a product’s <code>attributes</code> are not editable. Instead, you would need
+        to deactivate the existing product and create a new one with the new attribute
+        values.</p>"
       operationId: UpdateProduct
       parameters:
       - description: Body parameters for the request.
@@ -12998,7 +13230,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -13338,7 +13571,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -13559,7 +13793,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -13662,10 +13897,9 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specified refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>This request only accepts <code>metadata</code> as an argument.</p>
+      description: "<p>Updates the specified refund by setting the values of the parameters
+        passed. Any parameters not provided will be left unchanged.</p><p>This request
+        only accepts <code>metadata</code> as an argument.</p>"
       operationId: UpdateRefund
       parameters:
       - description: Body parameters for the request.
@@ -13768,7 +14002,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -13820,8 +14055,8 @@ paths:
               type:
               - object
             currency:
-              description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-                for currency.
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -13926,10 +14161,11 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specific SKU by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>Note that a SKU’s <code>attributes</code> are not editable. Instead, you would need to deactivate the existing SKU and create a new one with the new attribute values.</p>
+      description: "<p>Updates the specific SKU by setting the values of the parameters
+        passed. Any parameters not provided will be left unchanged.</p><p>Note that
+        a SKU’s <code>attributes</code> are not editable. Instead, you would need
+        to deactivate the existing SKU and create a new one with the new attribute
+        values.</p>"
       operationId: UpdateSKU
       parameters:
       - description: Body parameters for the request.
@@ -13954,8 +14190,8 @@ paths:
               type:
               - object
             currency:
-              description: 3-letter [ISO code](https://support.stripe.com/questions/which-currencies-does-stripe-support)
-                for currency.
+              description: Three-letter [ISO currency code](https://support.stripe.com/questions/which-currencies-does-stripe-support#currencygroup1),
+                in lowercase. Must be a [supported currency](https://support.stripe.com/questions/which-currencies-does-stripe-support).
               title: currency
               type:
               - string
@@ -14021,11 +14257,6 @@ paths:
         required: false
         schema:
           properties:
-            alipay:
-              description: ''
-              title: alipay
-              type:
-              - object
             amount:
               description: Amount associated with the source. This is the amount for
                 which the source will be chargeable once ready. Required for `single-use`
@@ -14034,8 +14265,9 @@ paths:
               type:
               - integer
             currency:
-              description: The currency associated with the source. This is the currency
-                for which the source will be chargeable once ready.
+              description: Three-letter [ISO code for the currency](https://support.stripe.com/questions/which-currencies-does-stripe-support)
+                associated with the source. This is the currency for which the source
+                will be chargeable once ready.
               title: currency
               type:
               - string
@@ -14123,10 +14355,9 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>This request accepts only the <code>metadata</code> and <code>owner</code> as arguments.</p>
+      description: "<p>Updates the specified source by setting the values of the parameters
+        passed. Any parameters not provided will be left unchanged.</p><p>This request
+        accepts only the <code>metadata</code> and <code>owner</code> as arguments.</p>"
       operationId: SourceUpdate
       parameters:
       - description: Body parameters for the request.
@@ -14239,7 +14470,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -14496,7 +14728,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -14544,7 +14777,7 @@ paths:
                 invoice subtotal that will be transferred to the application owner's
                 Stripe account. The request must be made with an OAuth key in order
                 to set an application fee percentage. For more information, see the
-                application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).
+                application fees [documentation]('https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
               title: application_fee_percent
               type:
               - number
@@ -14623,15 +14856,15 @@ paths:
               - boolean
             source:
               description: The source can either be a token, like the ones returned
-                by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary
-                containing a user's credit card details (with the options shown below).
-                You must provide a source if the customer does not already have a
-                valid source attached, and you are subscribing the customer for a
-                plan that is not free. Passing `source` will create a new source object,
-                make it the customer default source, and delete the old customer default
-                if one exists. If you want to add an additional source to use with
-                subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card)
-                to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update
+                by [Elements](https://stripe.com/docs/elements), or a dictionary containing
+                a user's credit card details (with the options shown below). You must
+                provide a source if the customer does not already have a valid source
+                attached, and you are subscribing the customer for a plan that is
+                not free. Passing `source` will create a new source object, make it
+                the customer default source, and delete the old customer default if
+                one exists. If you want to add an additional source to use with subscriptions,
+                instead use the [card creation API](https://stripe.com/docs/api#create_card)
+                to add the card and then the [customer update API](https://stripe.com/docs/api#update
                 customer) to set it as the default. Whenever you attach a card to
                 a customer, Stripe will automatically validate the card.
               title: source
@@ -14678,10 +14911,22 @@ paths:
             "$ref": "#/definitions/error"
   "/v1/subscriptions/{subscription_exposed_id}":
     delete:
-      description: |-
-        <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to true, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. By default, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription. Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel at period end, any pending prorations will also be left in place and collected at the end of the period, but if the subscription is set to cancel immediately, pending prorations will be removed.</p>
-
-        <p>By default, all unpaid invoices for the customer will be closed upon subscription cancellation. We do this in order to prevent unexpected payment retries once the customer has canceled a subscription. However, you can reopen the invoices manually after subscription cancellation to have us proceed with automatic retries, or you could even re-attempt payment yourself on all unpaid invoices before allowing the customer to cancel the subscription at all.</p>
+      description: <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code>
+        parameter to true, the subscription will remain active until the end of the
+        period, at which point it will be canceled and not renewed. By default, the
+        subscription is terminated immediately. In either case, the customer will
+        not be charged again for the subscription. Note, however, that any pending
+        invoice items that you’ve created will still be charged for at the end of
+        the period unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve
+        set the subscription to cancel at period end, any pending prorations will
+        also be left in place and collected at the end of the period, but if the subscription
+        is set to cancel immediately, pending prorations will be removed.</p><p>By
+        default, all unpaid invoices for the customer will be closed upon subscription
+        cancellation. We do this in order to prevent unexpected payment retries once
+        the customer has canceled a subscription. However, you can reopen the invoices
+        manually after subscription cancellation to have us proceed with automatic
+        retries, or you could even re-attempt payment yourself on all unpaid invoices
+        before allowing the customer to cancel the subscription at all.</p>
       operationId: DeleteCustomerSubscription
       parameters:
       - description: Body parameters for the request.
@@ -14743,7 +14988,7 @@ paths:
                 invoice subtotal that will be transferred to the application owner's
                 Stripe account. The request must be made with an OAuth key in order
                 to set an application fee percentage. For more information, see the
-                application fees [documentation](http://127.0.0.1:6040/docs/connect/collecting-fees#subscriptions).
+                application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions')}).
               title: application_fee_percent
               type:
               - number
@@ -14834,15 +15079,15 @@ paths:
               - boolean
             source:
               description: The source can either be a token, like the ones returned
-                by [Elements](http://127.0.0.1:6040/docs/elements), or a dictionary
-                containing a user's credit card details (with the options shown below).
-                You must provide a source if the customer does not already have a
-                valid source attached, and you are subscribing the customer for a
-                plan that is not free. Passing `source` will create a new source object,
-                make it the customer default source, and delete the old customer default
-                if one exists. If you want to add an additional source to use with
-                subscriptions, instead use the [card creation API](http://127.0.0.1:6040/docs/api#create_card)
-                to add the card and then the [customer update API](http://127.0.0.1:6040/docs/api#update
+                by [Elements](https://stripe.com/docs/elements), or a dictionary containing
+                a user's credit card details (with the options shown below). You must
+                provide a source if the customer does not already have a valid source
+                attached, and you are subscribing the customer for a plan that is
+                not free. Passing `source` will create a new source object, make it
+                the customer default source, and delete the old customer default if
+                one exists. If you want to add an additional source to use with subscriptions,
+                instead use the [card creation API](https://stripe.com/docs/api#create_card)
+                to add the card and then the [customer update API](https://stripe.com/docs/api#update
                 customer) to set it as the default. Whenever you attach a card to
                 a customer, Stripe will automatically validate the card.
               title: source
@@ -15016,7 +15261,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -15077,6 +15323,11 @@ paths:
             source_transaction:
               description: ''
               title: source_transaction
+              type:
+              - string
+            source_type:
+              description: ''
+              title: source_type
               type:
               - string
             transfer_group:
@@ -15217,7 +15468,8 @@ paths:
                 type:
                 - boolean
               object:
-                description: The type of object. Always has the value "list".
+                description: String representing the object's type. Objects of the
+                  same type share the same value. Always has the value "list".
                 enum:
                 - list
                 type:
@@ -15314,10 +15566,9 @@ paths:
           schema:
             "$ref": "#/definitions/error"
     post:
-      description: |-
-        <p>Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
-
-        <p>This request only accepts metadata and description as arguments.</p>
+      description: "<p>Updates the specified reversal by setting the values of the
+        parameters passed. Any parameters not provided will be left unchanged.</p><p>This
+        request only accepts metadata and description as arguments.</p>"
       operationId: UpdateTransferReversal
       parameters:
       - description: ''

--- a/test/api_fixtures.rb
+++ b/test/api_fixtures.rb
@@ -4,7 +4,7 @@
 class APIFixtures
   def initialize
     @fixtures = ::JSON.parse(File.read("#{PROJECT_ROOT}/openapi/fixtures.json"),
-      symbolize_names: true)
+      symbolize_names: true)[:resources]
     freeze_recursively(@fixtures)
   end
 

--- a/test/api_stub_helpers.rb
+++ b/test/api_stub_helpers.rb
@@ -98,7 +98,7 @@ module APIStubHelpers
   # Finds the latest OpenAPI specification in ROOT/openapi/ and parses it for
   # use with Committee.
   def self.initialize_spec
-    spec_data = ::JSON.parse(File.read("#{PROJECT_ROOT}/openapi/spec.json"))
+    spec_data = ::JSON.parse(File.read("#{PROJECT_ROOT}/openapi/spec2.json"))
 
     driver = Committee::Drivers::OpenAPI2.new
     driver.parse(spec_data)


### PR DESCRIPTION
See [1] for details, but a few conventions changed around the structure
of the OpenAPI repository and the data within the fixtures file. Here we
put in some minor changes to compensate for them.

[1] https://github.com/stripe/openapi/pull/3