### PR TITLE
Skip calling to_hash for nil

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -116,7 +116,7 @@ module Stripe
 
     def to_hash
       maybe_to_hash = lambda do |value|
-        value.respond_to?(:to_hash) ? value.to_hash : value
+        value && value.respond_to?(:to_hash) ? value.to_hash : value
       end
 
       @values.each_with_object({}) do |(key, value), acc|

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -115,23 +115,39 @@ module Stripe
       end
     end
 
-    should "recursively call to_hash on its values" do
-      # deep nested hash (when contained in an array) or StripeObject
-      nested_hash = { id: 7, foo: "bar" }
-      nested = Stripe::StripeObject.construct_from(nested_hash)
+    context "#to_hash" do
+      should "skip calling to_hash on nil" do
+        module NilWithToHash
+          def to_hash
+            raise "Can't call to_hash on nil"
+          end
+        end
+        NilClass.include NilWithToHash
 
-      obj = Stripe::StripeObject.construct_from(id: 1,
-                                                # simple hash that contains a StripeObject to help us test deep
-                                                # recursion
-                                                nested: { object: "list", data: [nested] },
-                                                list: [nested])
+        hash_with_nil = { id: 3, foo: nil }
+        obj = StripeObject.construct_from(hash_with_nil)
+        expected_hash = { id: 3, foo: nil }
+        assert_equal expected_hash, obj.to_hash
+      end
 
-      expected_hash = {
-        id: 1,
-        nested: { object: "list", data: [nested_hash] },
-        list: [nested_hash],
-      }
-      assert_equal expected_hash, obj.to_hash
+      should "recursively call to_hash on its values" do
+        # deep nested hash (when contained in an array) or StripeObject
+        nested_hash = { id: 7, foo: "bar" }
+        nested = Stripe::StripeObject.construct_from(nested_hash)
+
+        obj = Stripe::StripeObject.construct_from(id: 1,
+                                                  # simple hash that contains a StripeObject to help us test deep
+                                                  # recursion
+                                                  nested: { object: "list", data: [nested] },
+                                                  list: [nested])
+
+        expected_hash = {
+          id: 1,
+          nested: { object: "list", data: [nested_hash] },
+          list: [nested_hash],
+        }
+        assert_equal expected_hash, obj.to_hash
+      end
     end
 
     should "assign question mark accessors for booleans" do


### PR DESCRIPTION
# Problem
Using `stripe` and `representable` where they both override `to_hash` method, depending on load order of the gems we randomly ran into issues like:
```shell
 NoMethodError:
       undefined method `definitions' for NilClass:Class
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable.rb:96:in `representable_attrs'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable.rb:74:in `representable_bindings_for'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable.rb:64:in `representable_map'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable.rb:70:in `representable_map!'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable.rb:45:in `create_representation_with'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/representable-3.0.4/lib/representable/hash.rb:34:in `to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/roar-1.1.0/lib/roar/json/hal.rb:58:in `to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:121:in `block in to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:129:in `block in to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `each'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `inject'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:121:in `block in to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:129:in `block in to_hash'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `each'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `inject'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/stripe-1.58.0/lib/stripe/stripe_object.rb:124:in `to_hash'
     # ./spec/notifications/events/invoice_transaction_representer_spec.rb:23:in `block (2 levels) in <top (required)>'
     # ./spec/notifications/events/invoice_transaction_representer_spec.rb:27:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:43:in `block (3 levels) in <top (required)>'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/database_cleaner-1.6.1/lib/database_cleaner/generic/base.rb:16:in `cleaning'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/database_cleaner-1.6.1/lib/database_cleaner/base.rb:98:in `cleaning'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/database_cleaner-1.6.1/lib/database_cleaner/configuration.rb:86:in `block (2 levels) in cleaning'
     # /Users/ashkinas/.rvm/gems/ruby-2.4.1/gems/database_cleaner-1.6.1/lib/database_cleaner/configuration.rb:87:in `cleaning'
     # ./spec/rails_helper.rb:43:in `block (2 levels) in <top (required)>'
```

When calling `to_hash` on an `Stripe::Event` object.

# Solution
While this seems like something that need to be fixed also on `representable` we noticed above issue only happens when trying to call `to_hash` on `nil` attributes of `Stripe::Event` so adding a simple check to see if `value` is not `nil` then call `to_hash` should fix the problem.