### PR TITLE
Move file upload tests over to be handled by `stripe-mock`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ sudo: false
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.12.0
+    # If changing this number, please also change it in `test/test_helper.rb`.
+    - STRIPE_MOCK_VERSION=0.15.0
 
 cache:
   directories:

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -2,43 +2,18 @@ require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class FileUploadTest < Test::Unit::TestCase
-    # Note that these tests are written different from others because we
-    # don't have anything on the uploads service in our OpenAPI spec. This is
-    # something that should be looked into at some point. We may need to ship
-    # a separate spec for it though, so it's high effort with low reward for
-    # the time being.
-    FIXTURE = {
-      id: "file_123",
-      object: "file_upload",
-    }.freeze
-
     should "be listable" do
-      stub_request(:get, "#{Stripe.uploads_base}/v1/files")
-        .to_return(body: JSON.generate(data: [FIXTURE],
-                                       object: "list",
-                                       resource_url: "/v1/files"))
-
       files = Stripe::FileUpload.list
       assert files.data.is_a?(Array)
       assert files.data[0].is_a?(Stripe::FileUpload)
     end
 
     should "be retrievable" do
-      stub_request(:get, "#{Stripe.uploads_base}/v1/files/file_123")
-        .to_return(body: JSON.generate(FIXTURE))
-
       file = Stripe::FileUpload.retrieve("file_123")
       assert file.is_a?(Stripe::FileUpload)
     end
 
     should "be creatable with a File" do
-      stub_request(:post, "#{Stripe.uploads_base}/v1/files")
-        .with(headers: {
-          "Content-Type" => /\A#{Faraday::Request::Multipart.mime_type}/,
-        }) do |request|
-        request.body =~ /FileUploadTest/
-      end.to_return(body: JSON.generate(FIXTURE))
-
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
         file: File.new(__FILE__)
@@ -47,13 +22,6 @@ module Stripe
     end
 
     should "be creatable with a Tempfile" do
-      stub_request(:post, "#{Stripe.uploads_base}/v1/files")
-        .with(headers: {
-          "Content-Type" => /\A#{Faraday::Request::Multipart.mime_type}/,
-        }) do |request|
-        request.body =~ /Hello world/
-      end.to_return(body: JSON.generate(FIXTURE))
-
       tempfile = Tempfile.new("foo")
       tempfile.write("Hello world")
       tempfile.rewind
@@ -66,13 +34,6 @@ module Stripe
     end
 
     should "be creatable with Faraday::UploadIO" do
-      stub_request(:post, "#{Stripe.uploads_base}/v1/files")
-        .with(headers: {
-          "Content-Type" => /\A#{Faraday::Request::Multipart.mime_type}/,
-        }) do |request|
-        request.body =~ /FileUploadTest/
-      end.to_return(body: JSON.generate(FIXTURE))
-
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
         file: Faraday::UploadIO.new(File.new(__FILE__), nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,8 @@ PROJECT_ROOT = File.expand_path("../../", __FILE__)
 
 require File.expand_path("../test_data", __FILE__)
 
-MOCK_MINIMUM_VERSION = "0.12.0".freeze
+# If changing this number, please also change it in `.travis.yml`.
+MOCK_MINIMUM_VERSION = "0.15.0".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to
@@ -46,6 +47,11 @@ module Test
       setup do
         Stripe.api_key = "sk_test_123"
         Stripe.api_base = "http://localhost:#{MOCK_PORT}"
+
+        # We don't point to the same host for the API and uploads in
+        # production, but `stripe-mock` supports both APIs.
+        Stripe.uploads_base = Stripe.api_base
+
         stub_connect
       end
 


### PR DESCRIPTION
`stripe-mock` can now respond accurately for file API endpoints thanks
to a few improvements in how it handles `multipart/form-data` payloads
and the OpenAPI spec.

Here we upgrade `stripe-mock` to 0.15.0 and remove the manual stubbing
that we had previously.

r? @ob-stripe
cc @stripe/api-libraries