### PR TITLE
Add support for coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Gemfile.lock
 tags
 /.bundle/
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
   gem "rake"
   gem "shoulda-context"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Stripe Ruby Library [![Build Status](https://travis-ci.org/stripe/stripe-ruby.svg?branch=master)](https://travis-ci.org/stripe/stripe-ruby)
+# Stripe Ruby Library
+
+[![Build Status](https://travis-ci.org/stripe/stripe-ruby.svg?branch=master)](https://travis-ci.org/stripe/stripe-ruby)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
 
 The Stripe Ruby library provides convenient access to the Stripe API from
 applications written in the Ruby language. It includes a pre-defined set of

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "coveralls"
+Coveralls.wear!("test_frameworks")
+
 require "stripe"
 require "test/unit"
 require "mocha/setup"


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for coveralls.io: https://coveralls.io/github/stripe/stripe-ruby