### PR TITLE
Introduce new `IdempotencyError` type

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,12 +13,12 @@ Metrics/AbcSize:
 # Offense count: 27
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 455
+  Max: 467
 
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 583
+  Max: 595
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -66,6 +66,11 @@ module Stripe
     end
   end
 
+  # IdempotencyError is raised in cases where an idempotency key was used
+  # improperly.
+  class IdempotencyError < StripeError
+  end
+
   # InvalidRequestError is raised when a request is initiated with invalid
   # parameters.
   class InvalidRequestError < StripeError


### PR DESCRIPTION
A few weeks back a new error type `idempotency_error` was introduced in the
API. I put it in to respond to #503, but then forgot to add support for it in
this library. This patch introduces a new exception class that represents it.

r? @ob-stripe One thing that's a little janky about this patch is that we were
previously just doing error type switching off of the returned status code, but
here we add a second ladder on error type because a 400 becomes ambiguous. This
works fine conceptually, but it might be that we just have a single ladder on
error type and ignore the status code completely (this is how stripe-node works
for example). Thoughts?