### PR TITLE
Upgrade stripe-mock to 0.30.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.26.0
+    - STRIPE_MOCK_VERSION=0.30.0
 
 cache:
   directories:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ PROJECT_ROOT = ::File.expand_path("../../", __FILE__)
 require ::File.expand_path("../test_data", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.26.0".freeze
+MOCK_MINIMUM_VERSION = "0.30.0".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
Upgrades to the most recent version of stripe-mock now that we've got a
few more fixes into both its implementation and into stripe-ruby's test
suite.