### PR TITLE
Add upcoming invoice subscription items test

### DIFF
--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -73,6 +73,26 @@ module Stripe
         assert invoice.kind_of?(Stripe::Invoice)
       end
 
+      should "retrieve upcoming invoices with items" do
+        items = [{
+          plan: 'gold',
+          quantity: 2
+        }]
+
+        invoice = Stripe::Invoice.upcoming(
+          customer: "cus_123",
+          subscription_items: items
+        )
+
+        assert_requested :get, "#{Stripe.api_base}/v1/invoices/upcoming",
+          query: {
+            customer: "cus_123",
+            :'subscription_items[][plan]' => 'gold',
+            :'subscription_items[][quantity]' =>  2
+          }
+        assert invoice.kind_of?(Stripe::Invoice)
+      end
+
       should "be callable with an empty string" do
         invoice = Stripe::Invoice.upcoming(
           coupon: '',


### PR DESCRIPTION
Since this commit: https://github.com/stripe/stripe-ruby/commit/0019cfdc7e44f18503d5cf16e9bb9b1ad31065d4#diff-392254e7a00123f08e60cb565776b883L47 removed the test for passing in subscription items to upcoming invoice, I am adding another test for passing in a list of subscription items into upcoming invoices endpoint. 