### PR TITLE
Use `::File` instead of `File`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :update_certs do
   require "faraday"
 
   fetch_file "https://curl.haxx.se/ca/cacert.pem",
-             File.expand_path("../lib/data/ca-certificates.crt", __FILE__)
+             ::File.expand_path("../lib/data/ca-certificates.crt", __FILE__)
 end
 
 #
@@ -24,7 +24,7 @@ end
 #
 
 def fetch_file(url, dest)
-  File.open(dest, "w") do |file|
+  ::File.open(dest, "w") do |file|
     resp = Faraday.get(url)
     unless resp.status == 200
       abort("bad response when fetching: #{url}\n" \

--- a/bin/stripe-console
+++ b/bin/stripe-console
@@ -5,7 +5,7 @@
 require "irb"
 require "irb/completion"
 
-require "#{File.dirname(__FILE__)}/../lib/stripe"
+require "#{::File.dirname(__FILE__)}/../lib/stripe"
 
 # Config IRB to enable --simple-prompt and auto indent
 IRB.conf[:PROMPT_MODE] = :SIMPLE

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -94,7 +94,7 @@ require "stripe/usage_record"
 require "stripe/oauth"
 
 module Stripe
-  DEFAULT_CA_BUNDLE_PATH = File.dirname(__FILE__) + "/data/ca-certificates.crt"
+  DEFAULT_CA_BUNDLE_PATH = ::File.dirname(__FILE__) + "/data/ca-certificates.crt"
 
   @app_info = nil
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -544,8 +544,8 @@ module Stripe
     # integrations.
     class SystemProfiler
       def self.uname
-        if File.exist?("/proc/version")
-          File.read("/proc/version").strip
+        if ::File.exist?("/proc/version")
+          ::File.read("/proc/version").strip
         else
           case RbConfig::CONFIG["host_os"]
           when /linux|darwin|bsd|sunos|solaris|cygwin/i

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -154,7 +154,7 @@ module Stripe
       # report incorrect results on some more oddball filesystems
       # (such as AFS)
 
-      File.open(file) { |f| }
+      ::File.open(file) { |f| }
     rescue StandardError
       false
     else

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
+$LOAD_PATH.unshift(::File.join(::File.dirname(__FILE__), "lib"))
 
 require "stripe/version"
 
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| ::File.basename(f) }
   s.require_paths = ["lib"]
 end

--- a/test/stripe/account_external_accounts_operations_test.rb
+++ b/test/stripe/account_external_accounts_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class AccountExternalAccountsOperationsTest < Test::Unit::TestCase

--- a/test/stripe/account_login_links_operations_test.rb
+++ b/test/stripe/account_login_links_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class AccountLoginLinksOperationsTest < Test::Unit::TestCase

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class AccountTest < Test::Unit::TestCase

--- a/test/stripe/alipay_account_test.rb
+++ b/test/stripe/alipay_account_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class AlipayAccountTest < Test::Unit::TestCase

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApiOperationsTest < Test::Unit::TestCase

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApiResourceTest < Test::Unit::TestCase

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApplePayDomainTest < Test::Unit::TestCase

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApplicationFeeRefundTest < Test::Unit::TestCase

--- a/test/stripe/application_fee_refunds_operations_test.rb
+++ b/test/stripe/application_fee_refunds_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApplicationFeeRefundsOperationsTest < Test::Unit::TestCase

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ApplicationFeeTest < Test::Unit::TestCase

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class BalanceTest < Test::Unit::TestCase

--- a/test/stripe/bank_account_test.rb
+++ b/test/stripe/bank_account_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class BankAccountTest < Test::Unit::TestCase

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ChargeTest < Test::Unit::TestCase

--- a/test/stripe/country_spec_test.rb
+++ b/test/stripe/country_spec_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class CountrySpecTest < Test::Unit::TestCase

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class CouponTest < Test::Unit::TestCase

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class CustomerCardTest < Test::Unit::TestCase

--- a/test/stripe/customer_sources_operations_test.rb
+++ b/test/stripe/customer_sources_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class CustomerSourcesOperationsTest < Test::Unit::TestCase

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class CustomerTest < Test::Unit::TestCase

--- a/test/stripe/dispute_test.rb
+++ b/test/stripe/dispute_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class DisputeTest < Test::Unit::TestCase

--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class EphemeralKeyTest < Test::Unit::TestCase

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class StripeErrorTest < Test::Unit::TestCase

--- a/test/stripe/exchange_rate_test.rb
+++ b/test/stripe/exchange_rate_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ExchangeRateTest < Test::Unit::TestCase

--- a/test/stripe/file_link_test.rb
+++ b/test/stripe/file_link_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class FileLinkTest < Test::Unit::TestCase

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class FileUploadTest < Test::Unit::TestCase
@@ -18,7 +18,7 @@ module Stripe
     should "be creatable with a File" do
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
-        file: File.new(__FILE__)
+        file: ::File.new(__FILE__)
       )
       assert file.is_a?(Stripe::FileUpload)
     end
