### PR TITLE
Maintain class in deep_copy

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -427,7 +427,7 @@ module Stripe
           copy
         end
       when StripeObject
-        StripeObject.construct_from(
+        obj.class.construct_from(
           deep_copy(obj.instance_variable_get(:@values)),
           obj.instance_variable_get(:@opts).select do |k, _v|
             Util::OPTS_COPYABLE.include?(k)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -104,6 +104,15 @@ module Stripe
         assert_equal opts.reject { |k, _v| k == :client },
                      copy_obj.instance_variable_get(:@opts)
       end
+
+      should "return an instance of the same class" do
+        class TestObject < Stripe::StripeObject; end
+
+        obj = TestObject.construct_from(id: 1)
+        copy_obj = obj.class.send(:deep_copy, obj)
+
+        assert_equal obj.class, copy_obj.class
+      end
     end
 
     should "recursively call to_hash on its values" do


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Minor fix: I noticed that `deep_copy` always returns a `StripeObject` instance. This PR fixes it so it returns an instance of the same class that is being copied.
