### PR TITLE
Fix replacement of non-`metadata` embedded `StripeObjects`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/ClassLength:
 
 # Offense count: 11
 Metrics/CyclomaticComplexity:
-  Max: 13
+  Max: 15
 
 # Offense count: 259
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
@@ -47,7 +47,7 @@ Metrics/ParameterLists:
 
 # Offense count: 5
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 17
 
 # Offense count: 2
 Style/ClassVars:

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -62,6 +62,15 @@ module Stripe
       end
 
       def self.included(base)
+        # Set `metadata` as additive so that when it's set directly we remember
+        # to clear keys that may have been previously set by sending empty
+        # values for them.
+        #
+        # It's possible that not every object with `Save` has `metadata`, but
+        # it's a close enough heuristic, and having this option set when there
+        # is no `metadata` field is not harmful.
+        base.additive_object_param(:metadata)
+
         base.extend(ClassMethods)
       end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -7,6 +7,66 @@ module Stripe
     # The default :id method is deprecated and isn't useful to us
     undef :id if method_defined?(:id)
 
+    # Sets the given parameter name to one which is known to be an additive
+    # object.
+    #
+    # Additive objects are subobjects in the API that don't have the same
+    # semantics as most subobjects, which are fully replaced when they're set.
+    # This is best illustrated by example. The `source` parameter sent when
+    # updating a subscription is *not* additive; if we set it:
+    #
+    #     source[object]=card&source[number]=123
+    #
+    # We expect the old `source` object to have been overwritten completely. If
+    # the previous source had an `address_state` key associated with it and we
+    # didn't send one this time, that value of `address_state` is gone.
+    #
+    # By contrast, additive objects are those that will have new data added to
+    # them while keeping any existing data in place. The only known case of its
+    # use is for `metadata`, but it could in theory be more general. As an
+    # example, say we have a `metadata` object that looks like this on the
+    # server side:
+    #
+    #     metadata = { old: "old_value" }
+    #
+    # If we update the object with `metadata[new]=new_value`, the server side
+    # object now has *both* fields:
+    #
+    #     metadata = { old: "old_value", new: "new_value" }
+    #
+    # This is okay in itself because usually users will want to treat it as
+    # additive:
+    #
+    #     obj.metadata[:new] = "new_value"
+    #     obj.save
+    #
+    # However, in other cases, they may want to replace the entire existing
+    # contents:
+    #
+    #     obj.metadata = { new: "new_value" }
+    #     obj.save
+    #
+    # This is where things get a little bit tricky because in order to clear
+    # any old keys that may have existed, we actually have to send an explicit
+    # empty string to the server. So the operation above would have to send
+    # this form to get the intended behavior:
+    #
+    #     metadata[old]=&metadata[new]=new_value
+    #
+    # This method allows us to track which parameters are considered additive,
+    # and lets us behave correctly where appropriate when serializing
+    # parameters to be sent.
+    def self.additive_object_param(name)
+      @additive_params ||= Set.new
+      @additive_params << name
+    end
+
+    # Returns whether the given name is an additive object parameter. See
+    # `.additive_object_param` for details.
+    def self.additive_object_param?(name)
+      !@additive_params.nil? && @additive_params.include?(name)
+    end
+
     def initialize(id = nil, opts = {})
       id, @retrieve_params = Util.normalize_id(id)
       @opts = Util.normalize_opts(opts)
@@ -410,12 +470,12 @@ module Stripe
       elsif value.is_a?(StripeObject)
         update = value.serialize_params(force: force)
 
-        # If the entire object was replaced and this is a `metadata` hash, then
-        # we need blank each field of the old object that held a value because
-        # otherwise the update to `metadata` will be additive instead of a full
-        # replacement. The new serialized values will override any of these
-        # empty values.
-        if original && unsaved && key && key == :metadata
+        # If the entire object was replaced and this is an additive object,
+        # then we need blank each field of the old object that held a value
+        # because otherwise the update to the keys of the object will be
+        # additive instead of a full replacement. The new serialized values
+        # will override any of these empty values.
+        if original && unsaved && key && self.class.additive_object_param?(key)
           update = empty_values(original).merge(update)
         end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -410,10 +410,14 @@ module Stripe
       elsif value.is_a?(StripeObject)
         update = value.serialize_params(force: force)
 
-        # If the entire object was replaced, then we need blank each field of
-        # the old object that held a value. The new serialized values will
-        # override any of these empty values.
-        update = empty_values(original).merge(update) if original && unsaved
+        # If the entire object was replaced and this is a `metadata` hash, then
+        # we need blank each field of the old object that held a value because
+        # otherwise the update to `metadata` will be additive instead of a full
+        # replacement. The new serialized values will override any of these
+        # empty values.
+        if original && unsaved && key && key == :metadata
+          update = empty_values(original).merge(update)
+        end
 
         update
 

