### PR TITLE
Add section for configuring timeouts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ an intermittent network problem:
 [Idempotency keys][idempotency-keys] are added to requests to guarantee that
 retries are safe.
 
+### Configuring Timeouts
+
+Open and read timeouts are configurable:
+
+```java
+Stripe.open_timeout = 30 // in seconds
+Stripe.read_timeout = 80
+```
+
+Please take care to set conservative read timeouts. Some API requests can take
+some time, and a short timeout increases the likelihood of a problem within our
+servers.
+
 ### Writing a Plugin
 
 If you're writing a plugin that uses the library, we'd appreciate it if you


### PR DESCRIPTION
Timeouts are about to come to stripe-java [1], so for consistency we
mirror the README section that we're going to be adding over there.

[1] https://github.com/stripe/stripe-java/pull/369

r? @ob-stripe 