### PR TITLE
Encode arrays as hashes when needed

### DIFF
--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -7,6 +7,7 @@ module Stripe
     OBJECT_NAME = "invoice".freeze
 
     def self.upcoming(params, opts = {})
+      params[:subscription_items] = Util.array_to_hash(params[:subscription_items]) if params[:subscription_items]
       resp, opts = request(:get, upcoming_url, params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -12,8 +12,14 @@ module Stripe
     end
 
     def return_order(params, opts = {})
+      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
       resp, opts = request(:post, returns_url, params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
+    end
+
+    def self.create(params = {}, opts = {})
+      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
+      super(params, opts)
     end
 
     private

--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -24,6 +24,16 @@ module Stripe
       super(params, opts)
     end
 
+    def serialize_params(options = {})
+      update_hash = super
+      if @unsaved_values.include?(:items)
+        value = Util.array_to_hash(@values[:items])
+        update_hash[:items] =
+          serialize_params_value(value, nil, true, options[:force], key: :items)
+      end
+      update_hash
+    end
+
     private
 
     def discount_url

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -54,5 +54,51 @@ module Stripe
         assert subscription.is_a?(Stripe::Subscription)
       end
     end
+
+    context "#serialize_params" do
+      should "serialize when items is set to an Array" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "subscription",
+          items: Stripe::Util.convert_to_stripe_object(
+            object: "list",
+            data: []
+          ),
+        }, {})
+        obj.items = [
+          { id: "si_foo", deleted: true },
+          { plan: "plan_bar" },
+        ]
+
+        expected = {
+          items: {
+            :"0" => { id: "si_foo", deleted: true },
+            :"1" => { plan: "plan_bar" },
+          },
+        }
+        assert_equal(expected, obj.serialize_params)
+      end
+
+      should "serialize when items is set to a Hash" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "subscription",
+          items: Stripe::Util.convert_to_stripe_object(
+            object: "list",
+            data: []
+          ),
+        }, {})
+        obj.items = {
+          "0" => { id: "si_foo", deleted: true },
+          "1" => { plan: "plan_bar" },
+        }
+
+        expected = {
+          items: {
+            :"0" => { id: "si_foo", deleted: true },
+            :"1" => { plan: "plan_bar" },
+          },
+        }
+        assert_equal(expected, obj.serialize_params)
+      end
+    end
   end
 end


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #554.

Back in #467, we introduced support for transparently turning the `items` parameter to a hash of hashes if needed when calling `Subscription#create` or `Subscription#update`. However, this failed to handle the case where you'd retrieve a subscription, set the `items` attribute and save the subscription.

There were actually two different issues going on in the above case:

1. The parameter was not being converted to a Hash if needed.

2. Even if the user provided a Hash directly, the library would try to unset the fields on the existing `ListObject` of the subscription's `items` attribute.

This PR fixes both issues, by calling `Util.array_to_hash` and by passing `nil` for the original value when serializing `items`.

It also calls `Util.array_to_hash` on a few other methods/parameters as needed.