--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -25,13 +25,8 @@ module Stripe
     end
 
     def serialize_params(options = {})
-      update_hash = super
-      if @unsaved_values.include?(:items)
-        value = Util.array_to_hash(@values[:items])
-        update_hash[:items] =
-          serialize_params_value(value, nil, true, options[:force], key: :items)
-      end
-      update_hash
+      @values[:items] = Util.array_to_hash(@values[:items]) if @values[:items]
+      super
     end
 
     private

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -303,12 +303,23 @@ module Stripe
       assert_equal({ foo: "bar" }, serialized[:metadata])
     end
 
-    should "#serialize_params with a StripeObject that's been replaced" do
+    should "#serialize_params with StripeObject that's been replaced" do
+      obj = Stripe::StripeObject.construct_from(source: Stripe::StripeObject.construct_from(bar: "foo"))
+
+      # Here we replace the object wholesale.
+      obj.source =
+        Stripe::StripeObject.construct_from(baz: "foo")
+
+      serialized = obj.serialize_params
+      assert_equal({ baz: "foo" }, serialized[:source])
+    end
+
+    should "#serialize_params with StripeObject that's been replaced which is `metadata`" do
       obj = Stripe::StripeObject.construct_from(metadata: Stripe::StripeObject.construct_from(bar: "foo"))
 
-      # Here we replace the object wholesale which means that the client must
-      # be able to blank out the values that were in the old object, but which
-      # are no longer present in the new one.
+      # Here we replace the object wholesale. Because it's `metadata`, the
+      # client must be able to blank out the values that were in the old
+      # object, but which are no longer present in the new one.
       obj.metadata =
         Stripe::StripeObject.construct_from(baz: "foo")
 

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -315,7 +315,11 @@ module Stripe
     end
 
     should "#serialize_params with StripeObject that's been replaced which is `metadata`" do
-      obj = Stripe::StripeObject.construct_from(metadata: Stripe::StripeObject.construct_from(bar: "foo"))
+      class WithAdditiveObjectParam < Stripe::StripeObject
+        additive_object_param :metadata
+      end
+
+      obj = WithAdditiveObjectParam.construct_from(metadata: Stripe::StripeObject.construct_from(bar: "foo"))
 
       # Here we replace the object wholesale. Because it's `metadata`, the
       # client must be able to blank out the values that were in the old


### PR DESCRIPTION
So we have a bit of a problem right now when it comes to replacing a
`StripeObject` that's embedded in an API resource.

Most of the time when someone does this, they want to _replace_ an
object embedded in another object. Take setting a source on a
subscription for example:

``` ruby
subscription.source = {
  object: 'card',
  number: 123,
}
subscription.save
```

In the case above, the serialized parameters should come out as:

```
source[object]=card&source[number]=123
```

That should apply even if the previous source had something else set on
it which we're not going to set this time -- say an optional parameter
like `source[address_state]`. Those should not be present at all in the
final serialized parameters.

(Another example is setting a `payout_schedule` as seen in #631 which is
PR is intended to address.)

There is an exception to this rule in the form of metadata though.
Metadata is a bit of a strange case in that the API will treat it as
additive, so if we send `metadata[foo]`, that will set the `foo` key,
but it won't overwrite any other keys that were already present.

This is a problem because when a user fully sets `metadata` to a new
object in Ruby, what they're probably trying to do is _replace_ it
rather than add to it. For example:

``` ruby
subscription.metadata
=> { old: 'bar' }

subscription.metadata = {
  new: 'baz'
}
subscription.save
```

To accomplish what the user is probably trying to do, we actually need
to send `metadata[old]=&metadata[new]=baz` so that we empty the value of
`old` while simultaneously setting `new` to `baz`.

In summary, metadata behaves different from other embedded objects in a
fairly fundamental way, and because the code is currently only set up to
handle the metadata case, it's not behaving correctly when other types
of objects are being set. A lot of the time emptying values like we do
for `metadata` is benign, but as we've seen in #631, sometimes it's not.

In this patch, I modify serialization to only empty out object values
when we see that parameter is `metadata`.

I'm really not crazy about the implementation here _at all_, but I'm
having trouble thinking of a better way to do it. One possibility is to
introduce a new class annotation like `empty_embedded_object :metadata`,
but that will have to go everywhere and might be error-prone in case
someone forgets it on a new resource type. If anyone has a suggestion
for an alternative (or can let me know if I'm missing something), I'd
love to hear it.

This PR is an alternate to #631.

@ob-stripe Thoughts? Thanks!
@remi-stripe Do I have the API semantics stated above right? Thanks!
cc @stripe/api-libraries