### PR TITLE
Log `Stripe-Account` values with `STRIPE_LOG`

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -139,8 +139,9 @@ module Stripe
       # stores information on the request we're about to make so that we don't
       # have to pass as many parameters around for logging.
       context = RequestLogContext.new(
+        account: headers["Stripe-Account"],
         api_key: api_key,
-        api_version: headers["Stripe-Version"] || Stripe.api_version,
+        api_version: headers["Stripe-Version"],
         idempotency_key: headers["Idempotency-Key"],
         method: method,
         path: path,
@@ -439,6 +440,7 @@ module Stripe
 
     def log_request(context, num_retries)
       Util.log_info("Request to Stripe API",
+        account: context.account,
         api_version: context.api_version,
         idempotency_key: context.idempotency_key,
         method: context.method,
@@ -454,6 +456,7 @@ module Stripe
 
     def log_response(context, request_start, status, body)
       Util.log_info("Response from Stripe API",
+        account: context.account,
         api_version: context.api_version,
         elapsed: Time.now - request_start,
         idempotency_key: context.idempotency_key,
@@ -492,6 +495,7 @@ module Stripe
     # that we can log certain information. It's useful because it means that we
     # don't have to pass around as many parameters.
     class RequestLogContext
+      attr_accessor :account
       attr_accessor :api_key
       attr_accessor :api_version
       attr_accessor :idempotency_key
@@ -500,8 +504,9 @@ module Stripe
       attr_accessor :payload
       attr_accessor :request_id
 
-      def initialize(api_key: nil, api_version: nil, idempotency_key: nil,
-          method: nil, path: nil, payload: nil)
+      def initialize(account: nil, api_key: nil, api_version: nil,
+          idempotency_key: nil, method: nil, path: nil, payload: nil)
+        self.account = account
         self.api_key = api_key
         self.api_version = api_version
         self.idempotency_key = idempotency_key
@@ -529,6 +534,7 @@ module Stripe
         end
 
         context = self.dup
+        context.account = headers["Stripe-Account"]
         context.api_version = headers["Stripe-Version"]
         context.idempotency_key = headers["Idempotency-Key"]
         context.request_id = headers["Request-Id"]

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -160,6 +160,7 @@ module Stripe
           body = JSON.generate({ object: "account" })
 
           Util.expects(:log_info).with("Request to Stripe API",
+            account: "acct_123",
             api_version: '2010-11-12',
             idempotency_key: "abc",
             method: :post,
@@ -172,6 +173,7 @@ module Stripe
           )
 
           Util.expects(:log_info).with("Response from Stripe API",
+            account: "acct_123",
             api_version: '2010-11-12',
             elapsed: 0.0,
             idempotency_key: "abc",
@@ -197,6 +199,7 @@ module Stripe
               headers: {
                 "Idempotency-Key" => "abc",
                 "Request-Id" => "req_123",
+                "Stripe-Account" => "acct_123",
                 "Stripe-Version" => "2010-11-12"
               }
             )
@@ -205,6 +208,7 @@ module Stripe
           client.execute_request(:post, '/v1/account',
             headers: {
               "Idempotency-Key" => "abc",
+              "Stripe-Account" => "acct_123",
               "Stripe-Version" => "2010-11-12"
             }
           )
@@ -212,6 +216,7 @@ module Stripe
 
         should "produce logging on API error" do
           Util.expects(:log_info).with("Request to Stripe API",
+            account: nil,
             api_version: nil,
             idempotency_key: nil,
             method: :post,
@@ -219,6 +224,7 @@ module Stripe
             path: "/v1/account"
           )
           Util.expects(:log_info).with("Response from Stripe API",
+            account: nil,
             api_version: nil,
             elapsed: 0.0,
             idempotency_key: nil,
@@ -258,6 +264,7 @@ module Stripe
 
         should "produce logging on OAuth error" do
           Util.expects(:log_info).with("Request to Stripe API",
+            account: nil,
             api_version: nil,
             idempotency_key: nil,
             method: :post,
@@ -265,6 +272,7 @@ module Stripe
             path: "/oauth/token"
           )
           Util.expects(:log_info).with("Response from Stripe API",
+            account: nil,
             api_version: nil,
             elapsed: 0.0,
             idempotency_key: nil,


### PR DESCRIPTION
Hopefully the last tweak in a while, but a discussion on [1] tipped me
off that this was missing. Here we add a `Stripe-Account` for a request
and response to logging. Follows #566 and #567.

[1] https://github.com/stripe/stripe-node/issues/364

r? @deontologician-stripe Sorry, hopefully the last one for a while.
cc @jlomas-stripe @stripe/api-libraries