### PR TITLE
Don't use net-http-persistent on Windows

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -36,9 +36,9 @@ module Stripe
           builder.use Faraday::Request::UrlEncoded
           builder.use Faraday::Response::RaiseError
 
-          # Net::HTTP::Persistent doesn't seem to do well on JRuby, so fall
-          # back to default there.
-          if RUBY_PLATFORM == "java"
+          # Net::HTTP::Persistent doesn't seem to do well on Windows or JRuby,
+          # so fall back to default there.
+          if Gem.win_platform? || RUBY_PLATFORM == "java"
             builder.adapter :net_http
           else
             builder.adapter :net_http_persistent


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Unfortunately, the `net-http-persistent` gem is incompatible with Windows: https://github.com/drbrain/net-http-persistent/issues/79. Someone submitted a PR to fix this (https://github.com/drbrain/net-http-persistent/pull/90) but the gem hasn't been updated in a while now.

Fixes #702.
