### PR TITLE
Add OAuth methods

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -69,6 +69,9 @@ require 'stripe/three_d_secure'
 require 'stripe/token'
 require 'stripe/transfer'
 
+# OAuth
+require 'stripe/oauth'
+
 module Stripe
   DEFAULT_CA_BUNDLE_PATH = File.dirname(__FILE__) + '/data/ca-certificates.crt'
 
@@ -90,7 +93,7 @@ module Stripe
   @read_timeout = 80
 
   class << self
-    attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs, :api_version, :connect_base, :uploads_base,
+    attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs, :api_version, :client_id, :connect_base, :uploads_base,
                   :open_timeout, :read_timeout
 
     attr_reader :max_network_retry_delay, :initial_network_retry_delay

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -93,11 +93,12 @@ module Stripe
       raise NoMethodError.new('Overridding legal_entity can cause serious issues. Instead, set the individual fields of legal_entity like blah.legal_entity.first_name = \'Blah\'')
     end
 
-    def deauthorize(client_id, opts={})
-      opts = {:api_base => Stripe.connect_base}.merge(Util.normalize_opts(opts))
-      resp, opts = request(:post, '/oauth/deauthorize', { 'client_id' => client_id, 'stripe_user_id' => self.id }, opts)
-      opts.delete(:api_base) # the api_base here is a one-off, don't persist it
-      Util.convert_to_stripe_object(resp.data, opts)
+    def deauthorize(client_id=nil, opts={})
+      params = {
+        client_id: client_id,
+        stripe_user_id: self.id,
+      }
+      OAuth.deauthorize(params, opts)
     end
 
     ARGUMENT_NOT_PROVIDED = Object.new

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -100,4 +100,44 @@ module Stripe
       @sig_header = sig_header
     end
   end
