### PR TITLE
Add correct required_ruby_version

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -5,7 +5,7 @@ require 'stripe/version'
 spec = Gem::Specification.new do |s|
   s.name = 'stripe'
   s.version = Stripe::VERSION
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
   s.summary = 'Ruby bindings for the Stripe API'
   s.description = 'Stripe is the easiest way to accept payments online.  See https://stripe.com for details.'
   s.author = 'Stripe'


### PR DESCRIPTION
The `stripe` gem installs on 1.9.3, but is unusable due to the use of keyword args.

    vagrant@vagrant-ubuntu-trusty-64: ~
    $ ruby -v
    ruby 1.9.3p551 (2014-11-13) [x86_64-linux] Brightbox

    vagrant@vagrant-ubuntu-trusty-64: ~
    $ sudo gem install stripe
    Fetching: multipart-post-2.0.0.gem (100%)
    Fetching: faraday-0.13.1.gem (100%)
    Fetching: stripe-3.3.1.gem (100%)
    Successfully installed multipart-post-2.0.0
    Successfully installed faraday-0.13.1
    Successfully installed stripe-3.3.1
    3 gems installed

    vagrant@vagrant-ubuntu-trusty-64: ~
    $ irb
    irb(main):001:0> require 'stripe'
    SyntaxError: /var/lib/gems/1.9.1/gems/stripe-3.3.1/lib/stripe.rb:207: syntax error, unexpected tLABEL
      def self.set_app_info(name, version: nil, url: nil)
                                          ^
    /var/lib/gems/1.9.1/gems/stripe-3.3.1/lib/stripe.rb:207: Can't assign to nil
      def self.set_app_info(name, version: nil, url: nil)
                                               ^
    /var/lib/gems/1.9.1/gems/stripe-3.3.1/lib/stripe.rb:225: syntax error, unexpected keyword_end, expecting $end
            from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
            from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
            from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
            from (irb):1
            from /usr/bin/irb:12:in `<main>'