### PR TITLE
Upgrade `stripe-mock` to v0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.8.0
+    - STRIPE_MOCK_VERSION=0.12.0
 
 cache:
   directories:

--- a/test/stripe/account_external_accounts_operations_test.rb
+++ b/test/stripe/account_external_accounts_operations_test.rb
@@ -48,7 +48,8 @@ module Stripe
           @external_account_id
         )
         assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{@account_id}/external_accounts/#{@external_account_id}"
-        assert external_account.is_a?(Stripe::BankAccount)
+        assert external_account.deleted
+        assert_equal @external_account_id, external_account.id
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path("../test_data", __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.4.0".freeze
+MOCK_MINIMUM_VERSION = "0.12.0".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
The most important changes here are that deleted objects are now
represented more accurately, and that IDs used in URLs are "reflected"
back into responses so that test suites can treat return objects a
little more realistically than they could before.

This should resolve incompatibilities between `stripe-ruby` and newer
versions of `stripe-mock`.