### PR TITLE
Allow thread-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ Stripe::Charge.retrieve(
 )
 ```
 
+### Per-thread Configuration
+If your application uses workers in different threads, each with a specific key,
+you can use the per-thread configuration:
+
+``` ruby
+require "stripe"
+
+Stripe.config(
+  {
+    :api_key => "sk_test_...",
+    :stripe_account => "acct_...",
+    :stripe_version => "2018-02-28"
+  }
+)
+```
+
 ### Configuring a Client
 
 While a default HTTP client is used by default, it's also possible to have the

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -115,12 +115,41 @@ module Stripe
   @open_timeout = 30
   @read_timeout = 80
 
+  @api_key = nil
+  @api_version = nil
+  @stripe_account = nil
+
   class << self
-    attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs, :api_version, :client_id, :connect_base, :uploads_base,
+    attr_accessor :api_base, :verify_ssl_certs, :client_id, :connect_base, :uploads_base,
                   :open_timeout, :read_timeout
 
     attr_reader :max_network_retry_delay, :initial_network_retry_delay
+
+    attr_writer :api_key, :api_version, :stripe_account
   end
+
+  # Optionally set config parameters just for current thread.
+  # params - hash with api_key & api_version.
+  def self.config(params = nil)
+    Thread.current[:stripe_config] = params
+  end
+
+  def self.thread_specific(field)
+    Thread.current[:stripe_config][field] if Thread.current[:stripe_config]
+  end
+
+  def self.api_key
+    thread_specific(:api_key) || @api_key
+  end
+
+  def self.api_version
+    thread_specific(:api_version) || @api_version
+  end
+
+  def self.stripe_account
+    thread_specific(:stripe_account) || @stripe_account
+  end
+
 
   # Gets the application for a plugin that's identified some. See
   # #set_app_info.

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -150,7 +150,6 @@ module Stripe
     thread_specific(:stripe_account) || @stripe_account
   end
 
-
   # Gets the application for a plugin that's identified some. See
   # #set_app_info.
   def self.app_info

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -64,8 +64,8 @@ class StripeTest < Test::Unit::TestCase
   should "allow api key configured per thread" do
     begin
       old = Stripe.api_key
-      Stripe.config(api_key: 'test_key')
-      assert_equal 'test_key', Stripe.api_key
+      Stripe.config(api_key: "test_key")
+      assert_equal "test_key", Stripe.api_key
 
       other_thread_value = nil
       Thread.new { other_thread_value = Stripe.api_key }.join
@@ -78,8 +78,8 @@ class StripeTest < Test::Unit::TestCase
 
   should "allow api version configured per thread" do
     begin
-      Stripe.config(api_version: '2078-01-32')
-      assert_equal '2078-01-32', Stripe.api_version
+      Stripe.config(api_version: "2078-01-32")
+      assert_equal "2078-01-32", Stripe.api_version
 
       other_thread_value = nil
       Thread.new { other_thread_value = Stripe.api_version }.join

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -60,4 +60,33 @@ class StripeTest < Test::Unit::TestCase
     assert_equal Stripe.open_timeout, 30
     assert_equal Stripe.read_timeout, 80
   end
+
+  should "allow api key configured per thread" do
+    begin
+      old = Stripe.api_key
+      Stripe.config(api_key: 'test_key')
+      assert_equal 'test_key', Stripe.api_key
+
+      other_thread_value = nil
+      Thread.new { other_thread_value = Stripe.api_key }.join
+      assert_equal old, other_thread_value
+    ensure
+      Stripe.config # delete thread-specific configuration
+      assert_equal old, Stripe.api_key
+    end
+  end
+
+  should "allow api version configured per thread" do
+    begin
+      Stripe.config(api_version: '2078-01-32')
+      assert_equal '2078-01-32', Stripe.api_version
+
+      other_thread_value = nil
+      Thread.new { other_thread_value = Stripe.api_version }.join
+      assert_equal nil, other_thread_value
+    ensure
+      Stripe.config # delete thread-specific configuration
+      assert_equal nil, Stripe.api_version
+    end
+  end
 end


### PR DESCRIPTION
Enable `:api_key, :api_version, :stripe_account` to be configured per thread, supporting multiple workers/accounts workflow.