### PR TITLE
Include IDs of resources set into properties

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -126,7 +126,7 @@ module Stripe
         update = v.is_a?(StripeObject) ? v.serialize_params : v
 
         if update != {} && (!original_value ||
-          update != legal_entity.serialize_params_value(nil, original_value[i], nil, false, true))
+          update != legal_entity.serialize_params_value(original_value[i], nil, false, true))
             update_hash[i.to_s] = update
         end
       end

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -126,7 +126,7 @@ module Stripe
         update = v.is_a?(StripeObject) ? v.serialize_params : v
 
         if update != {} && (!original_value ||
-          update != legal_entity.serialize_params_value(original_value[i], nil, false, true))
+          update != legal_entity.serialize_params_value(nil, original_value[i], nil, false, true))
             update_hash[i.to_s] = update
         end
       end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -337,10 +337,6 @@ module Stripe
       self
     end
 
-    def saved_and_unchanged?
-      !@values.empty? && @unsaved_values.empty?
-    end
-
     def serialize_params_value(value, original, unsaved, force, key: nil)
       case true
       when value == nil

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -176,7 +176,7 @@ module Stripe
         unsaved = @unsaved_values.include?(k)
         if options[:force] || unsaved || v.is_a?(StripeObject)
           update_hash[k.to_sym] =
-            serialize_params_value(k, @values[k], @original_values[k], unsaved, options[:force])
+            serialize_params_value(@values[k], @original_values[k], unsaved, options[:force], key: k)
         end
       end
 
@@ -341,7 +341,7 @@ module Stripe
       !@values.empty? && @unsaved_values.empty?
     end
 
-    def serialize_params_value(key, value, original, unsaved, force)
+    def serialize_params_value(value, original, unsaved, force, key: nil)
       case true
       when value == nil
         ''
@@ -380,10 +380,10 @@ module Stripe
         end
 
       when value.is_a?(Array)
-        update = value.map { |v| serialize_params_value(nil, v, nil, true, force) }
+        update = value.map { |v| serialize_params_value(v, nil, true, force) }
 
         # This prevents an array that's unchanged from being resent.
-        if update != serialize_params_value(nil, original, nil, true, force)
+        if update != serialize_params_value(original, nil, true, force)
           update
         else
           nil


### PR DESCRIPTION
Tweaks the serialization behavior so that when a resource is explicitly set
to a resource's field and that resource is subsequently saved, then if it
looks like the set resource was persisted we extract its ID and send it up
to the API.

By slight extension we also throw an `ArgumentError` if it looks like that
set resource was _not_ persisted because if the user set it explicitly then
it was probably not their intention to have it silently ignored by the
library in the event of a problem.

Fixes #558.