+
+  module OAuth
+    # OAuthError is raised when the OAuth API returns an error.
+    class OAuthError < StripeError
+      attr_accessor :code
+
+      def initialize(code, description, http_status: nil, http_body: nil, json_body: nil,
+                     http_headers: nil)
+        super(description, http_status: http_status, http_body: http_body,
+          json_body: json_body, http_headers: http_headers)
+        @code = code
+      end
+    end
+
+    # InvalidGrantError is raised when a specified code doesn't exist, is
+    # expired, has been used, or doesn't belong to you; a refresh token doesn't
+    # exist, or doesn't belong to you; or if an API key's mode (live or test)
+    # doesn't match the mode of a code or refresh token.
+    class InvalidGrantError < OAuthError
+    end
+
+    # InvalidRequestError is raised when a code, refresh token, or grant type
+    # parameter is not provided, but was required.
+    class InvalidRequestError < OAuthError
+    end
+
+    # InvalidScopeError is raised when an invalid scope parameter is provided.
+    class InvalidScopeError < OAuthError
+    end
+
+    # UnsupportedGrantTypeError is raised when an unuspported grant type
+    # parameter is specified.
+    class UnsupportedGrantTypeError < OAuthError
+    end
+
+    # UnsupportedResponseTypeError is raised when an unsupported response type
+    # parameter is specified.
+    class UnsupportedResponseTypeError < OAuthError
+    end
+  end
 end

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -1,0 +1,56 @@
+module Stripe
+  module OAuth
+    module OAuthOperations
+      extend APIOperations::Request::ClassMethods
+
+      def self.request(method, url, params, opts)
+        opts = Util.normalize_opts(opts)
+        opts[:client] ||= StripeClient.active_client
+        opts[:api_base] ||= Stripe.connect_base
+
+        super(method, url, params, opts)
+      end
+    end
+
+    def self.get_client_id(params={})
+      client_id = params[:client_id] || Stripe.client_id
+      unless client_id
+        raise AuthenticationError.new('No client_id provided. ' \
+          'Set your client_id using "Stripe.client_id = <CLIENT-ID>". ' \
+          'You can find your client_ids in your Stripe dashboard at ' \
+          'https://dashboard.stripe.com/account/applications/settings, ' \
+          'after registering your account as a platform. See ' \
+          'https://stripe.com/docs/connect/standalone-accounts for details, ' \
+          'or email support@stripe.com if you have any questions.')
+      end
+      client_id
+    end
+
+    def self.authorize_url(params={}, opts={})
+      base = opts[:connect_base] || Stripe.connect_base
+
+      params[:client_id] = get_client_id(params)
+      params[:response_type] ||= 'code'
+      query = Util.encode_parameters(params)
+
+      "#{base}/oauth/authorize?#{query}"
+    end
+
+    def self.token(params={}, opts={})
+      opts = Util.normalize_opts(opts)
+      resp, opts = OAuthOperations.request(
+        :post, '/oauth/token', params, opts)
+      # This is just going to return a generic StripeObject, but that's okay
+      Util.convert_to_stripe_object(resp.data, opts)
+    end
+
+    def self.deauthorize(params={}, opts={})
+      opts = Util.normalize_opts(opts)
+      params[:client_id] = get_client_id(params)
+      resp, opts = OAuthOperations.request(
+        :post, '/oauth/deauthorize', params, opts)
+      # This is just going to return a generic StripeObject, but that's okay
+      Util.convert_to_stripe_object(resp.data, opts)
+    end
+  end
+end

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -1,0 +1,85 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+module Stripe
+  class OAuthTest < Test::Unit::TestCase
+    setup do
+      Stripe.client_id = 'ca_test'
+    end
+
+    teardown do
+      Stripe.client_id = nil
+    end
+
+    context ".authorize_url" do
+      should "return the authorize URL" do
+        uri_str = OAuth.authorize_url({
+          scope: 'read_write',
+          state: 'csrf_token',
+          stripe_user: {
+            email: 'test@example.com',
+            url: 'https://example.com/profile/test',
+            country: 'US',
+          },
+        })
+
+        uri = URI::parse(uri_str)
+        params = CGI::parse(uri.query)
+
+        assert_equal('https', uri.scheme)
+        assert_equal('connect.stripe.com', uri.host)
+        assert_equal('/oauth/authorize', uri.path)
+
+        assert_equal(['ca_test'], params['client_id'])
+        assert_equal(['read_write'], params['scope'])
+        assert_equal(['test@example.com'], params['stripe_user[email]'])
+        assert_equal(['https://example.com/profile/test'], params['stripe_user[url]'])
+        assert_equal(['US'], params['stripe_user[country]'])
+      end
+    end
+
+    context ".token" do
+      should "exchange a code for an access token" do
+        # The OpenAPI fixtures don't cover the OAuth endpoints, so we just
+        # stub the request manually.
+        stub_request(:post, "#{Stripe.connect_base}/oauth/token").
+          with(body: {
+            'grant_type' => 'authorization_code',
+            'code' => 'this_is_an_authorization_code',
+          }).
+          to_return(body: JSON.generate({
+            access_token: 'sk_access_token',
+            scope: 'read_only',
+            livemode: false,
+            token_type: 'bearer',
+            refresh_token: 'sk_refresh_token',
+            stripe_user_id: 'acct_test',
+            stripe_publishable_key: 'pk_test',
+          }))
+
+        resp = OAuth.token({
+          grant_type: 'authorization_code',
+          code: 'this_is_an_authorization_code',
+        })
+        assert_equal('sk_access_token', resp.access_token)
+      end
+    end
+
+    context ".deauthorize" do
+      should "deauthorize an account" do
+        # The OpenAPI fixtures don't cover the OAuth endpoints, so we just
+        # stub the request manually.
+        stub_request(:post, "#{Stripe.connect_base}/oauth/deauthorize").
+          with(body: {
+            'client_id' => 'ca_test',
+            'stripe_user_id' => 'acct_test_deauth',
+          }).
+          to_return(body: JSON.generate({
+            stripe_user_id: 'acct_test_deauth',
+          }))
+
+        resp = OAuth.deauthorize({stripe_user_id: 'acct_test_deauth'})
+        assert_equal('acct_test_deauth', resp.stripe_user_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR adds support for Connect's OAuth flow directly in the library.

I took a similar approach to https://github.com/stripe/stripe-python/pull/287 and subclassed `StripeClient` to correctly handle errors returned by `connect.stripe.com`.

wdyt?