### PR TITLE
Implement deep copy for StripeObject and remove marshal/unmarshal

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,10 +35,10 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 47
 
-# Offense count: 1
+# Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 290
+  Max: 423
 
 # Offense count: 6
 # Configuration parameters: CountKeywordArgs.
@@ -48,11 +48,6 @@ Metrics/ParameterLists:
 # Offense count: 5
 Metrics/PerceivedComplexity:
   Max: 11
-  Exclude:
-    - 'lib/stripe/stripe_object.rb'
-
-# Offense count: 1
-Security/MarshalLoad:
   Exclude:
     - 'lib/stripe/stripe_object.rb'
 

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -2,8 +2,6 @@ module Stripe
   module APIOperations
     module Request
       module ClassMethods
-        OPTS_KEYS_TO_PERSIST = Set[:api_key, :api_base, :client, :stripe_account, :stripe_version]
-
         def request(method, url, params = {}, opts = {})
           warn_on_opts_in_params(params)
 
@@ -25,7 +23,7 @@ module Stripe
           # Hash#select returns an array before 1.9
           opts_to_persist = {}
           opts.each do |k, v|
-            opts_to_persist[k] = v if OPTS_KEYS_TO_PERSIST.include?(k)
+            opts_to_persist[k] = v if Util::OPTS_KEYS_TO_PERSIST.include?(k)
           end
 
           [resp, opts_to_persist]
@@ -33,11 +31,8 @@ module Stripe
 
         private
 
-        KNOWN_OPTS = Set[:api_key, :idempotency_key, :stripe_account, :stripe_version]
-        private_constant :KNOWN_OPTS
-
         def warn_on_opts_in_params(params)
-          KNOWN_OPTS.each do |opt|
+          Util::OPTS_USER_SPECIFIED.each do |opt|
             if params.key?(opt)
               $stderr.puts("WARNING: #{opt} should be in opts instead of params.")
             end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -2,6 +2,22 @@ require "cgi"
 
 module Stripe
   module Util
+    # Options that a user is allowed to specify.
+    OPTS_USER_SPECIFIED = Set[
+      :api_key,
+      :idempotency_key,
+      :stripe_account,
+      :stripe_version
+    ].freeze
+
+    # Options that should be copyable from one StripeObject to another
+    # including options that may be internal.
+    OPTS_COPYABLE = (OPTS_USER_SPECIFIED + Set[:api_base]).freeze
+
+    # Options that should be persisted between API requests. This includes
+    # client, which is an object containing an HTTP client to reuse.
+    OPTS_KEYS_TO_PERSIST = (OPTS_USER_SPECIFIED + Set[:client]).freeze
+
     def self.objects_to_ids(h)
       case h
       when APIResource


### PR DESCRIPTION
We were previously using a bit of a hack to get a free deep copy
implementation through Ruby's marshaling framework. Lint call this out
as a security problem though, and rightfully so: when combined with
unsanitized user input, unmarshaling can result in very serious security
breaches involving arbitrary code execution.

This patch removes all uses of marshal/unmarshal in favor of
implementing a deep copy method for `StripeObject`. I also reworked some
of the constants around what keys are available for `opts`. I'm still
not completely happy with the results, but I think it's going to need a
slightly larger refactor in order to get somewhere truly good.

There is what could be a breaking change for people doing non-standard
stuff with the library: the opts that we copy with an object are now
whitelisted, so if they were being used to pass around extraneous data,
that might not work as expected anymore. But because this is a contract
that we never committed to, I don't think I'd bump the major version for
change.

r? @ob-stripe