### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 tags
 /.bundle/
 coverage/
+test/reports/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ cache:
     - stripe-mock
 
 before_install:
+  # Download and Configure Testspace client 
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+
   # Unpack and start stripe-mock so that the test suite can talk to it
   - |
     if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then
@@ -36,3 +41,6 @@ before_install:
 
 script:
   - bundle exec rake
+
+after_script:
+  - testspace [Ruby_${TRAVIS_RUBY_VERSION}]test/reports/TEST-*.xml{test}

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "ci_reporter_test_unit"
   gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
   gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 require "rake/testtask"
+require "ci/reporter/rake/test_unit"
 require "rubocop/rake_task"
 
-task default: %i[test rubocop]
+task default: %i[ci:setup:testunit test rubocop]
 
 Rake::TestTask.new do |t|
   t.pattern = "./test/**/*_test.rb"


### PR DESCRIPTION
Hi, `stride-ruby` team. We’ve made a few minor changes to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/).
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:stripe-ruby from our fork.

A few of the **benefits** for your Contributors:
 * Move beyond the flat, endless console output. Results in Testspace mirror your matrix jobs, test folders, suites, and cases hierarchy.
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

And for Owners:
 * Monitor the status of all your repositories, their local branches, and pull requests from a single dashboard.
 * View historical tracking of all your important metrics; test case and coverage growth, static analysis issues, custom metrics, etc.

Note: We also generated a Pull Request for the [stripe-java](https://github.com/stripe/stripe-java/pulls) Repo.

[Read more...](https://blog.testspace.com/testspace-and-open-source/)

----

**Want to Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users
