### PR TITLE
Parse webhook payload after verifying the signature header

### DIFF
--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -7,12 +7,10 @@ module Stripe
     # This may raise JSON::ParserError if the payload is not valid JSON, or
     # SignatureVerificationError if the signature verification fails.
     def self.construct_event(payload, sig_header, secret, tolerance: DEFAULT_TOLERANCE)
-      data = JSON.parse(payload, symbolize_names: true)
-      event = Event.construct_from(data)
-
       Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
 
-      event
+      data = JSON.parse(payload, symbolize_names: true)
+      Event.construct_from(data)
     end
 
     module Signature


### PR DESCRIPTION
Currently `Stripe::Webhook.construct_event` immediately calls `JSON.parse` with the symbolize_names option. IIRC creating symbols from untrusted input can be a potential DoS attack vector, particularly on older rubies without Symbol GC?

This also makes it easier to ignore the `JSON::ParserError` exception (if the request has been verified from Stripe then it's less likely to be malformed).