@@ -38,7 +38,7 @@ module Stripe
     should "be creatable with Faraday::UploadIO" do
       file = Stripe::FileUpload.create(
         purpose: "dispute_evidence",
-        file: Faraday::UploadIO.new(File.new(__FILE__), nil)
+        file: Faraday::UploadIO.new(::File.new(__FILE__), nil)
       )
       assert file.is_a?(Stripe::FileUpload)
     end

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class InvoiceItemTest < Test::Unit::TestCase

--- a/test/stripe/invoice_line_item_test.rb
+++ b/test/stripe/invoice_line_item_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class InvoiceLineItemTest < Test::Unit::TestCase

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class InvoiceTest < Test::Unit::TestCase

--- a/test/stripe/issuer_fraud_record_test.rb
+++ b/test/stripe/issuer_fraud_record_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class IssuerFraudRecordTest < Test::Unit::TestCase

--- a/test/stripe/issuing/authorization_test.rb
+++ b/test/stripe/issuing/authorization_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/issuing/card_test.rb
+++ b/test/stripe/issuing/card_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/issuing/cardholder_test.rb
+++ b/test/stripe/issuing/cardholder_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/issuing/dispute_test.rb
+++ b/test/stripe/issuing/dispute_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/issuing/transaction_test.rb
+++ b/test/stripe/issuing/transaction_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ListObjectTest < Test::Unit::TestCase

--- a/test/stripe/login_link_test.rb
+++ b/test/stripe/login_link_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class LoginLinkTest < Test::Unit::TestCase

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class OAuthTest < Test::Unit::TestCase

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class OrderReturnTest < Test::Unit::TestCase

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class OrderTest < Test::Unit::TestCase

--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   TEST_RESOURCE_ID = "pi_123".freeze

--- a/test/stripe/payout_test.rb
+++ b/test/stripe/payout_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class PayoutTest < Test::Unit::TestCase

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class PlanTest < Test::Unit::TestCase

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ProductTest < Test::Unit::TestCase

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class RecipientTest < Test::Unit::TestCase

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class RefundTest < Test::Unit::TestCase

--- a/test/stripe/reversal_test.rb
+++ b/test/stripe/reversal_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ReversalTest < Test::Unit::TestCase

--- a/test/stripe/sigma/scheduled_query_run_test.rb
+++ b/test/stripe/sigma/scheduled_query_run_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../../test_helper", __FILE__)
+require ::File.expand_path("../../../test_helper", __FILE__)
 
 module Stripe
   module Issuing

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SKUTest < Test::Unit::TestCase

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SourceTest < Test::Unit::TestCase

--- a/test/stripe/source_transaction_test.rb
+++ b/test/stripe/source_transaction_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SourceTransactionTest < Test::Unit::TestCase

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class StripeClientTest < Test::Unit::TestCase

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class StripeObjectTest < Test::Unit::TestCase

--- a/test/stripe/stripe_response_test.rb
+++ b/test/stripe/stripe_response_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class StripeResponseTest < Test::Unit::TestCase

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SubscriptionItemTest < Test::Unit::TestCase

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SubscriptionTest < Test::Unit::TestCase

--- a/test/stripe/three_d_secure_test.rb
+++ b/test/stripe/three_d_secure_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class ThreeDSecureTest < Test::Unit::TestCase

--- a/test/stripe/topup_test.rb
+++ b/test/stripe/topup_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class TopupTest < Test::Unit::TestCase

--- a/test/stripe/transfer_reversals_operations_test.rb
+++ b/test/stripe/transfer_reversals_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class TransferReversalsOperationsTest < Test::Unit::TestCase

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class TransferTest < Test::Unit::TestCase

--- a/test/stripe/usage_record_test.rb
+++ b/test/stripe/usage_record_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class UsageRecordTest < Test::Unit::TestCase

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class UtilTest < Test::Unit::TestCase

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test_helper", __FILE__)
+require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class WebhookTest < Test::Unit::TestCase

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../test_helper", __FILE__)
+require ::File.expand_path("../test_helper", __FILE__)
 
 class StripeTest < Test::Unit::TestCase
   should "warn that #refresh_from is deprecated" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,9 +11,9 @@ require "shoulda/context"
 require "timecop"
 require "webmock/test_unit"
 
-PROJECT_ROOT = File.expand_path("../../", __FILE__)
+PROJECT_ROOT = ::File.expand_path("../../", __FILE__)
 
-require File.expand_path("../test_data", __FILE__)
+require ::File.expand_path("../test_data", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
 MOCK_MINIMUM_VERSION = "0.25.0".freeze


### PR DESCRIPTION
Ensure that every reference to Ruby's [`File`](https://ruby-doc.org/core-2.5.0/File.html) class uses `::File`.

This has no functional impact, but will make it easier to add a `Stripe::File` class later.

r? @brandur-stripe 
cc @stripe/api-libraries 
