### PR TITLE
Fix Faraday minimum version

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://stripe.com/docs/api/ruby'
   s.license = 'MIT'
 
-  s.add_dependency('faraday', '~> 0')
+  s.add_dependency('faraday', '~> 0.9')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
Fixes #526 

The [`SSLOptions`](https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/options.rb#L204) class was introduced in v0.9.0, so I set it as the minimum required version.

r? @brandur-stripe 
cc @stripe/api-libraries 
