### PR TITLE
Require Faraday 0.10 for proper nested array encoding

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://stripe.com/docs/api/ruby"
   s.license = "MIT"
 
-  s.add_dependency("faraday", "~> 0.9")
+  s.add_dependency("faraday", "~> 0.10")
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #576.

Seems difficult to add a test for this as the issue doesn't happen in stripe-ruby itself. Maybe by setting up some sort of echo server? Not sure if worth the trouble, wdyt?