### PR TITLE
Support Tempfiles in file_upload creation requests

### DIFF
--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -1,3 +1,5 @@
+require "tempfile"
+
 module Stripe
   class FileUpload < APIResource
     extend Stripe::APIOperations::Create
@@ -20,7 +22,7 @@ module Stripe
       # rest-client would accept a vanilla `File` for upload, but Faraday does
       # not. Support the old API by wrapping a `File` with an `UploadIO` object
       # if we're given one.
-      if params[:file] && params[:file].is_a?(File)
+      if params[:file] && [File, Tempfile].any? { |klass| params[:file].is_a?(klass) }
         params[:file] = Faraday::UploadIO.new(params[:file], nil)
       end
 

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -31,7 +31,7 @@ module Stripe
       assert file.is_a?(Stripe::FileUpload)
     end
 
-    should "be creatable" do
+    should "be creatable with a File" do
       stub_request(:post, "#{Stripe.uploads_base}/v1/files")
         .with(headers: {
           "Content-Type" => /\A#{Faraday::Request::Multipart.mime_type}/,
@@ -42,6 +42,25 @@ module Stripe
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
         file: File.new(__FILE__)
+      )
+      assert file.is_a?(Stripe::FileUpload)
+    end
+
+    should "be creatable with a Tempfile" do
+      stub_request(:post, "#{Stripe.uploads_base}/v1/files")
+        .with(headers: {
+          "Content-Type" => /\A#{Faraday::Request::Multipart.mime_type}/,
+        }) do |request|
+        request.body =~ /Hello world/
+      end.to_return(body: JSON.generate(FIXTURE))
+
+      tempfile = Tempfile.new("foo")
+      tempfile.write("Hello world")
+      tempfile.rewind
+
+      file = Stripe::FileUpload.create(
+        purpose: "dispute_evidence",
+        file: tempfile
       )
       assert file.is_a?(Stripe::FileUpload)
     end


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Fixes #610.

Back in #508, we reintroduced support for passing `File` instances, but not `Tempfile` instances. (I'm not sure why `Tempfile` is not a subclass of `File` but ¯\\\_(ツ)\_/¯)

This PR adds support for passing `Tempfile` instances, which is useful for e.g. opening a remote file via `open-uri`.
