### PR TITLE
Add `frozen_string_literal` to every file and enforce Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Layout/IndentArray:
 Layout/IndentHash:
   EnforcedStyle: consistent
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/testtask"
 require "rubocop/rake_task"
 

--- a/bin/stripe-console
+++ b/bin/stripe-console
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 require "irb"
 require "irb/completion"
 

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Stripe Ruby bindings
 # API spec at https://stripe.com/docs/api
 require "cgi"

--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Account < APIResource
     extend Gem::Deprecate

--- a/lib/stripe/alipay_account.rb
+++ b/lib/stripe/alipay_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class AlipayAccount < APIResource
     include Stripe::APIOperations::Save

--- a/lib/stripe/api_operations/create.rb
+++ b/lib/stripe/api_operations/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     module Create

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     module Delete

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     module List

--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     # Adds methods to help manipulate a subresource from its parent resource so

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     module Request

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module APIOperations
     module Save

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class APIResource < StripeObject
     include Stripe::APIOperations::Request

--- a/lib/stripe/apple_pay_domain.rb
+++ b/lib/stripe/apple_pay_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   # Domains registered for Apple Pay on the Web
   class ApplePayDomain < APIResource

--- a/lib/stripe/application_fee.rb
+++ b/lib/stripe/application_fee.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class ApplicationFee < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/application_fee_refund.rb
+++ b/lib/stripe/application_fee_refund.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class ApplicationFeeRefund < APIResource
     include Stripe::APIOperations::Save

--- a/lib/stripe/balance.rb
+++ b/lib/stripe/balance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Balance < SingletonAPIResource
     OBJECT_NAME = "balance".freeze

--- a/lib/stripe/balance_transaction.rb
+++ b/lib/stripe/balance_transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class BalanceTransaction < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/bank_account.rb
+++ b/lib/stripe/bank_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class BankAccount < APIResource
     include Stripe::APIOperations::Save

--- a/lib/stripe/bitcoin_receiver.rb
+++ b/lib/stripe/bitcoin_receiver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class BitcoinReceiver < APIResource
     # Directly creating or retrieving BitcoinReceivers is deprecated. Please use

--- a/lib/stripe/bitcoin_transaction.rb
+++ b/lib/stripe/bitcoin_transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class BitcoinTransaction < APIResource
     # Directly retrieving BitcoinTransactions is deprecated. Please use the

--- a/lib/stripe/card.rb
+++ b/lib/stripe/card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Card < APIResource
     include Stripe::APIOperations::Save

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Charge < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/country_spec.rb
+++ b/lib/stripe/country_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class CountrySpec < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/coupon.rb
+++ b/lib/stripe/coupon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Coupon < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/customer.rb
+++ b/lib/stripe/customer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Customer < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/dispute.rb
+++ b/lib/stripe/dispute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Dispute < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/ephemeral_key.rb
+++ b/lib/stripe/ephemeral_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class EphemeralKey < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   # StripeError is the base error from which all other more specific Stripe
   # errors derive.

--- a/lib/stripe/event.rb
+++ b/lib/stripe/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Event < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/exchange_rate.rb
+++ b/lib/stripe/exchange_rate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class ExchangeRate < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/file_upload.rb
+++ b/lib/stripe/file_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class FileUpload < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Invoice < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/invoice_item.rb
+++ b/lib/stripe/invoice_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class InvoiceItem < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/invoice_line_item.rb
+++ b/lib/stripe/invoice_line_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class InvoiceLineItem < StripeObject
     OBJECT_NAME = "line_item".freeze

--- a/lib/stripe/issuer_fraud_record.rb
+++ b/lib/stripe/issuer_fraud_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class IssuerFraudRecord < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class ListObject < StripeObject
     include Enumerable

--- a/lib/stripe/login_link.rb
+++ b/lib/stripe/login_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class LoginLink < APIResource
     OBJECT_NAME = "login_link".freeze

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module OAuth
     module OAuthOperations

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Order < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/order_return.rb
+++ b/lib/stripe/order_return.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class OrderReturn < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/payout.rb
+++ b/lib/stripe/payout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Payout < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/plan.rb
+++ b/lib/stripe/plan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Plan < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/product.rb
+++ b/lib/stripe/product.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Product < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/recipient.rb
+++ b/lib/stripe/recipient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   # Recipients objects are deprecated. Please use Stripe Connect instead.
   class Recipient < APIResource

--- a/lib/stripe/recipient_transfer.rb
+++ b/lib/stripe/recipient_transfer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class RecipientTransfer < StripeObject
     OBJECT_NAME = "recipient_transfer".freeze

