### PR TITLE
Integer-index encode all arrays

### DIFF
--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -9,7 +9,6 @@ module Stripe
     OBJECT_NAME = "invoice".freeze
 
     def self.upcoming(params, opts = {})
-      params[:subscription_items] = Util.array_to_hash(params[:subscription_items]) if params[:subscription_items]
       resp, opts = request(:get, upcoming_url, params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -14,14 +14,8 @@ module Stripe
     end
 
     def return_order(params, opts = {})
-      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
       resp, opts = request(:post, returns_url, params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
-    end
-
-    def self.create(params = {}, opts = {})
-      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
-      super(params, opts)
     end
 
     private

--- a/lib/stripe/subscription.rb
+++ b/lib/stripe/subscription.rb
@@ -16,21 +16,6 @@ module Stripe
       initialize_from({ discount: nil }, opts, true)
     end
 
-    def self.update(id, params = {}, opts = {})
-      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
-      super(id, params, opts)
-    end
-
-    def self.create(params = {}, opts = {})
-      params[:items] = Util.array_to_hash(params[:items]) if params[:items]
-      super(params, opts)
-    end
-
-    def serialize_params(options = {})
-      @values[:items] = Util.array_to_hash(@values[:items]) if @values[:items]
-      super
-    end
-
     private
 
     def discount_url

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -56,51 +56,5 @@ module Stripe
         assert subscription.is_a?(Stripe::Subscription)
       end
     end
-
-    context "#serialize_params" do
-      should "serialize when items is set to an Array" do
-        obj = Stripe::Util.convert_to_stripe_object({
-          object: "subscription",
-          items: Stripe::Util.convert_to_stripe_object(
-            object: "list",
-            data: []
-          ),
-        }, {})
-        obj.items = [
-          { id: "si_foo", deleted: true },
-          { plan: "plan_bar" },
-        ]
-
-        expected = {
-          items: {
-            :"0" => { id: "si_foo", deleted: true },
-            :"1" => { plan: "plan_bar" },
-          },
-        }
-        assert_equal(expected, obj.serialize_params)
-      end
-
-      should "serialize when items is set to a Hash" do
-        obj = Stripe::Util.convert_to_stripe_object({
-          object: "subscription",
-          items: Stripe::Util.convert_to_stripe_object(
-            object: "list",
-            data: []
-          ),
-        }, {})
-        obj.items = {
-          "0" => { id: "si_foo", deleted: true },
-          "1" => { plan: "plan_bar" },
-        }
-
-        expected = {
-          items: {
-            :"0" => { id: "si_foo", deleted: true },
-            :"1" => { plan: "plan_bar" },
-          },
-        }
-        assert_equal(expected, obj.serialize_params)
-      end
-    end
   end
 end

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -33,37 +33,9 @@ module Stripe
         g: [],
       }
       assert_equal(
-        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[]=0&e[]=1&f=",
+        "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[0]=0&e[1]=1&f=",
         Stripe::Util.encode_parameters(params)
       )
-    end
-
-    should "#encode_params should throw an error on an array of maps that cannot be encoded" do
-      params = {
-        a: [
-          { a: 1, b: 2 },
-          { c: 3, a: 4 },
-        ],
-      }
-      e = assert_raises(ArgumentError) do
-        Stripe::Util.encode_parameters(params)
-      end
-      expected = "All maps nested in an array should start with the same key " \
-                 "(expected starting key 'a', got 'c')"
-      assert_equal expected, e.message
-
-      # Make sure the check is recursive by taking our original params and
-      # nesting it into yet another map and array. Should throw exactly the
-      # same error because it's still the in inner array of maps that's wrong.
-      params = {
-        x: [
-          params,
-        ],
-      }
-      e = assert_raises(ArgumentError) do
-        Stripe::Util.encode_parameters(params)
-      end
-      assert_equal expected, e.message
     end
 
     should "#url_encode should prepare strings for HTTP" do
@@ -92,16 +64,16 @@ module Stripe
         ["c",        "bar&baz"],
         ["d[a]",     "a"],
         ["d[b]",     "b"],
-        ["e[]",      0],
-        ["e[]",      1],
+        ["e[0]",      0],
+        ["e[1]",      1],
 
         # *The key here is the order*. In order to be properly interpreted as
         # an array of hashes on the server, everything from a single hash must
         # come in at once. A duplicate key in an array triggers a new element.
-        ["f[][foo]", "1"],
-        ["f[][ghi]", "2"],
-        ["f[][foo]", "3"],
-        ["f[][bar]", "4"],
+        ["f[0][foo]", "1"],
+        ["f[0][ghi]", "2"],
+        ["f[1][foo]", "3"],
+        ["f[1][bar]", "4"],
       ], Stripe::Util.flatten_params(params))
     end
 
@@ -158,10 +130,6 @@ module Stripe
     should "#convert_to_stripe_object should marshal arrays" do
       obj = Util.convert_to_stripe_object([1, 2, 3], {})
       assert_equal [1, 2, 3], obj
-    end
-
-    should "#array_to_hash should convert an array into a hash with integer keys" do
-      assert_equal({ "0" => 1, "1" => 2, "2" => 3 }, Util.array_to_hash([1, 2, 3]))
     end
 
     context ".request_id_dashboard_url" do


### PR DESCRIPTION
Changes all arrays from classic Rack encoding:

``` sh
arr[]=...&arr[]=...&arr[]=...
```

To integer-indexed encoding:

``` sh
arr[0]=...&arr[1]=...&arr[2]=...
```

We think that this should be tractable now that we've fully converted
all endpoints over to the new AbstractAPIMethod infrastructure on the
backend (although we should do a little more testing to make sure that
all endpoints still work).

As part of the conversion, we also remove any places that we were "spot
encoding" to get required integer-indexed syntax. This should now all be
built in.

cc @stevene-stripe @zanker-stripe