### PR TITLE
Add an estimated stripe fee

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -2,6 +2,12 @@ require "cgi"
 
 module Stripe
   module Util
+    def self.est_stripe_fee(amount=0.0)
+      # 2.9% + $0.30
+      percent = amount * 0.029
+      (percent + 0.30).round(2)
+    end
+
     def self.objects_to_ids(h)
       case h
       when APIResource


### PR DESCRIPTION
This is probably not the implementation you'd want, but I wanted to send this over as an idea. Calculating stripe's fee is one of the things I almost always end up doing in every Stripe app I've built.

The ideal scenario would probably be dependent on the user's account, and maybe even dependent on a specific charge (depending on currency?), so maybe this is something that could happen upon setting up the library with your keys. May also want to add methods to individual charges to get stripe's fees.

I'm personally surprised that Stripe's fees aren't returned when you create a charge by default.