### PR TITLE
Only send telemetry if request ID was present

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -225,7 +225,8 @@ module Stripe
         resp = yield
         context = context.dup_from_response(resp)
         log_response(context, request_start, resp.status, resp.body)
-        if Stripe.enable_telemetry?
+
+        if Stripe.enable_telemetry? && context.request_id
           request_duration_ms = ((Time.now - request_start) * 1000).to_int
           @last_request_metrics = StripeRequestMetrics.new(context.request_id, request_duration_ms)
         end


### PR DESCRIPTION
Tweaks telemetry implementation slightly to be inline with the recent
implementation in stripe-php. Telemetry isn't much good if a request ID
wasn't present, so we only send telemetry if it was.

r? @akropp-stripe