### PR TITLE
Fix some parameters being sent in tests

### DIFF
--- a/lib/stripe/version.rb
+++ b/lib/stripe/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   VERSION = "3.15.0".freeze
 end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -46,7 +46,7 @@ module Stripe
     context "#create_subscription" do
       should "create a new subscription" do
         customer = Stripe::Customer.retrieve("cus_123")
-        subscription = customer.create_subscription(plan: "silver")
+        subscription = customer.create_subscription(items: [{ plan: "silver" }])
         assert subscription.is_a?(Stripe::Subscription)
       end
     end

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -41,7 +41,7 @@ module Stripe
     context "#pay" do
       should "pay an order" do
         order = Stripe::Order.retrieve("or_123")
-        order = order.pay(token: "tok_123")
+        order = order.pay(source: "tok_123")
         assert order.is_a?(Stripe::Order)
       end
     end
@@ -49,7 +49,7 @@ module Stripe
     context "#return_order" do
       should "return an order" do
         order = Stripe::Order.retrieve("or_123")
-        order = order.return_order(orders: [
+        order = order.return_order(items: [
           { parent: "sku_123" },
         ])
         assert order.is_a?(Stripe::OrderReturn)

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -22,7 +22,6 @@ module Stripe
 
     should "be creatable" do
       item = Stripe::SubscriptionItem.create(
-        item: "silver",
         plan: "sapphire-elite",
         quantity: 3,
         subscription: "sub_123"


### PR DESCRIPTION
I found a bug recently in stripe-mock which causes it not to actually be
validating that parameters not in the spec are not being sent (the
actual Stripe API does check for this).

After applying a fix, I found that stripe-ruby's test suite no longer
passes against it, and the reason is that there are some subtle mistakes
throughout. This patch corrects them to be in line with what the API
actually expects.

r? @stripe/api-libraries