### PR TITLE
Fix encoding of arrays that are sent in query strings

### DIFF
--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -87,8 +87,9 @@ module Stripe
         assert_requested :get, "#{Stripe.api_base}/v1/invoices/upcoming",
                          query: {
                            customer: "cus_123",
-                           :'subscription_items[][plan]' => "gold",
-                           :'subscription_items[][quantity]' =>  2,
+                           subscription_items: [
+                             { plan: "gold", quantity: "2" },
+                           ],
                          }
         assert invoice.is_a?(Stripe::Invoice)
       end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -176,7 +176,7 @@ module Stripe
           Util.expects(:log_debug).with("Request details",
                                         body: "",
                                         idempotency_key: "abc",
-                                        query_string: nil)
+                                        query_params: nil)
 
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: "acct_123",


### PR DESCRIPTION
As discussed in #608, we currently have a problem where Faraday
deconstructs a query string that we encode and strips out any of the
array index numbers that we added. It's not too clear on why it does
this, but it appears to be built in at a pretty low level and hard to
change.

I spent a little time on this and it turns out that we can avoid the bad
code by depending on Faraday's `params` accessor on a request instead of
trying to do the encoding ourselves. Webmock has a pretty hard time
detecting the difference, but you can see some before and after encoding
here.

Before:

```
I, [2017-12-06T17:41:23.083942 #36737]  INFO -- : get
http://localhost:12111/v1/invoices/upcoming?customer=cus_123&subscription_items%5B%5D%5Bplan%5D=gold&subscription_items%5B%5D%5Bquantity%5D=2
```

After:

```
I, [2017-12-06T17:42:12.727752 #37158]  INFO -- : get
http://localhost:12111/v1/invoices/upcoming?customer=cus_123&subscription_items%5B0%5D%5Bplan%5D=gold&subscription_items%5B0%5D%5Bquantity%5D=2
```

Honestly, some of this can still use a lot of cleanup: it's weird that
we manually encode parameters ourselves for bodies, but not for queries;
but I think this'll fix the problem for now.

Fixes #608.