### PR TITLE
Idea: Add status constants to all Stripe objects.

### DIFF
--- a/lib/stripe/payout.rb
+++ b/lib/stripe/payout.rb
@@ -6,6 +6,14 @@ module Stripe
 
     OBJECT_NAME = "payout".freeze
 
+    STATUSES = [
+      STATUS_PAID = "paid".freeze,
+      STATUS_PENDING = "pending".freeze,
+      STATUS_IN_TRANSIT = "in_transit".freeze,
+      STATUS_CANCELED = "canceled".freeze,
+      STATUS_FAILED = "failed".freeze,
+    ].freeze
+
     def cancel
       resp, api_key = request(:post, cancel_url)
       initialize_from(resp.data, api_key)


### PR DESCRIPTION
When working with Stripe objects and Stripe Events, it's very common to have conditionals branching on the `status` of the Stripe object.

Instead of having magic strings throughout our codebase of the various Stripe object statuses, we have string constants defined. As an example for `Stripe::Payout`:

```ruby
# https://stripe.com/docs/api#payout_object-status
STRIPE_PAYOUT_STATUSES = [
  STRIPE_PAYOUT_STATUS_PAID = 'paid'.freeze,
  STRIPE_PAYOUT_STATUS_PENDING = 'pending'.freeze,
  STRIPE_PAYOUT_STATUS_IN_TRANSIT = 'in_transit'.freeze,
  STRIPE_PAYOUT_STATUS_CANCELED = 'canceled'.freeze,
  STRIPE_PAYOUT_STATUS_FAILED = 'failed'.freeze,
].freeze
```

To me, it makes sense for these strings to live in the stripe-ruby codebase so they can be used by other projects too. Since we're working with Ruby, we _could_ just reopen the `Stripe` namespaces and monkey-patch these in, but I try to avoid doing that wherever I can.

I understand there's an extra maintenance cost for having the statuses live in this project, so no hard feelings if y'all reject it. ✌️

This pull request so far is just for `Stripe::Payout`, but I'd be willing to add in the rest if this idea is approved! 💁‍♂️