### PR TITLE
handle invalid-client oauth error

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -114,6 +114,12 @@ module Stripe
       end
     end
 
+    # InvalidClientError is raised when the client doesn't belong to you, or
+    # the API key mode (live or test) doesn't match the client mode. Or the
+    # stripe_user_id doesn't exist or isn't connected to your application.
+    class InvalidClientError < OAuthError
+    end
+
     # InvalidGrantError is raised when a specified code doesn't exist, is
     # expired, has been used, or doesn't belong to you; a refresh token doesn't
     # exist, or doesn't belong to you; or if an API key's mode (live or test)

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -312,6 +312,7 @@ module Stripe
       }]
 
       case error_code
+      when 'invalid_client'            then OAuth::InvalidClientError.new(*args)
       when 'invalid_grant'             then OAuth::InvalidGrantError.new(*args)
       when 'invalid_request'           then OAuth::InvalidRequestError.new(*args)
       when 'invalid_scope'             then OAuth::InvalidScopeError.new(*args)


### PR DESCRIPTION
The OAuth deauthorization endpoint can return an `invalid_client` error code, but the ruby API client doesn't expect it. That means it goes through `specific_oauth_error`, ends with `nil`, and then goes to `specific_api_error`, and then raises a `TypeError`.

This accepts and handles the `invalid_client` error code with a new error class.

For a general fix, probably nothing should go to `specific_api_error` after `specific_oauth_error` is attempted, since getting the oauth error is only tried when the error data is a string, and the api error expects the error data to be a hash. That's just asking for trouble.

(@sandrasi found this, and I decided to make the PR for it)