### PR TITLE
Adding metadata header to client requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 tags
 /.bundle/
 coverage/
+.idea/

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 626
+  Max: 659
 
 # Offense count: 11
 Metrics/CyclomaticComplexity:

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -124,6 +124,8 @@ module Stripe
   @open_timeout = 30
   @read_timeout = 80
 
+  @enable_telemetry = false
+
   class << self
     attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs, :api_version, :client_id, :connect_base, :uploads_base,
                   :open_timeout, :read_timeout
@@ -223,6 +225,14 @@ module Stripe
 
   def self.max_network_retries=(val)
     @max_network_retries = val.to_i
+  end
+
+  def self.enable_telemetry?
+    @enable_telemetry
+  end
+
+  def self.enable_telemetry=(val)
+    @enable_telemetry = val
   end
 
   # Sets some basic information about the running application that's sent along


### PR DESCRIPTION
This PR adds in basic client telemetry that for now only includes timing information. The telemetry is sent back as a sidecar payload in an HTTP header of:

`X-Stripe-Client-Telemetry`

With a JSON payload format of:

```
{ 
  "last_request_metrics": {
      "request_id": "...",
      "request_duration": 1.23
  }
}
```
By sending as a sidecar http header we avoid an extraneous network call at the cost of only being able to track the previous request.

Adding in this telemetry will allow stripe to help diagnose latency and other connection issues as well as provide a space to augment future telemetry data.

Telemetry needs to be opted into by setting:

```
Stripe.enable_telemetry = true
```
And can be disabled at any time by toggling that flag (the value is not cached)
