### PR TITLE
Upgrade stripe-mock to 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.1.12
+    - STRIPE_MOCK_VERSION=0.2.0
 
 cache:
   directories:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path('../test_data', __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.1.12"
+MOCK_MINIMUM_VERSION = "0.2.0"
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
This pulls us onto the new version of stripe-mock which should be
checking parameters more accurately now that it's on OpenAPI 3.0.