### PR TITLE
Add support for the Webhook Endpoint resource

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -96,6 +96,7 @@ require "stripe/topup"
 require "stripe/transfer"
 require "stripe/usage_record"
 require "stripe/usage_record_summary"
+require "stripe/webhook_endpoint"
 
 # OAuth
 require "stripe/oauth"

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -106,6 +106,7 @@ module Stripe
         Transfer::OBJECT_NAME                  => Transfer,
         UsageRecord::OBJECT_NAME               => UsageRecord,
         UsageRecordSummary::OBJECT_NAME        => UsageRecordSummary,
+        WebhookEndpoint::OBJECT_NAME           => WebhookEndpoint,
       }
     end
 

--- a/lib/stripe/webhook_endpoint.rb
+++ b/lib/stripe/webhook_endpoint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Stripe
+  class WebhookEndpoint < APIResource
+    extend Stripe::APIOperations::Create
+    include Stripe::APIOperations::Save
+    include Stripe::APIOperations::Delete
+    extend Stripe::APIOperations::List
+
+    OBJECT_NAME = "webhook_endpoint".freeze
+  end
+end

--- a/test/stripe/webhook_endpoint_test.rb
+++ b/test/stripe/webhook_endpoint_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require ::File.expand_path("../../test_helper", __FILE__)
+
+module Stripe
+  class WebhookEndpointTest < Test::Unit::TestCase
+    should "be listable" do
+      webhook_endpoints = Stripe::WebhookEndpoint.list
+      assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints"
+      assert webhook_endpoints.data.is_a?(Array)
+      assert webhook_endpoints.first.is_a?(Stripe::WebhookEndpoint)
+    end
+
+    should "be retrievable" do
+      webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+      assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
+      assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
+    end
+
+    should "be creatable" do
+      webhook_endpoint = Stripe::WebhookEndpoint.create(
+        enabled_events: ["charge.succeeded"],
+        url: "https://stripe.com"
+      )
+      assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints"
+      assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
+    end
+
+    should "be saveable" do
+      webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+      webhook_endpoint.enabled_events = ["charge.succeeded"]
+      webhook_endpoint.save
+      assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
+    end
+
+    should "be updateable" do
+      webhook_endpoint = Stripe::WebhookEndpoint.update("we_123", enabled_events: ["charge.succeeded"])
+      assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
+      assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
+    end
+  end
+end


### PR DESCRIPTION
cc @stripe/api-libraries 

Flagging that with the most recent local fixtures an Order test is failing while validating `items`