### PR TITLE
[WIP] Update stripe-mock to 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.8.0
+    - STRIPE_MOCK_VERSION=0.11.0
 
 cache:
   directories:

--- a/test/stripe/account_external_accounts_operations_test.rb
+++ b/test/stripe/account_external_accounts_operations_test.rb
@@ -43,12 +43,11 @@ module Stripe
 
     context "#delete_external_account" do
       should "delete an external_account" do
-        external_account = Stripe::Account.delete_external_account(
+        Stripe::Account.delete_external_account(
           @account_id,
           @external_account_id
         )
         assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts/#{@external_account_id}"
-        assert external_account.is_a?(Stripe::BankAccount)
       end
     end
 

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -54,8 +54,9 @@ module Stripe
 
     should "be deletable" do
       account = Stripe::Account.retrieve("acct_123")
+      account_id = account.id
       account = account.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{account.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{account_id}"
       assert account.is_a?(Stripe::Account)
     end
 

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -23,8 +23,9 @@ module Stripe
 
     should "be deletable" do
       domain = Stripe::ApplePayDomain.retrieve("apwc_123")
+      domain_id = domain.id
       domain = domain.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain_id}"
       assert domain.is_a?(Stripe::ApplePayDomain)
     end
   end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -36,8 +36,9 @@ module Stripe
 
     should "be deletable" do
       customer = Stripe::Customer.retrieve("cus_123")
+      customer_id = customer.id
       customer = customer.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer_id}"
       assert customer.is_a?(Stripe::Customer)
     end
 

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -44,9 +44,10 @@ module Stripe
 
     should "be deletable" do
       item = Stripe::InvoiceItem.retrieve("ii_123")
+      item_id = item.id
       item = item.delete
       assert_requested :delete,
-                       "#{Stripe.api_base}/v1/invoiceitems/#{item.id}"
+                       "#{Stripe.api_base}/v1/invoiceitems/#{item_id}"
       assert item.is_a?(Stripe::InvoiceItem)
     end
   end

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -42,8 +42,9 @@ module Stripe
 
     should "be deletable" do
       plan = Stripe::Plan.retrieve("sapphire-elite")
+      plan_id = plan.id
       plan = plan.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan_id}"
       assert plan.is_a?(Stripe::Plan)
     end
   end

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -39,8 +39,9 @@ module Stripe
 
     should "be deletable" do
       product = Stripe::Product.retrieve("prod_123")
+      product_id = product.id
       product = product.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product_id}"
       assert product.is_a?(Stripe::Product)
     end
   end

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -39,8 +39,9 @@ module Stripe
 
     should "be deletable" do
       recipient = Stripe::Recipient.retrieve("rp_123")
+      recipient_id = recipient.id
       recipient = recipient.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient_id}"
       assert recipient.is_a?(Stripe::Recipient)
     end
   end

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -40,8 +40,9 @@ module Stripe
 
     should "be deletable" do
       sku = Stripe::SKU.retrieve("sku_123")
+      sku_id = sku.id
       sku = sku.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku_id}"
       assert sku.is_a?(Stripe::SKU)
     end
   end

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -44,8 +44,9 @@ module Stripe
 
     should "be deletable" do
       item = Stripe::SubscriptionItem.retrieve("si_123")
+      item_id = item.id
       item = item.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
+      assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item_id}"
       assert item.is_a?(Stripe::SubscriptionItem)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path("../test_data", __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.4.0".freeze
+MOCK_MINIMUM_VERSION = "0.11.0".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Update stripe-mock to 0.11.0.

~Because stripe-mock now properly returns deleted resources without an ID, I had to modify the deletion tests to store the ID before deleting the resource so that we can use the ID to form the asserted URL.~

Actually, I think I was confused and this is a bug in recent stripe-mock versions:

```bash
$ curl -X DELETE http://localhost:12111/v1/customers/cus_123 -H "Authorization: Bearer sk_test_123"
{
  "deleted": true,
  "id": ""
}

$ curl -X DELETE https://api.stripe.com/v1/customers/cus_... -u $STRIPE_SECRET_KEY:
{
  "id": "cus_...",
  "deleted": true
}
```

`id` should not be an empty string.