### PR TITLE
Modify CardError constructor to make  a keyword argument

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -57,9 +57,8 @@ module Stripe
   class CardError < StripeError
     attr_reader :param
 
-    # TODO: make code a keyword arg in next major release
-    def initialize(message, param, code, http_status: nil, http_body: nil, json_body: nil,
-                   http_headers: nil)
+    def initialize(message, param, http_status: nil, http_body: nil, json_body: nil,
+                   http_headers: nil, code: nil)
       super(message, http_status: http_status, http_body: http_body,
                      json_body: json_body, http_headers: http_headers,
                      code: code)

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -311,11 +311,8 @@ module Stripe
       when 401
         AuthenticationError.new(error_data[:message], opts)
       when 402
-        # TODO: modify CardError constructor to make code a keyword argument
-        #       so we don't have to delete it from opts
-        opts.delete(:code)
         CardError.new(
-          error_data[:message], error_data[:param], error_data[:code],
+          error_data[:message], error_data[:param],
           opts
         )
       when 403


### PR DESCRIPTION
I try to modify CardError constructor,
so we don't have to delete it from opts in StripeClient::specific_api_error when 402.