### PR TITLE
Add support for /v1/topups endpoints

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 304
+  Max: 305
 
 # Offense count: 5
 # Configuration parameters: CountKeywordArgs.

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -74,6 +74,7 @@ require "stripe/subscription"
 require "stripe/subscription_item"
 require "stripe/three_d_secure"
 require "stripe/token"
+require "stripe/topup"
 require "stripe/transfer"
 
 # OAuth

--- a/lib/stripe/topup.rb
+++ b/lib/stripe/topup.rb
@@ -1,0 +1,9 @@
+module Stripe
+  class Topup < APIResource
+    extend Stripe::APIOperations::List
+    extend Stripe::APIOperations::Create
+    include Stripe::APIOperations::Save
+
+    OBJECT_NAME = "topup".freeze
+  end
+end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -83,6 +83,7 @@ module Stripe
         SubscriptionItem::OBJECT_NAME     => SubscriptionItem,
         ThreeDSecure::OBJECT_NAME         => ThreeDSecure,
         Token::OBJECT_NAME                => Token,
+        Topup::OBJECT_NAME                => Topup,
         Transfer::OBJECT_NAME             => Transfer,
       }
     end

--- a/test/stripe/topup_test.rb
+++ b/test/stripe/topup_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class TopupTest < Test::Unit::TestCase
+    should "be listable" do
+      topups = Stripe::Topup.list
+      assert_requested :get, "#{Stripe.api_base}/v1/topups"
+      assert topups.data.is_a?(Array)
+      assert topups.data[0].is_a?(Stripe::Topup)
+    end
+
+    should "be retrievable" do
+      topup = Stripe::Topup.retrieve("tu_123")
+      assert_requested :get, "#{Stripe.api_base}/v1/topups/tu_123"
+      assert topup.is_a?(Stripe::Topup)
+    end
+
+    should "be creatable" do
+      topup = Stripe::Topup.create(
+        amount: 100,
+        currency: "USD",
+        source: "src_123",
+        description: "description",
+        statement_descriptor: "statement descriptor"
+      )
+      assert_requested :post, "#{Stripe.api_base}/v1/topups"
+      assert topup.is_a?(Stripe::Topup)
+    end
+
+    should "be saveable" do
+      topup = Stripe::Topup.retrieve("tu_123")
+      topup.metadata["key"] = "value"
+      topup.save
+      assert_requested :post, "#{Stripe.api_base}/v1/topups/#{topup.id}"
+    end
+
+    should "be updateable" do
+      topup = Stripe::Topup.update("tu_123", metadata: { foo: "bar" })
+      assert_requested :post, "#{Stripe.api_base}/v1/topups/tu_123"
+      assert topup.is_a?(Stripe::Topup)
+    end
+  end
+end


### PR DESCRIPTION
This add standard retrieve, create and update client support for the new `/v1/topups` endpoint.

r? @apakulov-stripe @ccontinanza-stripe @chellman-stripe @kenneth-stripe @miguel-stripe
r? @stripe/api-libraries 