### PR TITLE
Reject nil keys

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -253,7 +253,7 @@ module Stripe
       when String
         { api_key: opts }
       when Hash
-        check_api_key!(opts.fetch(:api_key)) if opts.key?(:api_key)
+        opts.keys.map { |key| check_key!(opts.fetch(key)) }
         opts.clone
       else
         raise TypeError, "normalize_opts expects a string or a hash"
@@ -265,9 +265,9 @@ module Stripe
       key
     end
 
-    def self.check_api_key!(key)
-      raise TypeError, "api_key must be a string" unless key.is_a?(String)
-      key
+    def self.check_key!(value)
+      raise TypeError, "#{value} must be present" if value.nil?
+      value
     end
 
     # Normalizes header keys so that they're all lower case and each

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -130,6 +130,7 @@ module Stripe
     should "#normalize_opts should reject nil keys" do
       assert_raise { Stripe::Util.normalize_opts(nil) }
       assert_raise { Stripe::Util.normalize_opts(api_key: nil) }
+      assert_raise { Stripe::Util.normalize_opts(any_specified_key: nil) }
     end
 
     should "#convert_to_stripe_object should pass through unknown types" do


### PR DESCRIPTION
When listing charges, if a user specifies a `customer_id`, but
`customer_id` is nil, raise a TypeError instead of silently omitting
the key and returning charges for any user.

