### PR TITLE
Add support for Source List resources

### DIFF
--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -2,6 +2,7 @@
 
 module Stripe
   class Source < APIResource
+    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Save
 

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -4,6 +4,13 @@ require ::File.expand_path("../../test_helper", __FILE__)
 
 module Stripe
   class SourceTest < Test::Unit::TestCase
+    should "be listable" do
+      charges = Stripe::Source.list
+      assert_requested :get, "#{Stripe.api_base}/v1/sources"
+      assert charges.data.is_a?(Array)
+      assert charges.data[0].is_a?(Stripe::Source)
+    end
+
     should "be retrievable" do
       source = Stripe::Source.retrieve("src_123")
       assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123"


### PR DESCRIPTION
Not sure if this a highly requested thing but I noticed a small inconsistency with the API. As of today you can get a collection of charges two ways: 

- Fetching the customer and the corresponding charges method: `Stripe::Customer.retrieve('cust_12').charges`
- Use the `Stripe::Charge.list(limit: xxx)`

Now with the sources API i noticed you can also retrieve a collection sources via the customer by calling `Stripe::Customer.retrieve('cust_12').sources`. However there is no list support for sources `Stripe::Source.list(limit: xxx)`. 

This PR adds List resource support for the Sources endpoint. Note that the specs will fail since I think the Stripe open api needs to also be updated.