### PR TITLE
Generate OAuth authorize URLs for express accounts

### DIFF
--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -31,11 +31,14 @@ module Stripe
     def self.authorize_url(params = {}, opts = {})
       base = opts[:connect_base] || Stripe.connect_base
 
+      path = "/oauth/authorize"
+      path = "/express" + path if opts[:express]
+
       params[:client_id] = get_client_id(params)
       params[:response_type] ||= "code"
       query = Util.encode_parameters(params)
 
-      "#{base}/oauth/authorize?#{query}"
+      "#{base}#{path}?#{query}"
     end
 
     def self.token(params = {}, opts = {})

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -35,6 +35,15 @@ module Stripe
         assert_equal(["https://example.com/profile/test"], params["stripe_user[url]"])
         assert_equal(["US"], params["stripe_user[country]"])
       end
+
+      should "optionally return an express path" do
+        uri_str = OAuth.authorize_url({}, express: true)
+
+        uri = URI.parse(uri_str)
+        assert_equal("https", uri.scheme)
+        assert_equal("connect.stripe.com", uri.host)
+        assert_equal("/express/oauth/authorize", uri.path)
+      end
     end
 
     context ".token" do


### PR DESCRIPTION
Connect with Express accounts uses a slightly different version of the
OAuth authorize URL [1] in that it's prefixed with `/express`.

Here we add a new option to `Stripe::OAuth.authorize_url` which allows
`express: true` to be passed in to generate the Express variant.

Note that the token endpoint has no equivalent so we don't need the
option there.

Fixes #717.

r? @ob-stripe

[1] https://stripe.com/docs/connect/oauth-reference#express-account-differences