### PR TITLE
Bump Faraday minimum version to 0.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,9 @@ group :development do
   # older Ruby versions. Check Ruby the version here and put a maximum
   # constraint on Rack if necessary.
   if RUBY_VERSION >= "2.2.2"
-    gem "rack", ">= 1.5"
+    gem "rack", ">= 2.0.6"
   else
-    gem "rack", ">= 1.5", "< 2.0" # rubocop:disable Bundler/DuplicatedGem
+    gem "rack", ">= 1.6.11", "< 2.0" # rubocop:disable Bundler/DuplicatedGem
   end
 
   platforms :mri do

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://stripe.com/docs/api/ruby"
   s.license = "MIT"
 
-  s.add_dependency("faraday", "~> 0.10")
+  s.add_dependency("faraday", "~> 0.13")
   s.add_dependency("net-http-persistent", "~> 3.0")
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

We require net-http-persistent 3.0.0 or more recent, but Faraday doesn't support this version until 0.13.0 (cf. https://github.com/lostisland/faraday/pull/619). Bump the minumum Faraday version in the gemspec file.

Fixes #700.

Also opportunistically bump rack version in the Gemfile to fix a security vulnerability reported by GitHub (https://nvd.nist.gov/vuln/detail/CVE-2018-16471).
