### PR TITLE
Don't persist `idempotency_key` option between API requests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 298
+  Max: 302
 
 # Offense count: 5
 # Configuration parameters: CountKeywordArgs.

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -23,7 +23,7 @@ module Stripe
           # Hash#select returns an array before 1.9
           opts_to_persist = {}
           opts.each do |k, v|
-            opts_to_persist[k] = v if Util::OPTS_KEYS_TO_PERSIST.include?(k)
+            opts_to_persist[k] = v if Util::OPTS_PERSISTABLE.include?(k)
           end
 
           [resp, opts_to_persist]

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -12,11 +12,15 @@ module Stripe
 
     # Options that should be copyable from one StripeObject to another
     # including options that may be internal.
-    OPTS_COPYABLE = (OPTS_USER_SPECIFIED + Set[:api_base]).freeze
+    OPTS_COPYABLE = (
+      OPTS_USER_SPECIFIED + Set[:api_base]
+    ).freeze
 
     # Options that should be persisted between API requests. This includes
     # client, which is an object containing an HTTP client to reuse.
-    OPTS_KEYS_TO_PERSIST = (OPTS_USER_SPECIFIED + Set[:client]).freeze
+    OPTS_PERSISTABLE = (
+      OPTS_USER_SPECIFIED + Set[:client] - Set[:idempotency_key]
+    ).freeze
 
     def self.objects_to_ids(h)
       case h

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -2,6 +2,22 @@ require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class UtilTest < Test::Unit::TestCase
+    context "OPTS_COPYABLE" do
+      should "include :apibase" do
+        assert_include Stripe::Util::OPTS_COPYABLE, :api_base
+      end
+    end
+
+    context "OPTS_PERSISTABLE" do
+      should "include :client" do
+        assert_include Stripe::Util::OPTS_PERSISTABLE, :client
+      end
+
+      should "not include :idempotency_key" do
+        refute_includes Stripe::Util::OPTS_PERSISTABLE, :idempotency_key
+      end
+    end
+
     should "#encode_parameters should prepare parameters for an HTTP request" do
       params = {
         a: 3,


### PR DESCRIPTION
Excludes `idempotency_key` from opts to persist between API requests.
Obviously the same idempotency key is not something that we ever want to
use again.

Fixes #598.

r? @ob-stripe