### PR TITLE
Don't require `opts` param for `convert_to_stripe_object`.

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -74,7 +74,7 @@ module Stripe
     # * +data+ - Hash of fields and values to be converted into a StripeObject.
     # * +opts+ - Options for +StripeObject+ like an API key that will be reused
     #   on subsequent API calls.
-    def self.convert_to_stripe_object(data, opts)
+    def self.convert_to_stripe_object(data, opts = {})
       case data
       when Array
         data.map { |i| convert_to_stripe_object(i, opts) }


### PR DESCRIPTION
I'm using this utility function to convert `StripeObject`s into their more specific concrete type (like `Stripe::Card`). For me, it's always the case that `opts` is `{}`, so for me at least, it'd be helpful if this was the default value so one doesn't need to specify it everywhere.