### PR TITLE
Support "app info" for plugins in Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ an intermittent network problem:
 [Idempotency keys][idempotency-keys] are added to requests to guarantee that
 retries are safe.
 
+### Writing a Plugin
+
+If you're writing a plugin that uses the library, we'd appreciate it if you
+identified using `#set_app_info`:
+
+    Stripe.set_app_info("MyAwesomePlugin", version: "1.2.34", url: "https://myawesomeplugin.info");
+
+This information is passed along when the library makes calls to the Stripe
+API.
+
 ## Development
 
 Run all tests:

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -92,6 +92,16 @@ module Stripe
     attr_reader :max_network_retry_delay, :initial_network_retry_delay
   end
 
+  # Gets the application for a plugin that's identified some. See
+  # #set_app_info.
+  def self.app_info
+    @app_info
+  end
+
+  def self.app_info=(info)
+    @app_info = info
+  end
+
   # The location of a file containing a bundle of CA certificates. By default
   # the library will use an included bundle that can successfully validate
   # Stripe certificates.
@@ -129,6 +139,19 @@ module Stripe
 
   def self.max_network_retries=(val)
     @max_network_retries = val.to_i
+  end
+
+  # Sets some basic information about the running application that's sent along
+  # with API requests. Useful for plugin authors to identify their plugin when
+  # communicating with Stripe.
+  #
+  # Takes a name and optional version and plugin URL.
+  def self.set_app_info(name, version: nil, url: nil)
+    @app_info = {
+      name: name,
+      url: url,
+      version: version,
+    }
   end
 
   private

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -70,6 +70,8 @@ require 'stripe/transfer'
 module Stripe
   DEFAULT_CA_BUNDLE_PATH = File.dirname(__FILE__) + '/data/ca-certificates.crt'
 
+  @app_info = nil
+
   @api_base = 'https://api.stripe.com'
   @connect_base = 'https://connect.stripe.com'
   @uploads_base = 'https://uploads.stripe.com'

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -218,6 +218,16 @@ module Stripe
                    http_status: status, http_body: body)
     end
 
+    # Formats a plugin "app info" hash into a string that we can tack onto the
+    # end of a User-Agent string where it'll be fairly prominant in places like
+    # the Dashboard. Note that this formatting has been implemented to match
+    # other libraries, and shouldn't be changed without universal consensus.
+    private def format_app_info(info)
+      str = info[:name]
+      str = "#{str}/#{info[:version]}" unless info[:version].nil?
+      str = "#{str} (#{info[:url]})" unless info[:url].nil?
+      str
+    end
 
     def handle_api_error(http_resp)
       begin
@@ -309,8 +319,13 @@ module Stripe
     end
 
     def request_headers(api_key, method)
+      user_agent = "Stripe/v1 RubyBindings/#{Stripe::VERSION}"
+      unless Stripe.app_info.nil?
+        user_agent += " " + format_app_info(Stripe.app_info)
+      end
+
       headers = {
-        'User-Agent' => "Stripe/v1 RubyBindings/#{Stripe::VERSION}",
+        'User-Agent' => user_agent,
         'Authorization' => "Bearer #{api_key}",
         'Content-Type' => 'application/x-www-form-urlencoded'
       }

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -222,7 +222,7 @@ module Stripe
     # end of a User-Agent string where it'll be fairly prominant in places like
     # the Dashboard. Note that this formatting has been implemented to match
     # other libraries, and shouldn't be changed without universal consensus.
-    private def format_app_info(info)
+    def format_app_info(info)
       str = info[:name]
       str = "#{str}/#{info[:version]}" unless info[:version].nil?
       str = "#{str} (#{info[:url]})" unless info[:url].nil?

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -382,6 +382,7 @@ module Stripe
         lang_version = "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})"
 
         {
+          :application => Stripe.app_info,
           :bindings_version => Stripe::VERSION,
           :lang => 'ruby',
           :lang_version => lang_version,
@@ -390,7 +391,7 @@ module Stripe
           :publisher => 'stripe',
           :uname => @uname,
           :hostname => Socket.gethostname,
-        }
+        }.delete_if { |k, v| v.nil? }
       end
     end
   end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -143,14 +143,19 @@ module Stripe
 
       context "Stripe-Account header" do
         should "use a globally set header" do
-          Stripe.stripe_account = 'acct_1234'
+          begin
+            old = Stripe.stripe_account
+            Stripe.stripe_account = 'acct_1234'
 
-          stub_request(:post, "#{Stripe.api_base}/v1/account").
-            with(headers: {"Stripe-Account" => Stripe.stripe_account}).
-            to_return(body: JSON.generate(API_FIXTURES.fetch(:account)))
+            stub_request(:post, "#{Stripe.api_base}/v1/account").
+              with(headers: {"Stripe-Account" => Stripe.stripe_account}).
+              to_return(body: JSON.generate(API_FIXTURES.fetch(:account)))
 
-          client = StripeClient.new
-          client.execute_request(:post, '/v1/account')
+            client = StripeClient.new
+            client.execute_request(:post, '/v1/account')
+          ensure
+            Stripe.stripe_account = old
+          end
         end
 
         should "use a locally set header" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -193,14 +193,21 @@ module Stripe
 
             stub_request(:post, "#{Stripe.api_base}/v1/account").
               with { |req|
+                assert_equal \
+                  "Stripe/v1 RubyBindings/#{Stripe::VERSION} " \
+                  "MyAwesomePlugin/1.2.34 (https://myawesomeplugin.info)",
+                  req.headers["User-Agent"]
+
                 data = JSON.parse(req.headers["X-Stripe-Client-User-Agent"],
                   symbolize_names: true)
 
-                data["application"] == {
+                assert_equal({
                   name: "MyAwesomePlugin",
                   url: "https://myawesomeplugin.info",
                   version: "1.2.34"
-                }
+                }, data[:application])
+
+                true
               }.to_return(body: JSON.generate(API_FIXTURES.fetch(:account)))
 
             client = StripeClient.new

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -14,6 +14,24 @@ class StripeTest < Test::Unit::TestCase
     end
   end
 
+  should "allow app_info to be configured" do
+    begin
+      old = Stripe.app_info
+      Stripe.set_app_info(
+        "MyAwesomePlugin",
+        url: "https://myawesomeplugin.info",
+        version: "1.2.34"
+      )
+      assert_equal({
+        name: "MyAwesomePlugin",
+        url: "https://myawesomeplugin.info",
+        version: "1.2.34"
+      }, Stripe.app_info)
+    ensure
+      Stripe.app_info = old
+    end
+  end
+
   should "allow ca_bundle_path to be configured" do
     begin
       old = Stripe.ca_bundle_path


### PR DESCRIPTION
Adds support for "app info" (a mechanism that allows a plugin's author to identify that plugin) in Ruby. This is already supported in PHP and we're adding it elsewhere.

r? @ob-stripe One thing I didn't do here is add the app info the user agent string (like PHP does). I figure this is okay since we're mostly using the JSON version in the backend anyway. Thoughts?