### PR TITLE
Fix typo/misspell in comments & error messages

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -103,7 +103,7 @@ module Stripe
     end
 
     def legal_entity=(_)
-      raise NoMethodError, 'Overridding legal_entity can cause serious issues. Instead, set the individual fields of legal_entity like blah.legal_entity.first_name = \'Blah\''
+      raise NoMethodError, 'Overriding legal_entity can cause serious issues. Instead, set the individual fields of legal_entity like blah.legal_entity.first_name = \'Blah\''
     end
 
     def deauthorize(client_id = nil, opts = {})

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -278,7 +278,7 @@ module Stripe
     end
 
     # Formats a plugin "app info" hash into a string that we can tack onto the
-    # end of a User-Agent string where it'll be fairly prominant in places like
+    # end of a User-Agent string where it'll be fairly prominent in places like
     # the Dashboard. Note that this formatting has been implemented to match
     # other libraries, and shouldn't be changed without universal consensus.
     def format_app_info(info)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -452,14 +452,14 @@ module Stripe
 
     should "#to_s will call to_s for all embedded stripe objects" do
       obj = Stripe::StripeObject.construct_from(id: "id",
-                                                # embeded list object
+                                                # embedded list object
                                                 refunds: Stripe::ListObject.construct_from(data: [
                                                   # embedded object in list
                                                   Stripe::StripeObject.construct_from(id: "id",
                                                                                       # embedded object in an object in a list object
                                                                                       metadata: Stripe::StripeObject.construct_from(foo: "bar")),
                                                 ]),
-                                                # embeded stripe object
+                                                # embedded stripe object
                                                 metadata: Stripe::StripeObject.construct_from(foo: "bar"))
       expected = JSON.pretty_generate(id: "id",
                                       refunds: {


### PR DESCRIPTION
This pull request a few typo/misspellings in comments/error messages.