### PR TITLE
Remove manual exchange rate stubbing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.2.0
+    - STRIPE_MOCK_VERSION=0.4.0
 
 cache:
   directories:

--- a/test/stripe/exchange_rate_test.rb
+++ b/test/stripe/exchange_rate_test.rb
@@ -3,24 +3,6 @@ require File.expand_path("../../test_helper", __FILE__)
 module Stripe
   class ExchangeRateTest < Test::Unit::TestCase
     should "be listable" do
-      # TODO: remove stub once stripe-mock supports /v1/exchange_rates
-      stub_request(:get, "#{Stripe.api_base}/v1/exchange_rates")
-        .to_return(body: JSON.generate(
-          object: "list",
-          data: [
-            {
-              id: "eur",
-              object: "exchange_rate",
-              rates: { "usd" => 1.18221 },
-            },
-            {
-              id: "usd",
-              object: "exchange_rate",
-              rates: { "eur" => 0.845876 },
-            },
-          ]
-        ))
-
       list_rates = Stripe::ExchangeRate.list
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates"
       assert list_rates.data.is_a?(Array)
@@ -28,14 +10,6 @@ module Stripe
     end
 
     should "be retrievable" do
-      # TODO: remove stub once stripe-mock supports /v1/exchange_rates
-      stub_request(:get, "#{Stripe.api_base}/v1/exchange_rates/usd")
-        .to_return(body: JSON.generate(
-          id: "usd",
-          object: "exchange_rate",
-          rates: { "eur" => 0.845876 }
-        ))
-
       rates = Stripe::ExchangeRate.retrieve("usd")
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates/usd"
       assert rates.is_a?(Stripe::ExchangeRate)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path("../test_data", __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.2.0".freeze
+MOCK_MINIMUM_VERSION = "0.4.0".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
stripe-mock 0.4.0 comes with the up-to-date exchange rates API. Here we
bump the required version and remove the manual exchange rate stubbing
in stripe-ruby's test suite.

r? @ob-stripe
cc @stripe/api-libraries