### PR TITLE
Properly serialize `individual` on Account objects

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -80,15 +80,20 @@ module Stripe
     # We're trying to get this overturned on the server side, but for now,
     # patch in a special allowance.
     def serialize_params(options = {})
-      serialize_params_account(self, super)
+      serialize_params_account(self, super, options)
     end
 
-    def serialize_params_account(_obj, update_hash)
+    def serialize_params_account(_obj, update_hash, options = {})
       if (entity = @values[:legal_entity])
         if (owners = entity[:additional_owners])
           entity_update = update_hash[:legal_entity] ||= {}
           entity_update[:additional_owners] =
             serialize_additional_owners(entity, owners)
+        end
+      end
+      if (individual = @values[:individual])
+        if individual.is_a?(Person) && !update_hash.key?(:individual)
+          update_hash[:individual] = individual.serialize_params(options)
         end
       end
       update_hash

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -195,6 +195,57 @@ module Stripe
         }
         assert_equal(expected, obj.serialize_params)
       end
+
+      should "serialize on a new individual" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "account",
+        }, {})
+        obj.individual = { first_name: "Jane" }
+
+        expected = { individual: { first_name: "Jane" } }
+        assert_equal(expected, obj.serialize_params)
+      end
+
+      should "serialize on a partially changed individual" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "account",
+          individual: Stripe::Util.convert_to_stripe_object({
+            object: "person",
+            first_name: "Jenny",
+          }, {}),
+        }, {})
+        obj.individual = { first_name: "Jane" }
+
+        expected = { individual: { first_name: "Jane" } }
+        assert_equal(expected, obj.serialize_params)
+      end
+
+      should "serialize on an unchanged individual" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "account",
+          individual: Stripe::Util.convert_to_stripe_object({
+            object: "person",
+            first_name: "Jenny",
+          }, {}),
+        }, {})
+
+        expected = { individual: {} }
+        assert_equal(expected, obj.serialize_params)
+      end
+
+      should "serialize on an unset individual" do
+        obj = Stripe::Util.convert_to_stripe_object({
+          object: "account",
+          individual: Stripe::Util.convert_to_stripe_object({
+            object: "person",
+            first_name: "Jenny",
+          }, {}),
+        }, {})
+        obj.individual = nil
+
+        expected = { individual: "" }
+        assert_equal(expected, obj.serialize_params)
+      end
     end
   end
 end


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Properly serialize `individual` on Account objects.