### PR TITLE
Add support for setting a logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ There are a few options for enabling it:
 
 2. Set `Stripe.log_level`:
    ``` ruby
-   Stripe.log_level = "info"
+   Stripe.log_level = Stripe::LEVEL_INFO
    ```
 
 ### Writing a Plugin

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -1,6 +1,7 @@
 # Stripe Ruby bindings
 # API spec at https://stripe.com/docs/api
 require 'cgi'
+require 'logger'
 require 'openssl'
 require 'rbconfig'
 require 'set'
@@ -145,13 +146,15 @@ module Stripe
     end
   end
 
-  LEVEL_DEBUG = "debug"
-  LEVEL_INFO = "info"
+  # map to the same values as the standard library's logger
+  LEVEL_DEBUG = Logger::DEBUG
+  LEVEL_ERROR = Logger::ERROR
+  LEVEL_INFO = Logger::INFO
 
-  # When set prompts the library to log some extra information to $stdout about
-  # what it's doing. For example, it'll produce information about requests,
-  # responses, and errors that are received. Valid log levels are `debug` and
-  # `info`, with `debug` being a little more verbose in places.
+  # When set prompts the library to log some extra information to $stdout and
+  # $stderr about what it's doing. For example, it'll produce information about
+  # requests, responses, and errors that are received. Valid log levels are
+  # `debug` and `info`, with `debug` being a little more verbose in places.
   #
   # Use of this configuration is only useful when `.logger` is _not_ set. When
   # it is, the decision what levels to print is entirely deferred to the logger.
@@ -160,7 +163,14 @@ module Stripe
   end
 
   def self.log_level=(val)
-    if val != nil && ![LEVEL_DEBUG, LEVEL_INFO].include?(val)
+    # Backwards compatibility for values that we briefly allowed
+    if val == "debug"
+      val = LEVEL_DEBUG
+    elsif val == "info"
+      val = LEVEL_INFO
+    end
+
+    if val != nil && ![LEVEL_DEBUG, LEVEL_ERROR, LEVEL_INFO].include?(val)
       raise ArgumentError, "log_level should only be set to `nil`, `debug` or `info`"
     end
     @log_level = val

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -84,6 +84,7 @@ module Stripe
   @uploads_base = 'https://uploads.stripe.com'
 
   @log_level = nil
+  @logger = nil
 
   @max_network_retries = 0
   @max_network_retry_delay = 2
@@ -151,6 +152,9 @@ module Stripe
   # what it's doing. For example, it'll produce information about requests,
   # responses, and errors that are received. Valid log levels are `debug` and
   # `info`, with `debug` being a little more verbose in places.
+  #
+  # Use of this configuration is only useful when `.logger` is _not_ set. When
+  # it is, the decision what levels to print is entirely deferred to the logger.
   def self.log_level
     @log_level
   end
@@ -160,6 +164,21 @@ module Stripe
       raise ArgumentError, "log_level should only be set to `nil`, `debug` or `info`"
     end
     @log_level = val
+  end
+
+  # Sets a logger to which logging output will be sent. The logger should
+  # support the same interface as the `Logger` class that's part of Ruby's
+  # standard library (hint, anything in `Rails.logger` will likely be
+  # suitable).
+  #
+  # If `.logger` is set, the value of `.log_level` is ignored. The decision on
+  # what levels to print is entirely deferred to the logger.
+  def self.logger
+    @logger
+  end
+
+  def self.logger=(val)
+    @logger = val
   end
 
   def self.max_network_retries

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -279,7 +279,7 @@ module Stripe
     end
 
     def specific_api_error(resp, error_data, context)
-      Util.log_info('Stripe API error',
+      Util.log_error('Stripe API error',
         status: resp.http_status,
         error_code: error_data['code'],
         error_message: error_data['message'],
@@ -336,7 +336,7 @@ module Stripe
     def specific_oauth_error(resp, error_code, context)
       description = resp.data[:error_description] || error_code
 
-      Util.log_info('Stripe OAuth error',
+      Util.log_error('Stripe OAuth error',
         status: resp.http_status,
         error_code: error_code,
         error_description: description,
@@ -364,7 +364,7 @@ module Stripe
     end
 
     def handle_network_error(e, context, num_retries, api_base=nil)
-      Util.log_info('Stripe OAuth error',
+      Util.log_error('Stripe network error',
         error_message: e.message,
         idempotency_key: context.idempotency_key,
         request_id: context.request_id
@@ -481,7 +481,7 @@ module Stripe
     private :log_response
 
     def log_response_error(context, request_start, e)
-      Util.log_info("Request error",
+      Util.log_error("Request error",
         elapsed: Time.now - request_start,
         error_message: e.message,
         idempotency_key: context.idempotency_key,

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -240,7 +240,7 @@ module Stripe
             param: 'param',
             type: 'type',
           }
-          Util.expects(:log_info).with('Stripe API error',
+          Util.expects(:log_error).with('Stripe API error',
             status: 500,
             error_code: error['code'],
             error_message: error['message'],
@@ -282,7 +282,7 @@ module Stripe
             status: 400
           )
 
-          Util.expects(:log_info).with('Stripe OAuth error',
+          Util.expects(:log_error).with('Stripe OAuth error',
             status: 400,
             error_code: "invalid_request",
             error_description: "No grant type specified",


### PR DESCRIPTION
Adds support for setting `Stripe.logger` to a logger that's compatible
with `Logger` from Ruby's standard library. In set, the library will no
longer log to stdout, and instead emit straight to the logger and defer
decision on what log level to print to it.

Addresses a request in #566.