### PR TITLE
Upgrade `stripe-mock` to 0.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.8.0
+    - STRIPE_MOCK_VERSION=0.11.1
 
 cache:
   directories:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path("../test_data", __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.4.0".freeze
+MOCK_MINIMUM_VERSION = "0.11.1".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
Updates `stripe-mock` in use in CI.