### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -11,8 +11,8 @@ module Stripe
       Util.convert_to_stripe_object(resp.data, opts)
     end
 
-    def pay(opts={})
-      resp, opts = request(:post, pay_url, {}, opts)
+    def pay(params={}, opts={})
+      resp, opts = request(:post, pay_url, params, opts)
       initialize_from(resp.data, opts)
     end
 

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -46,6 +46,19 @@ module Stripe
           "#{Stripe.api_base}/v1/invoices/#{FIXTURE[:id]}/pay"
         assert invoice.kind_of?(Stripe::Invoice)
       end
+
+      should "pay invoice with a specific source" do
+        invoice = Stripe::Invoice.retrieve(FIXTURE[:id])
+        invoice = invoice.pay(
+          source: API_FIXTURES[:customer][:sources][:data][0][:id]
+        )
+        assert_requested :post,
+          "#{Stripe.api_base}/v1/invoices/#{FIXTURE[:id]}/pay",
+          body: {
+            source: API_FIXTURES[:customer][:sources][:data][0][:id]
+          }
+        assert invoice.kind_of?(Stripe::Invoice)
+      end
     end
 
     context "#upcoming" do


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @ark-stripe

Users can now provide a `source` parameter when paying invoices, but the `pay` method currently does not let users provide any parameters. This PR fixes that.

Unfortunately, this is a breaking change because if someone is currently passing a `opts` argument, they'll need to modify their code since it's now the second argument. I didn't want to add `params` as the second argument since it would be inconsistent with ~every other method in the library.