### PR TITLE
CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ cache:
     - stripe-mock
 
 before_install:
+  # Install bundler 1.x, because we need to support Ruby 2.1 for now
+  - gem install bundler -v "~> 1.0"
   # Unpack and start stripe-mock so that the test suite can talk to it
   - |
     if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -159,18 +159,21 @@ module Stripe
 
     context "#to_hash" do
       should "skip calling to_hash on nil" do
-        module NilWithToHash
-          def to_hash
-            raise "Can't call to_hash on nil"
+        begin
+          module NilWithToHash
+            def to_hash
+              raise "Can't call to_hash on nil"
+            end
           end
-        end
-        # include is private in Ruby 2.0
-        NilClass.send(:include, NilWithToHash)
+          ::NilClass.include NilWithToHash
 
-        hash_with_nil = { id: 3, foo: nil }
-        obj = StripeObject.construct_from(hash_with_nil)
-        expected_hash = { id: 3, foo: nil }
-        assert_equal expected_hash, obj.to_hash
+          hash_with_nil = { id: 3, foo: nil }
+          obj = StripeObject.construct_from(hash_with_nil)
+          expected_hash = { id: 3, foo: nil }
+          assert_equal expected_hash, obj.to_hash
+        ensure
+          ::NilClass.send(:undef_method, :to_hash)
+        end
       end
 
       should "recursively call to_hash on its values" do


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

A couple of CI fixes:
- pin bundler to 1.x. bundler 2.0 was released yesterday, but it dropped support for Ruby 2.1
- clean up the `to_hash` method added to `NilClass` for a test. This caused issues with Simplecov in some Ruby versions
