### PR TITLE
detach method for detaching sources from customers

### DIFF
--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -5,18 +5,23 @@ module Stripe
 
     OBJECT_NAME = "source".freeze
 
-    def delete(params = {}, opts = {})
+    def detach(params = {}, opts = {})
       if !respond_to?(:customer) || customer.nil? || customer.empty?
         raise NotImplementedError,
-              "Source objects cannot be deleted, they can only be detached " \
-              "from customer objects. This source object does not appear to " \
-              "be currently attached to a customer object."
+              "This source object does not appear to be currently attached " \
+              "to a customer object."
       end
 
       url = "#{Customer.resource_url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
       resp, opts = request(:delete, url, params, Util.normalize_opts(opts))
       initialize_from(resp.data, opts)
     end
+
+    def delete(params = {}, opts = {})
+      detach(params, opts)
+    end
+    extend Gem::Deprecate
+    deprecate :delete, "#detach", 2017, 10
 
     def verify(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/verify", params, Util.normalize_opts(opts))

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -30,12 +30,12 @@ module Stripe
       assert source.is_a?(Stripe::Source)
     end
 
-    context "#delete" do
+    context "#detach" do
       should "not be deletable when unattached" do
         source = Stripe::Source.retrieve("src_123")
 
         assert_raises NotImplementedError do
-          source.delete
+          source.detach
         end
       end
 
@@ -43,9 +43,27 @@ module Stripe
         source = Stripe::Source.construct_from(customer: "cus_123",
                                                id: "src_123",
                                                object: "source")
-        source = source.delete
+        source = source.detach
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/sources/src_123"
         assert source.is_a?(Stripe::Source)
+      end
+    end
+
+    context "#delete" do
+      should "warn that #delete is deprecated" do
+        old_stderr = $stderr
+        $stderr = StringIO.new
+        begin
+          source = Stripe::Source.construct_from(customer: "cus_123",
+                                                 id: "src_123",
+                                                 object: "source")
+          source.delete
+          message = "NOTE: Stripe::Source#delete is " \
+                    "deprecated; use #detach instead"
+          assert_match Regexp.new(message), $stderr.string
+        ensure
+          $stderr = old_stderr
+        end
       end
     end
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe @will-stripe

- Renames the `Source.delete` method to `Source.detach`. `detach` is more descriptive of what the method actually does (i.e. detaching the source object from its customer object, not actually deleting the source object).

- Alias `detach` to `delete` with a deprecation warning to avoid a breaking change. We should remove the `delete` method in next major version.
