### PR TITLE
Making stripe telemetry more specific in terms of units

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -219,7 +219,8 @@ module Stripe
         context = context.dup_from_response(resp)
         log_response(context, request_start, resp.status, resp.body)
         if Stripe.enable_telemetry?
-          @last_request_metrics = StripeRequestMetrics.new(context.request_id, Time.now - request_start)
+          request_duration_ms = ((Time.now - request_start) * 1000).to_int
+          @last_request_metrics = StripeRequestMetrics.new(context.request_id, request_duration_ms)
         end
 
       # We rescue all exceptions from a request so that we have an easy spot to
@@ -607,16 +608,16 @@ module Stripe
       # The Stripe request ID of the response.
       attr_accessor :request_id
 
-      # Request duration
-      attr_accessor :request_duration
+      # Request duration in milliseconds
+      attr_accessor :request_duration_ms
 
-      def initialize(request_id, request_duration)
-        self.request_id       = request_id
-        self.request_duration = request_duration
+      def initialize(request_id, request_duration_ms)
+        self.request_id = request_id
+        self.request_duration_ms = request_duration_ms
       end
 
       def payload
-        { request_id: request_id, request_duration: request_duration }
+        { request_id: request_id, request_duration_ms: request_duration_ms }
       end
     end
   end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -791,7 +791,7 @@ module Stripe
 
         trace_payload = JSON.parse(trace_metrics_header)
         assert(trace_payload["last_request_metrics"]["request_id"] == "req_123")
-        assert(!trace_payload["last_request_metrics"]["request_duration"].nil?)
+        assert(!trace_payload["last_request_metrics"]["request_duration_ms"].nil?)
       end
     end
   end


### PR DESCRIPTION
Related to #696 making a minor change to make the telemetry payload more specific in terms of timing units.  I'm making the payload specific that it is in milliseconds and enforcing that in the ruby time difference. This is important so we can keep cross binding payloads consistent.

r? @ob-stripe @brandur-stripe 