### PR TITLE
Add explicit operations list everywhere

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -10,7 +10,8 @@ module Stripe
     OBJECT_NAME = "account".freeze
 
     save_nested_resource :external_account
-    nested_resource_class_methods :external_account
+    nested_resource_class_methods :external_account,
+                                  operations: %i[create retrieve update delete list]
     nested_resource_class_methods :login_link, operations: %i[create]
 
     # This method is deprecated. Please use `#external_account=` instead.

--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -10,7 +10,7 @@ module Stripe
     module NestedResource
       def nested_resource_class_methods(resource, path: nil, operations: nil)
         path ||= "#{resource}s"
-        operations ||= %i[create retrieve update delete list]
+        raise ArgumentError, "operations array required" if operations.nil?
 
         resource_url_method = :"#{resource}s_url"
         define_singleton_method(resource_url_method) do |id, nested_id = nil|

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -9,7 +9,8 @@ module Stripe
     OBJECT_NAME = "customer".freeze
 
     save_nested_resource :source
-    nested_resource_class_methods :source
+    nested_resource_class_methods :source,
+                                  operations: %i[create retrieve update delete list]
 
     # The API request for deleting a card or bank account and for detaching a
     # source object are the same.

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -31,7 +31,8 @@ module Stripe
     context ".nested_resource_class_methods" do
       class MainResource < APIResource
         extend Stripe::APIOperations::NestedResource
-        nested_resource_class_methods :nested
+        nested_resource_class_methods :nested,
+                                      operations: %i[create retrieve update delete list]
       end
 
       should "define a create method" do


### PR DESCRIPTION
Makes the `operations` argument to `nested_resource_class_methods` required and adds explicit lists to any invocations that were missing one.

The impetus here is that I think it's more easily digestible if each call site is explicit about what operations it supports and therefore which methods it's about to create on the class.

r? @ob-stripe This is definitely the pedant in me, but I kind of like seeing the explicit list of operations for each of these, and most call sites had to define an explicit list from the beginning anyway sine they don't support all operations. Thoughts?