### PR TITLE
bump strip mock version to 0.40.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.40.0
+    - STRIPE_MOCK_VERSION=0.40.1
 
 cache:
   directories:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ PROJECT_ROOT = ::File.expand_path("../../", __FILE__)
 require ::File.expand_path("../test_data", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.40.0".freeze
+MOCK_MINIMUM_VERSION = "0.40.1".freeze
 MOCK_PORT = ENV["STRIPE_MOCK_PORT"] || 12_111
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 
Bump stripe mock-version after release https://github.com/stripe/stripe-mock/pull/132