### PR TITLE
Log `num_retries` with `STRIPE_LOG`

### DIFF
--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -163,6 +163,7 @@ module Stripe
             api_version: '2010-11-12',
             idempotency_key: "abc",
             method: :post,
+            num_retries: 0,
             path: "/v1/account"
           )
           Util.expects(:log_debug).with("Request details",
@@ -214,6 +215,7 @@ module Stripe
             api_version: nil,
             idempotency_key: nil,
             method: :post,
+            num_retries: 0,
             path: "/v1/account"
           )
           Util.expects(:log_info).with("Response from Stripe API",
@@ -259,6 +261,7 @@ module Stripe
             api_version: nil,
             idempotency_key: nil,
             method: :post,
+            num_retries: 0,
             path: "/oauth/token"
           )
           Util.expects(:log_info).with("Response from Stripe API",


### PR DESCRIPTION
This one is minor, but I realized after shipping #566 that it would be
nice if the number of retries was also logged for every request. This
patch follows up #566 by adding that in.

I also renamed `retry_count` to `num_retries` because I subjectively
think this name is a little better.

r? @deontologician-stripe Would you mind taking a quick look at this one as
well given that you have the most context? Thanks!
cc @stripe/api-libraries