### PR TITLE
Skip calling to_hash for nil

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -116,7 +116,7 @@ module Stripe
 
     def to_hash
       maybe_to_hash = lambda do |value|
-        value.respond_to?(:to_hash) ? value.to_hash : value
+        value && value.respond_to?(:to_hash) ? value.to_hash : value
       end
 
       @values.each_with_object({}) do |(key, value), acc|


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @ashkan18 

Replaces #602. The PR has been open for a while and it's been bothering me :P

This is exactly the same as #602, except that `NilClass.include NilWithToHash` was replaced with `NilClass.send(:include, NilWithToHash)` so that the test suite works with Ruby 2.0.

