### PR TITLE
Add Ruby 2.5 to test matrix + use aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
 
 rvm:
-  - 2.0.0
+  - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby-9.0.5.0
 
 notifications:


### PR DESCRIPTION
Adds Ruby 2.5 to the test matrix.

I also switched us over to aliases of each major Ruby version because I
think it makes more sense to be locked to whatever the latest release in
each is.

r? @ob-stripe 