### PR TITLE
Add port in "started stripe-mock" output

### DIFF
--- a/test/stripe_mock.rb
+++ b/test/stripe_mock.rb
@@ -55,7 +55,7 @@ module Stripe
 
       status = (::Process.wait2(@pid, ::Process::WNOHANG) || []).last
       if status.nil?
-        puts("Started stripe-mock, PID = #{@pid}")
+        puts("Started stripe-mock; PID = #{@pid}, port = #{@port}")
       else
         abort("stripe-mock terminated early: #{status}")
       end


### PR DESCRIPTION
A tiny tweak to add the port chosen by stripe-mock to the "starting
stripe-mock" output. This gives the user a little more information
(which might be handy if something isn't working), and brings it inline
with Go's output format: https://github.com/stripe/stripe-go/pull/780

cc @ob-stripe