### PR TITLE
Implement custom Marshal encoder/decoder for `StripeObject`

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -144,6 +144,28 @@ module Stripe
       end
     end
 
+    # Implements custom encoding for Ruby's Marshal. The data produced by this
+    # method should be comprehendable by #marshal_load.
+    #
+    # This allows us to remove certain features that cannot or should not be
+    # serialized.
+    def marshal_dump
+      # The StripeClient instance in @opts is not serializable and is not
+      # really a property of the StripeObject, so we exclude it when
+      # dumping
+      opts = @opts.clone
+      opts.delete(:client)
+      [@values, opts]
+    end
+
+    # Implements custom decoding for Ruby's Marshal. Consumes data that's
+    # produced by #marshal_dump.
+    def marshal_load(data)
+      values, opts = data
+      initialize(values[:id])
+      initialize_from(values, opts)
+    end
+
     def serialize_params(options = {})
       update_hash = {}
 

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -410,5 +410,18 @@ module Stripe
       end
       assert_match(/\(object\).foo = nil/, e.message)
     end
+
+    should "marshal and unmarshal using custom encoder and decoder" do
+      obj = Stripe::StripeObject.construct_from(
+        { id: 1, name: "Stripe" },
+        api_key: "apikey",
+        client: StripeClient.active_client
+      )
+      m = Marshal.load(Marshal.dump(obj))
+      assert_equal 1, m.id
+      assert_equal "Stripe", m.name
+      expected_hash = { api_key: "apikey" }
+      assert_equal expected_hash, m.instance_variable_get("@opts")
+    end
   end
 end


### PR DESCRIPTION
Backtracks a little bit #586 by bringing back custom `StripeObject`
encoding and decoding methods for Ruby's `Marshal`. These work by just
persisting values and some opts, and skipping everything else. It's
mostly the same as what we had before, but implemented a little more
cleanly so that we don't actually need to invoke `Marshal` anywhere
ourselves.

In #586 we still managed to remove all the uses of `Marshal` in our own
codebase to make the linter happy. Even though we wouldn't recommend the
use of `Marshal`, this code at least enables it for anyone using a Rails
cache or similar mechanism.

Addresses #90.