### PR TITLE
Detect custom OpenAPI spec file and start stripe-mock from test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   - |
     stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock > /dev/null &
     STRIPE_MOCK_PID=$!
+  - export PATH="${PATH}:${PWD}/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}"
 
 script:
   - bundle exec rake

--- a/test/openapi/README.md
+++ b/test/openapi/README.md
@@ -1,0 +1,9 @@
+## Using custom OpenAPI specification and fixtures files
+
+You can place custom OpenAPI specification and fixtures files in this
+directory. The files must be in JSON format, and must be named `spec3.json`
+and `fixtures3.json` respectively.
+
+If those files are present, the test suite will start its own stripe-mock
+process on a random available port. In order for this to work, `stripe-mock`
+must be on the `PATH` in the environment used to run the test suite.

--- a/test/stripe_mock.rb
+++ b/test/stripe_mock.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Stripe
+  class StripeMock
+    include Singleton
+
+    PATH_SPEC = "#{::File.dirname(__FILE__)}/openapi/spec3.json".freeze
+    PATH_FIXTURES = "#{::File.dirname(__FILE__)}/openapi/fixtures3.json".freeze
+
+    @pid = nil
+    @port = -1
+
+    # Starts stripe-mock, if necessary. Returns the port on which stripe-mock is listening.
+    def self.start
+      unless ::File.exist?(PATH_SPEC)
+        port = ENV["STRIPE_MOCK_PORT"] || 12_111
+        puts("No custom spec file found, assuming stripe-mock is already running on port #{port}")
+        return port
+      end
+
+      unless @pid.nil?
+        puts("stripe-mock already running on port #{@port}")
+        return @port
+      end
+
+      @port = find_available_port
+
+      puts("Starting stripe-mock on port #{@port}...")
+
+      @stdout, @child_stdout = ::IO.pipe
+      @stderr, @child_stderr = ::IO.pipe
+
+      @pid = ::Process.spawn(
+        ["stripe-mock", "stripe-mock"],
+        "-http-port",
+        @port.to_s,
+        "-spec",
+        PATH_SPEC,
+        "-fixtures",
+        PATH_FIXTURES,
+        out: @child_stdout,
+        err: @child_stderr
+      )
+
+      [@child_stdout, @child_stderr].each(&:close)
+
+      sleep 1
+
+      status = (::Process.wait2(@pid, ::Process::WNOHANG) || []).last
+      if status.nil?
+        puts("Started stripe-mock, PID = #{@pid}")
+      else
+        abort("stripe-mock terminated early: #{status}")
+      end
+
+      @port
+    end
+
+    # Stops stripe-mock, if necessary.
+    def self.stop
+      return if @pid.nil?
+      puts("Stopping stripe-mock...")
+      ::Process.kill(:SIGTERM, @pid)
+      ::Process.waitpid2(@pid)
+      @pid = nil
+      @port = -1
+      puts("Stopped stripe-mock")
+    end
+
+    # Finds and returns an available TCP port
+    private_class_method def self.find_available_port
+      server = TCPServer.new("localhost", 0)
+      port = server.addr[1]
+      server.close
+      port
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,10 +14,11 @@ require "webmock/test_unit"
 PROJECT_ROOT = ::File.expand_path("../../", __FILE__)
 
 require ::File.expand_path("../test_data", __FILE__)
+require ::File.expand_path("../stripe_mock", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
 MOCK_MINIMUM_VERSION = "0.40.1".freeze
-MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
+MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to
 # stripe-mock.
@@ -39,6 +40,10 @@ begin
 rescue Faraday::ConnectionFailed
   abort("Couldn't reach stripe-mock at `localhost:#{MOCK_PORT}`. Is " \
     "it running? Please see README for setup instructions.")
+end
+
+Test::Unit.at_exit do
+  Stripe::StripeMock.stop
 end
 
 module Test


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 

First attempt at embedding OpenAPI spec and fixtures files directly in the repo and using those for the test suite. Pretty rough, but it works.

Possible improvements:
- ~better logs / error handling~ (done)
- ~automatically choose an unused port~ (done)
- detect "Listening for HTTP on port" in stripe-mock output instead of sleeping for 1 second
