### PR TITLE
Pin Rubocop dependency in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,17 @@ gemspec
 group :development do
   gem "mocha", "~> 0.13.2"
   gem "rake"
-  gem "rubocop"
   gem "shoulda-context"
   gem "test-unit"
   gem "timecop"
   gem "webmock"
+
+  # Rubocop changes pretty quickly: new cops get added and old cops change
+  # names or go into new namespaces. This is a library and we don't have
+  # `Gemfile.lock` checked in, so to prevent good builds from suddenly going
+  # bad, pin to a specific version number here. Try to keep this relatively
+  # up-to-date, but it's not the end of the world if it's not.
+  gem "rubocop", "0.50.0"
 
   # Rack 2.0+ requires Ruby >= 2.2.2 which is problematic for the test suite on
   # older Ruby versions. Check Ruby the version here and put a maximum


### PR DESCRIPTION
Because we're a library, our `Gemfile.lock` is in `.gitinore` (see [1]).
This means that you'd be otherwise be vulnerable to the whims of
whatever version of Rubocop is installed on the local system.

Because Rubocop changes fairly quickly and those changes tend to lead to
either errors or warnings on its runs, lock the gem to a particular
version in our `Gemfile`. We should try to keep the locked version
relatively current.

cc @ob-stripe

[1] http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/