### PR TITLE
Remove ability to perform edit-actions on bitcoin receivers

### DIFF
--- a/lib/stripe/bitcoin_receiver.rb
+++ b/lib/stripe/bitcoin_receiver.rb
@@ -4,9 +4,6 @@ module Stripe
   class BitcoinReceiver < APIResource
     # Directly creating or retrieving BitcoinReceivers is deprecated. Please use
     # the Sources API instead: https://stripe.com/docs/sources/bitcoin
-    extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
-    include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "bitcoin_receiver".freeze


### PR DESCRIPTION
Tests pass:

```
» bundle exec rake test
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'test_frameworks' settings.
/Users/tomer/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/shoulda-context-1.2.2/lib/shoulda/context/context.rb:400: warning: assigned but unused variable - context
Loaded suite /Users/tomer/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.3.1/lib/rake/rake_test_loader
Started
..........................................................................................................................................
..........................................................................................................................................
..........................................................................................................................................
...............................................................
Finished in 2.654357 seconds.
------------------------------------------------------------------------------------------------------------------------------------------
477 tests, 571 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------
179.70 tests/s, 215.12 assertions/s
```

Looks like these didn't have much coverage :(