### PR TITLE
Improve error handling safety in the event of unrecognized OAuth error

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -249,8 +249,7 @@ module Stripe
 
       if error_data.is_a?(String)
         error = specific_oauth_error(resp, error_data)
-      end
-      if error.nil?
+      else
         error = specific_api_error(resp, error_data)
       end
 
@@ -319,7 +318,9 @@ module Stripe
       when 'unsupported_grant_type'    then OAuth::UnsupportedGrantTypeError.new(*args)
       when 'unsupported_response_type' then OAuth::UnsupportedResponseTypeError.new(*args)
       else
-        nil
+        # We'd prefer that all errors are typed, but we create a generic
+        # OAuthError in case we run into a code that we don't recognize.
+        OAuth::OAuthError.new(*args)
       end
     end
 


### PR DESCRIPTION
It was brought up in #562 that in case we receive an OAuth error that we
don't know about, `specific_oauth_error` will fall through with a `nil`,
then picked up by `specific_api_error` which will always try to handle
the error as if it were a `Hash` (even if we know it's not!) and thus
lead to typing problems at runtime.

This patch throws a generic `OAuthError` in cases where a code comes
back that we don't recognize. I'm still crazy about the fact that we
don't have a better way of recognizing an OAuth error in particular, but
it should do the trick.

r? @ob-stripe