### PR TITLE
Add version and SemVer stability badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/stripe/stripe-ruby.svg?branch=master)](https://travis-ci.org/stripe/stripe-ruby)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
+[![Gem Version](https://badge.fury.io/rb/stripe.svg)](http://badge.fury.io/rb/stripe)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=stripe&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=stripe&package-manager=bundler&version-scheme=semver&new-version=latest)
 
 The Stripe Ruby library provides convenient access to the Stripe API from
 applications written in the Ruby language. It includes a pre-defined set of


### PR DESCRIPTION
First up, thanks for Stripe and stripe-ruby. I use it and love it 🙂

This PR adds a gem version badge to the readme, together with a SemVer stability badge. The later displays the percentage of CI runs that pass when updating `stripe` from SemVer compatible versions to the latest one. Data comes from Dependabot (disclosure: I built it).

Here's what the badges look like:

[![Gem Version](https://badge.fury.io/rb/stripe.svg)](http://badge.fury.io/rb/stripe) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=stripe&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=stripe&package-manager=bundler&version-scheme=semver&new-version=latest)

The idea behind including the gem version one is to make it easy for new users to know what to put in their Gemfile. The stability badge is there to tell then what kind of requirement they should use (basically that Stripe follows SemVer) but also to make it obvious if/when a new version is released that contains bugs/backwards compatibility issues.