### PR TITLE
Remove `FIXTURE` definitions for ephemeral keys

### DIFF
--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -3,8 +3,6 @@ require File.expand_path('../../test_helper', __FILE__)
 module Stripe
   class EphemeralKeyTest < Test::Unit::TestCase
     context "#create" do
-      FIXTURE = API_FIXTURES.fetch(:ephemeral_key_with_secret)
-
       should "succeed" do
         key = Stripe::EphemeralKey.create(
           {customer:"cus_123"},
@@ -72,8 +70,6 @@ module Stripe
     end
 
     context "#delete" do
-      FIXTURE = API_FIXTURES.fetch(:ephemeral_key)
-
       should "succeed" do
         key = Stripe::EphemeralKey.create(
           {customer: 'cus_123'},


### PR DESCRIPTION
Redefining the constant like this produces a warning:

```
$ bundle exec rake
/Users/brandur/stripe/stripe-ruby/test/stripe/ephemeral_key_test.rb:75: warning: already initialized constant Stripe::EphemeralKeyTest::FIXTURE
/Users/brandur/stripe/stripe-ruby/test/stripe/ephemeral_key_test.rb:6: warning: previous definition of FIXTURE was here
Loaded suite /Users/brandur/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-11.1.2/lib/rake/rake_test_loader
Started
...
```

They also don't appear to be used, so it should be fine just to strip
them out of the test suite.

r? @grey-stripe