### PR TITLE
Nested resource class methods

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -20,6 +20,7 @@ require "stripe/api_operations/save"
 require "stripe/api_operations/delete"
 require "stripe/api_operations/list"
 require "stripe/api_operations/request"
+require "stripe/api_operations/nested_resource"
 
 # API resource support classes
 require "stripe/errors"

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -5,10 +5,13 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Delete
     include Stripe::APIOperations::Save
+    extend Stripe::APIOperations::NestedResource
 
     OBJECT_NAME = "account".freeze
 
     save_nested_resource :external_account
+    nested_resource_class_methods :external_account
+    nested_resource_class_methods :login_link, operations: %i[create]
 
     # This method is deprecated. Please use `#external_account=` instead.
     save_nested_resource :bank_account

--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -1,0 +1,54 @@
+module Stripe
+  module APIOperations
+    module NestedResource
+      def nested_resource_class_methods(resource, path: nil, operations: nil)
+        path ||= "#{resource}s"
+        operations ||= %i[create retrieve update delete list]
+
+        resource_url_method = :"#{resource}s_url"
+        define_singleton_method(resource_url_method) do |id, nested_id = nil|
+          url = "#{resource_url}/#{CGI.escape(id)}/#{CGI.escape(path)}"
+          url += "/#{CGI.escape(nested_id)}" unless nested_id.nil?
+          url
+        end
+
+        operations.each do |operation|
+          case operation
+          when :create
+            define_singleton_method(:"create_#{resource}") do |id, params = {}, opts = {}|
+              url = send(resource_url_method, id)
+              resp, opts = request(:post, url, params, opts)
+              Util.convert_to_stripe_object(resp.data, opts)
+            end
+          when :retrieve
+            define_singleton_method(:"retrieve_#{resource}") do |id, nested_id, opts = {}|
+              url = send(resource_url_method, id, nested_id)
+              resp, opts = request(:get, url, {}, opts)
+              Util.convert_to_stripe_object(resp.data, opts)
+            end
+          when :update
+            define_singleton_method(:"update_#{resource}") do |id, nested_id, params = {}, opts = {}|
+              url = send(resource_url_method, id, nested_id)
+              resp, opts = request(:post, url, params, opts)
+              Util.convert_to_stripe_object(resp.data, opts)
+            end
+          when :delete
+            define_singleton_method(:"delete_#{resource}") do |id, nested_id, params = {}, opts = {}|
+              url = send(resource_url_method, id, nested_id)
+              resp, opts = request(:delete, url, params, opts)
+              Util.convert_to_stripe_object(resp.data, opts)
+            end
+          when :list
+            define_singleton_method(:"list_#{resource}s") do |id, params = {}, opts = {}|
+              url = send(resource_url_method, id)
+              resp, opts = request(:get, url, params, opts)
+              Util.convert_to_stripe_object(resp.data, opts)
+            end
+          else
+            raise ArgumentError, "Unknown operation: #{operation.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -1,8 +1,11 @@
 module Stripe
   class ApplicationFee < APIResource
     extend Stripe::APIOperations::List
+    extend Stripe::APIOperations::NestedResource
 
     OBJECT_NAME = "application_fee".freeze
+
+    nested_resource_class_methods :refund, operations: %i[create retrieve update list]
 
     def self.resource_url
       "/v1/application_fees"

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -4,10 +4,18 @@ module Stripe
     include Stripe::APIOperations::Delete
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
+    extend Stripe::APIOperations::NestedResource
 
     OBJECT_NAME = "customer".freeze
 
     save_nested_resource :source
+    nested_resource_class_methods :source
+
+    # The API request for deleting a card or bank account and for detaching a
+    # source object are the same.
+    class << self
+      alias detach_source delete_source
+    end
 
     def add_invoice_item(params, opts = {})
       opts = @opts.merge(Util.normalize_opts(opts))

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -3,8 +3,11 @@ module Stripe
     extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Save
+    extend Stripe::APIOperations::NestedResource
 
     OBJECT_NAME = "transfer".freeze
+
+    nested_resource_class_methods :reversal, operations: %i[create retrieve update list]
 
     def cancel
       resp, api_key = request(:post, cancel_url)

