### PR TITLE
Initialize instance variable on the getter too

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -64,7 +64,8 @@ module Stripe
     # Returns whether the given name is an additive object parameter. See
     # `.additive_object_param` for details.
     def self.additive_object_param?(name)
-      !@additive_params.nil? && @additive_params.include?(name)
+      @additive_params ||= Set.new
+      @additive_params.include?(name)
     end
 
     def initialize(id = nil, opts = {})


### PR DESCRIPTION
The test suite is currently throwing a bunch of warnings from some
recent changes I made -- although we initialize `@additive_params` when
setting one with `self.additive_object_param`, we don't when we check
one with `self.additive_object_param?`. This often isn't a problem
because every API resource sets `metadata`, but it is from the test
suite and probably for vanilla `StripeObject`s too.