### PR TITLE
Do not colorize output destined for configured logger

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -396,7 +396,7 @@ module Stripe
     def self.log_internal(message, data = {}, color: nil, level: nil, logger: nil, out: nil)
       data_str = data.reject { |_k, v| v.nil? }
                      .map do |(k, v)|
-        format("%s=%s", colorize(k, color, !out.nil? && out.isatty), wrap_logfmt_value(v))
+        format("%s=%s", colorize(k, color, logger.nil? && !out.nil? && out.isatty), wrap_logfmt_value(v))
       end.join(" ")
 
       if !logger.nil?

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -396,7 +396,7 @@ module Stripe
         }
 
         Util.send(:log_internal, "message", { foo: "bar" },
-                  color: :green, level: Stripe::LEVEL_DEBUG, logger: logger, out: nil)
+                  color: :green, level: Stripe::LEVEL_DEBUG, logger: logger, out: $stdout)
         assert_equal "message=message foo=bar",
                      out.string
       end


### PR DESCRIPTION
This changes the predicate supplied to the #colorize method to ensure
that if a logger is set, the colorizing ANSI escape codes are not applied.

This definitely appears to have been the intention behind the original
implementation, but the tests didn't reflect how .log_internal was
actually called. In reality, it is always supplied with an `out:`
argument, not nil. This caused all logger bound output to also be
colorized.