### PR TITLE
Add support for retrieving a Checkout Session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.47.0
+    - STRIPE_MOCK_VERSION=0.49.0
 
 cache:
   directories:

--- a/test/stripe/checkout/session_test.rb
+++ b/test/stripe/checkout/session_test.rb
@@ -30,6 +30,12 @@ module Stripe
         assert_requested :post, "#{Stripe.api_base}/v1/checkout/sessions"
         assert session.is_a?(Stripe::Checkout::Session)
       end
+
+      should "be retrievable" do
+        charge = Stripe::Checkout::Session.retrieve("cs_123")
+        assert_requested :get, "#{Stripe.api_base}/v1/checkout/sessions/cs_123"
+        assert charge.is_a?(Stripe::Checkout::Session)
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require ::File.expand_path("../test_data", __FILE__)
 require ::File.expand_path("../stripe_mock", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.47.0".freeze
+MOCK_MINIMUM_VERSION = "0.49.0".freeze
 MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
This adds support for retrieving a Checkout Session via the API and also changes the shape of the resource to have more details.

cc @stripe/api-libraries 