--- a/lib/stripe/refund.rb
+++ b/lib/stripe/refund.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Refund < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/reversal.rb
+++ b/lib/stripe/reversal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Reversal < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/singleton_api_resource.rb
+++ b/lib/stripe/singleton_api_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class SingletonAPIResource < APIResource
     def self.resource_url

--- a/lib/stripe/sku.rb
+++ b/lib/stripe/sku.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class SKU < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Source < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/source_transaction.rb
+++ b/lib/stripe/source_transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class SourceTransaction < StripeObject
     OBJECT_NAME = "source_transaction".freeze

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   # StripeClient executes requests against the Stripe API and allows a user to
   # recover both a resource a call returns as well as a response object that

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class StripeObject
     include Enumerable

--- a/lib/stripe/stripe_response.rb
+++ b/lib/stripe/stripe_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   # StripeResponse encapsulates some vitals of a response that came back from
   # the Stripe API.

--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Subscription < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/subscription_item.rb
+++ b/lib/stripe/subscription_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class SubscriptionItem < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/three_d_secure.rb
+++ b/lib/stripe/three_d_secure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class ThreeDSecure < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/token.rb
+++ b/lib/stripe/token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Token < APIResource
     extend Stripe::APIOperations::Create

--- a/lib/stripe/topup.rb
+++ b/lib/stripe/topup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Topup < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class Transfer < APIResource
     extend Stripe::APIOperations::List

--- a/lib/stripe/usage_record.rb
+++ b/lib/stripe/usage_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class UsageRecord < APIResource
     def self.create(params = {}, opts = {})

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 
 module Stripe

--- a/lib/stripe/version.rb
+++ b/lib/stripe/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   VERSION = "3.14.0".freeze
 end

--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module Webhook
     DEFAULT_TOLERANCE = 300

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
 
 require "stripe/version"

--- a/test/api_stub_helpers.rb
+++ b/test/api_stub_helpers.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/test/stripe/account_external_accounts_operations_test.rb
+++ b/test/stripe/account_external_accounts_operations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/account_login_links_operations_test.rb
+++ b/test/stripe/account_login_links_operations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/alipay_account_test.rb
+++ b/test/stripe/alipay_account_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/application_fee_refunds_operations_test.rb
+++ b/test/stripe/application_fee_refunds_operations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/bank_account_test.rb
+++ b/test/stripe/bank_account_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/country_spec_test.rb
+++ b/test/stripe/country_spec_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/customer_sources_operations_test.rb
+++ b/test/stripe/customer_sources_operations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/dispute_test.rb
+++ b/test/stripe/dispute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/exchange_rate_test.rb
+++ b/test/stripe/exchange_rate_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/invoice_line_item_test.rb
+++ b/test/stripe/invoice_line_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/issuer_fraud_record_test.rb
+++ b/test/stripe/issuer_fraud_record_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/login_link_test.rb
+++ b/test/stripe/login_link_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/payout_test.rb
+++ b/test/stripe/payout_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/reversal_test.rb
+++ b/test/stripe/reversal_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/source_transaction_test.rb
+++ b/test/stripe/source_transaction_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/three_d_secure_test.rb
+++ b/test/stripe/three_d_secure_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/topup_test.rb
+++ b/test/stripe/topup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/transfer_reversals_operations_test.rb
+++ b/test/stripe/transfer_reversals_operations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/usage_record_test.rb
+++ b/test/stripe/usage_record_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../../test_helper", __FILE__)
 
 module Stripe

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../test_helper", __FILE__)
 
 class StripeTest < Test::Unit::TestCase

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   module TestData
     def make_error(type, message)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coveralls"
 Coveralls.wear!("test_frameworks")
 


### PR DESCRIPTION
Adds the magic `frozen_string_literal: true` comment to every file and
enables a Rubocop rule to make sure that it's always going to be there
going forward as well.

See here for more background [1], but the basic idea is that unlike many
other languages, static strings in code are mutable by default. This has
since been acknowledged as not a particularly good idea, and the
intention is to rectify the mistake when Ruby 3 comes out, where all
string literals will be frozen. The `frozen_string_literal` magic
comment was introduced in Ruby 2.3 as a way of easing the transition,
and allows libraries and projects to freeze their literals in advance.

I don't think this is breaking in any way: it's possible that users
might've been pulling out one of are literals somehow and mutating it,
but that would probably not have been useful for anything and would
certainly not be recommended, so I'm quite comfortable pushing this
change through as a minor version.

As discussed in #641.

[1] https://stackoverflow.com/a/37799399

@remi Would you mind quickly commenting as to whether you have any FUD about
this? This is a really uninteresting PR (the only change is adding a new line
to the top of every file) and the team is pretty busy this week, so I think I'm
going to just self-approve if not. Thanks!

cc @stripe/api-libraries 