### PR TITLE
Use Faraday's `Net::HTTP::Persistent` adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,8 @@ group :development do
   end
 
   platforms :mri do
-    # to avoid problems, bring Byebug in on just versions of Ruby under which
-    # it's known to work well
-    if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.0.0")
-      gem "byebug"
-      gem "pry"
-      gem "pry-byebug"
-    end
+    gem "byebug"
+    gem "pry"
+    gem "pry-byebug"
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -31,11 +31,18 @@ module Stripe
       # of connection re-use, so make sure that we have a separate connection
       # object per thread.
       Thread.current[:stripe_client_default_conn] ||= begin
-        conn = Faraday.new do |c|
-          c.use Faraday::Request::Multipart
-          c.use Faraday::Request::UrlEncoded
-          c.use Faraday::Response::RaiseError
-          c.adapter Faraday.default_adapter
+        conn = Faraday.new do |builder|
+          builder.use Faraday::Request::Multipart
+          builder.use Faraday::Request::UrlEncoded
+          builder.use Faraday::Response::RaiseError
+
+          # Net::HTTP::Persistent doesn't seem to do well on JRuby, so fall
+          # back to default there.
+          if RUBY_PLATFORM == "java"
+            builder.adapter :net_http
+          else
+            builder.adapter :net_http_persistent
+          end
         end
 
         if Stripe.verify_ssl_certs

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -7,7 +7,7 @@ require "stripe/version"
 Gem::Specification.new do |s|
   s.name = "stripe"
   s.version = Stripe::VERSION
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.1.0"
   s.summary = "Ruby bindings for the Stripe API"
   s.description = "Stripe is the easiest way to accept payments online.  See https://stripe.com for details."
   s.author = "Stripe"
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_dependency("faraday", "~> 0.10")
+  s.add_dependency("net-http-persistent", "~> 3.0")
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,8 @@ WebMock.disable_net_connect!(allow: "localhost:#{MOCK_PORT}")
 # we can print one error and fail fast so that it's more clear to the user how
 # they should fix the problem.
 begin
-  resp = Faraday.get("http://localhost:#{MOCK_PORT}/")
+  conn = Faraday::Connection.new("http://localhost:#{MOCK_PORT}")
+  resp = conn.get("/")
   version = resp.headers["Stripe-Mock-Version"]
   if version != "master" &&
      Gem::Version.new(version) < Gem::Version.new(MOCK_MINIMUM_VERSION)


### PR DESCRIPTION
This changes the library's default connection over to use the adapter
for `Net::HTTP::Persistent`, which is a connection pooling library for
Ruby.

In the long run, I think we should probably just drop Faraday ... the
amount of value it's getting us is extremely tenuous and its API is
difficult to work with. I hate to do it at this point though because
technically people could be writing custom middleware for it.

r? @ob-stripe
cc @stripe/api-libraries