### PR TITLE
Include predicate for lazily added boolean accessors

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -262,9 +262,10 @@ module Stripe
       # TODO: only allow setting in updateable classes.
       if name.to_s.end_with?('=')
         attr = name.to_s[0...-1].to_sym
+        val = args.first
 
         # the second argument is only required when adding boolean accessors
-        add_accessors([attr], {})
+        add_accessors([attr], { attr => val })
 
         begin
           mth = method(name)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -80,6 +80,13 @@ module Stripe
       refute obj.respond_to?(:not_bool?)
     end
 
+    should "assign question mark accessors for booleans added after initialization" do
+      obj = Stripe::StripeObject.new
+      obj.bool = true
+      assert obj.respond_to?(:bool?)
+      assert obj.bool?
+    end
+
     should "mass assign values with #update_attributes" do
       obj = Stripe::StripeObject.construct_from({ :id => 1, :name => 'Stripe' })
       obj.update_attributes(:name => 'STRIPE')


### PR DESCRIPTION
Previously, the value of whatever accessor was missing was left out of the call to build it. This had the effect of skipping over the lazily-built predicate method when the missing accessor is for a boolean.

Of course, I realize this all is a bit contrived as most of the time folks aren't assigning these values manually to stripe objects. However, in my testing it caught me by surprised that the behavior is asymmetric depending on how and when values are assigned.

As such I believe this is a less surprising implementation.

I wasn't sure how best to design the test, so I'm happy to move things around in order to closer follow the projects conventions.

Thank you for your care of a tremendously useful library! ❤️ 