### PR TITLE
Implement `STRIPE_LOG` for stripe-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   gem 'rake'
   gem 'shoulda-context'
   gem 'test-unit'
+  gem 'timecop'
   gem 'webmock'
 
   # Rack 2.0+ requires Ruby >= 2.2.2 which is problematic for the test suite on

--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ Please take care to set conservative read timeouts. Some API requests can take
 some time, and a short timeout increases the likelihood of a problem within our
 servers.
 
+### Logging
+
+The library can be configured to emit logging that will give you better insight
+into what it's doing. The `info` logging level is usually most appropriate for
+production use, but `debug` is also available for more verbosity.
+
+There are a few options for enabling it:
+
+1. Set the environment variable `STRIPE_LOG` to the value `debug` or `info`:
+   ```
+   $ export STRIPE_LOG=info
+   ```
+
+2. Set `Stripe.log_level`:
+   ``` ruby
+   Stripe.log_level = "info"
+   ```
+
 ### Writing a Plugin
 
 If you're writing a plugin that uses the library, we'd appreciate it if you

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -83,6 +83,8 @@ module Stripe
   @connect_base = 'https://connect.stripe.com'
   @uploads_base = 'https://uploads.stripe.com'
 
+  @log_level = nil
+
   @max_network_retries = 0
   @max_network_retry_delay = 2
   @initial_network_retry_delay = 0.5
@@ -142,6 +144,24 @@ module Stripe
     end
   end
 
+  LEVEL_DEBUG = "debug"
+  LEVEL_INFO = "info"
+
+  # When set prompts the library to log some extra information to $stdout about
+  # what it's doing. For example, it'll produce information about requests,
+  # responses, and errors that are received. Valid log levels are `debug` and
+  # `info`, with `debug` being a little more verbose in places.
+  def self.log_level
+    @log_level
+  end
+
+  def self.log_level=(val)
+    if val != nil && ![LEVEL_DEBUG, LEVEL_INFO].include?(val)
+      raise ArgumentError, "log_level should only be set to `nil`, `debug` or `info`"
+    end
+    @log_level = val
+  end
+
   def self.max_network_retries
     @max_network_retries
   end
@@ -173,4 +193,8 @@ module Stripe
     extend Gem::Deprecate
     deprecate :uri_encode, "Stripe::Util#encode_parameters", 2016, 01
   end
+end
+
+unless ENV["STRIPE_LOG"].nil?
+  Stripe.log_level = ENV["STRIPE_LOG"]
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'mocha/setup'
 require 'stringio'
 require 'shoulda/context'
+require "timecop"
 require 'webmock/test_unit'
 
 PROJECT_ROOT = File.expand_path("../../", __FILE__)


### PR DESCRIPTION
Adds logging support for stripe-ruby in a similar way that we did it for stripe-python [1], with the idea that users you can optionally get some additional low-cost-to-configure logging for operational visibility or debugging.

I made a few tweaks from the Python implementation (which I'll try to contribute back to there):

* Added an `elapsed` parameter to responses so you can tell how long they lasted.
* Mixed in `idempotency_key` to all lines that users have a way to aggregate logs related to a request from start to finish.
* Standardized naming between different log lines as much as possible.
* Detect a TTY and produce output that's colorized and formatted.

Here's what a debug trace looks like:

![image](https://user-images.githubusercontent.com/23105990/28895953-4ae05198-778f-11e7-9f72-a8f14794058d.png)

And here's the more concise info trace:

![image](https://user-images.githubusercontent.com/23105990/28895966-54dff388-778f-11e7-849e-23f8d5200d42.png)


[1] https://github.com/stripe/stripe-python/pull/269