### PR TITLE
Log query string as well as body on log debug

### DIFF
--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -166,7 +166,8 @@ module Stripe
                                        path: "/v1/account")
           Util.expects(:log_debug).with("Request details",
                                         body: "",
-                                        idempotency_key: "abc")
+                                        idempotency_key: "abc",
+                                        query_string: nil)
 
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: "acct_123",


### PR DESCRIPTION
This patch modifies the debugging-level logging logic slightly so that
if it's a `GET` request that includes a query string, we log that string
just like we would've for a request body on a `POST` or like.

This especially comes in handy when looking when trying to resolve
something like a problem with the upcoming invoices endpoint like we saw
in #576, but will be useful in a number of situations.

r? @ob-stripe 