--- a/test/stripe/account_external_accounts_operations_test.rb
+++ b/test/stripe/account_external_accounts_operations_test.rb
@@ -1,0 +1,66 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class AccountExternalAccountsOperationsTest < Test::Unit::TestCase
+    setup do
+      @account_id = "acct_123"
+      @external_account_id = "ba_123"
+    end
+
+    context "#create_external_account" do
+      should "create an external account" do
+        external_account = Stripe::Account.create_external_account(
+          @account_id,
+          external_account: "btok_123"
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts"
+        assert external_account.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#retrieve_external_account" do
+      should "retrieve an external account" do
+        external_account = Stripe::Account.retrieve_external_account(
+          @account_id,
+          @external_account_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts/#{@external_account_id}"
+        assert external_account.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#update_external_account" do
+      should "update an external account" do
+        external_account = Stripe::Account.update_external_account(
+          @account_id,
+          @external_account_id,
+          metadata: { foo: "bar" }
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts/#{@external_account_id}"
+        assert external_account.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#delete_external_account" do
+      should "delete an external_account" do
+        external_account = Stripe::Account.delete_external_account(
+          @account_id,
+          @external_account_id
+        )
+        assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts/#{@external_account_id}"
+        assert external_account.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#list_external_accounts" do
+      should "list the account's external accounts" do
+        external_accounts = Stripe::Account.list_external_accounts(
+          @account_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts"
+        assert external_accounts.is_a?(Stripe::ListObject)
+        assert external_accounts.data.is_a?(Array)
+      end
+    end
+  end
+end

--- a/test/stripe/account_login_links_operations_test.rb
+++ b/test/stripe/account_login_links_operations_test.rb
@@ -1,0 +1,19 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class AccountLoginLinksOperationsTest < Test::Unit::TestCase
+    setup do
+      @account_id = "acct_123"
+    end
+
+    context "#create_login_link" do
+      should "create a login link" do
+        login_link = Stripe::Account.create_login_link(
+          @account_id
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{@account_id}/login_links"
+        assert login_link.is_a?(Stripe::LoginLink)
+      end
+    end
+  end
+end

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -27,5 +27,49 @@ module Stripe
         assert_equal "Cannot update protected field: protected", e.message
       end
     end
+
+    context ".nested_resource_class_methods" do
+      class MainResource < APIResource
+        extend Stripe::APIOperations::NestedResource
+        nested_resource_class_methods :nested
+      end
+
+      should "define a create method" do
+        stub_request(:post, "#{Stripe.api_base}/v1/mainresources/id/nesteds")
+          .with(body: { foo: "bar" })
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        nested_resource = MainResource.create_nested("id", foo: "bar")
+        assert_equal "bar", nested_resource.foo
+      end
+
+      should "define a retrieve method" do
+        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        nested_resource = MainResource.retrieve_nested("id", "nested_id")
+        assert_equal "bar", nested_resource.foo
+      end
+
+      should "define an update method" do
+        stub_request(:post, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
+          .with(body: { foo: "baz" })
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "baz"))
+        nested_resource = MainResource.update_nested("id", "nested_id", foo: "baz")
+        assert_equal "baz", nested_resource.foo
+      end
+
+      should "define a delete method" do
+        stub_request(:delete, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", deleted: true))
+        nested_resource = MainResource.delete_nested("id", "nested_id")
+        assert_equal true, nested_resource.deleted
+      end
+
+      should "define a list method" do
+        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds")
+          .to_return(body: JSON.generate(object: "list", data: []))
+        nested_resources = MainResource.list_nesteds("id")
+        assert nested_resources.data.is_a?(Array)
+      end
+    end
   end
 end

--- a/test/stripe/application_fee_refunds_operations_test.rb
+++ b/test/stripe/application_fee_refunds_operations_test.rb
@@ -1,0 +1,54 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class ApplicationFeeRefundsOperationsTest < Test::Unit::TestCase
+    setup do
+      @application_fee_id = "fee_123"
+      @refund_id = "fr_123"
+    end
+
+    context "#create_refund" do
+      should "create a refund" do
+        refund = Stripe::ApplicationFee.create_refund(
+          @application_fee_id
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/application_fees/#{@application_fee_id}/refunds"
+        assert refund.is_a?(Stripe::ApplicationFeeRefund)
+      end
+    end
+
+    context "#retrieve_refund" do
+      should "retrieve a refund" do
+        refund = Stripe::ApplicationFee.retrieve_refund(
+          @application_fee_id,
+          @refund_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/application_fees/#{@application_fee_id}/refunds/#{@refund_id}"
+        assert refund.is_a?(Stripe::ApplicationFeeRefund)
+      end
+    end
+
+    context "#update_refund" do
+      should "update a refund" do
+        refund = Stripe::ApplicationFee.update_refund(
+          @application_fee_id,
+          @refund_id,
+          metadata: { foo: "bar" }
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/application_fees/#{@application_fee_id}/refunds/#{@refund_id}"
+        assert refund.is_a?(Stripe::ApplicationFeeRefund)
+      end
+    end
+
+    context "#list_refunds" do
+      should "list the application fee's refuns" do
+        refunds = Stripe::ApplicationFee.list_refunds(
+          @application_fee_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/application_fees/#{@application_fee_id}/refunds"
+        assert refunds.is_a?(Stripe::ListObject)
+        assert refunds.data.is_a?(Array)
+      end
+    end
+  end
+end

--- a/test/stripe/customer_sources_operations_test.rb
+++ b/test/stripe/customer_sources_operations_test.rb
@@ -1,0 +1,66 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class CustomerSourcesOperationsTest < Test::Unit::TestCase
+    setup do
+      @customer_id = "cus_123"
+      @source_id = "ba_123"
+    end
+
+    context "#create_source" do
+      should "create a source" do
+        source = Stripe::Customer.create_source(
+          @customer_id,
+          source: "tok_123"
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/customers/#{@customer_id}/sources"
+        assert source.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#retrieve_source" do
+      should "retrieve a source" do
+        source = Stripe::Customer.retrieve_source(
+          @customer_id,
+          @source_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/customers/#{@customer_id}/sources/#{@source_id}"
+        assert source.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#update_source" do
+      should "update a source" do
+        source = Stripe::Customer.update_source(
+          @customer_id,
+          @source_id,
+          metadata: { foo: "bar" }
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/customers/#{@customer_id}/sources/#{@source_id}"
+        assert source.is_a?(Stripe::Card)
+      end
+    end
+
+    context "#delete_source" do
+      should "delete a source" do
+        source = Stripe::Customer.delete_source(
+          @customer_id,
+          @source_id
+        )
+        assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{@customer_id}/sources/#{@source_id}"
+        assert source.is_a?(Stripe::BankAccount)
+      end
+    end
+
+    context "#list_sources" do
+      should "list the customer's sources" do
+        sources = Stripe::Customer.list_sources(
+          @customer_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/customers/#{@customer_id}/sources"
+        assert sources.is_a?(Stripe::ListObject)
+        assert sources.data.is_a?(Array)
+      end
+    end
+  end
+end

--- a/test/stripe/transfer_reversals_operations_test.rb
+++ b/test/stripe/transfer_reversals_operations_test.rb
@@ -1,0 +1,55 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class TransferReversalsOperationsTest < Test::Unit::TestCase
+    setup do
+      @transfer_id = "tr_123"
+      @reversal_id = "trr_123"
+    end
+
+    context "#create_reversal" do
+      should "create a reversal" do
+        reversal = Stripe::Transfer.create_reversal(
+          @transfer_id,
+          amount: 100
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/transfers/#{@transfer_id}/reversals"
+        assert reversal.is_a?(Stripe::Reversal)
+      end
+    end
+
+    context "#retrieve_reversal" do
+      should "retrieve a reversal" do
+        reversal = Stripe::Transfer.retrieve_reversal(
+          @transfer_id,
+          @reversal_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/transfers/#{@transfer_id}/reversals/#{@reversal_id}"
+        assert reversal.is_a?(Stripe::Reversal)
+      end
+    end
+
+    context "#update_reversal" do
+      should "update a reversal" do
+        reversal = Stripe::Transfer.update_reversal(
+          @transfer_id,
+          @reversal_id,
+          metadata: { foo: "bar" }
+        )
+        assert_requested :post, "#{Stripe.api_base}/v1/transfers/#{@transfer_id}/reversals/#{@reversal_id}"
+        assert reversal.is_a?(Stripe::Reversal)
+      end
+    end
+
+    context "#list_reversals" do
+      should "list the transfer's reversals" do
+        reversals = Stripe::Transfer.list_reversals(
+          @transfer_id
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/transfers/#{@transfer_id}/reversals"
+        assert reversals.is_a?(Stripe::ListObject)
+        assert reversals.data.is_a?(Array)
+      end
+    end
+  end
+end


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR is an attempt at fixing #420. It adds a `nested_resource_class_methods` DSL method that `StripeObject`s can use to define methods to access a nested resource without needing to retrieve the owning resource first.

E.g. you can now create a card on a customer like this:

```ruby
card = Stripe::Customer.create_card(
  "cus_...",
  token: "tok_visa"
)
```

and update it like this:

```ruby
updated_card = Stripe::Customer.update_card(
  "cus_...",
  "card_...",
  exp_month: 12,
  exp_year: 2020
)
```

This is helpful for users looking to minimize the number of outgoing API requests.
