### PR TITLE
Rubocop: Cap method length at 50 lines + disable module length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,15 @@ Layout/IndentArray:
 Layout/IndentHash:
   EnforcedStyle: consistent
 
+Metrics/MethodLength:
+  # There's ~2 long methods in `StripeClient`. If we want to truncate those a
+  # little, we could move this to be closer to ~30 (but the default of 10 is
+  # probably too short).
+  Max: 50
+
+Metrics/ModuleLength:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,16 +30,6 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 310
 
-# Offense count: 32
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 55
-
-# Offense count: 1
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Max: 315
-
 # Offense count: 6
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -39,7 +39,7 @@ module Stripe
       end
     end
 
-    def self.object_classes
+    def self.object_classes # rubocop:disable Metrics/MethodLength
       @object_classes ||= {
         # data structures
         ListObject::OBJECT_NAME => ListObject,


### PR DESCRIPTION
Remi pointed out in #666 that we basically just have to keep adding more
more onto the `Max` exception for both these rules every time we add a
new API resource.

Here I suggest that we modify the check on method length in two ways:

1. Permanently disable the cop on `Util.object_classes`. This is just
   going to keep growing until we change are approach to it.
2. Choose a more reasonable maximum of 50 lines for elsewhere (IMO, the
   default of 10 is just too short). Most of our methods already come in
   below this, but there's a couple outliers like `#execute_request` in
   `StripeClient`. If we knock over some of those, we could lower this
   number again, but I suspect that we'd probably want somewhere closer
   to 30 (instead of 10) event then.

I also disable the check on module length completely. I'm not convinced
this is a very good heuristic for code quality.

r? @ob-stripe @remi-stripe
cc @stripe/api-libraries