### PR TITLE
Static methods for delete

### DIFF
--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -3,10 +3,34 @@
 module Stripe
   module APIOperations
     module Delete
+      module ClassMethods
+        # Deletes an API resource
+        #
+        # Deletes the identified resource with the passed in parameters.
+        #
+        # ==== Attributes
+        #
+        # * +id+ - ID of the resource to delete.
+        # * +params+ - A hash of parameters to pass to the API
+        # * +opts+ - A Hash of additional options (separate from the params /
+        #   object values) to be added to the request. E.g. to allow for an
+        #   idempotency_key to be passed in the request headers, or for the
+        #   api_key to be overwritten. See {APIOperations::Request.request}.
+        def delete(id, params = {}, opts = {})
+          opts = Util.normalize_opts(opts)
+          resp, opts = request(:delete, "#{resource_url}/#{id}", params, opts)
+          Util.convert_to_stripe_object(resp.data, opts)
+        end
+      end
+
       def delete(params = {}, opts = {})
         opts = Util.normalize_opts(opts)
         resp, opts = request(:delete, resource_url, params, opts)
         initialize_from(resp.data, opts)
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
       end
     end
   end

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -36,11 +36,6 @@ module Stripe
       initialize_from(resp.data, opts)
     end
 
-    def self.capture(id, params = {}, opts = {})
-      resp, opts = request(:post, "#{resource_url}/#{id}/capture", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
-    end
-
     def update_dispute(params = {}, opts = {})
       resp, opts = request(:post, dispute_url, params, opts)
       initialize_from({ dispute: resp.data }, opts, true)

--- a/lib/stripe/charge.rb
+++ b/lib/stripe/charge.rb
@@ -36,6 +36,11 @@ module Stripe
       initialize_from(resp.data, opts)
     end
 
+    def self.capture(id, params = {}, opts = {})
+      resp, opts = request(:post, "#{resource_url}/#{id}/capture", params, opts)
+      Util.convert_to_stripe_object(resp.data, opts)
+    end
+
     def update_dispute(params = {}, opts = {})
       resp, opts = request(:post, dispute_url, params, opts)
       initialize_from({ dispute: resp.data }, opts, true)

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -57,11 +57,21 @@ module Stripe
       assert account.is_a?(Stripe::Account)
     end
 
-    should "be deletable" do
-      account = Stripe::Account.retrieve("acct_123")
-      account = account.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{account.id}"
-      assert account.is_a?(Stripe::Account)
+    context "#delete" do
+      should "be deletable" do
+        account = Stripe::Account.retrieve("acct_123")
+        account = account.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{account.id}"
+        assert account.is_a?(Stripe::Account)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        account = Stripe::Account.delete("acct_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/accounts/acct_123"
+        assert account.is_a?(Stripe::Account)
+      end
     end
 
     should "be able to list Persons" do

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -24,10 +24,23 @@ module Stripe
     end
 
     should "be deletable" do
-      domain = Stripe::ApplePayDomain.retrieve("apwc_123")
-      domain = domain.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain.id}"
-      assert domain.is_a?(Stripe::ApplePayDomain)
+    end
+
+    context "#delete" do
+      should "be deletable" do
+        domain = Stripe::ApplePayDomain.retrieve("apwc_123")
+        domain = domain.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain.id}"
+        assert domain.is_a?(Stripe::ApplePayDomain)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        domain = Stripe::ApplePayDomain.delete("apwc_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/apwc_123"
+        assert domain.is_a?(Stripe::ApplePayDomain)
+      end
     end
   end
 end

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -41,11 +41,21 @@ module Stripe
       assert coupon.is_a?(Stripe::Coupon)
     end
 
-    should "be deletable" do
-      coupon = Stripe::Coupon.retrieve("25OFF")
-      coupon = coupon.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
-      assert coupon.is_a?(Stripe::Coupon)
+    context "#delete" do
+      should "be deletable" do
+        coupon = Stripe::Coupon.delete("25OFF")
+        assert_requested :delete, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
+        assert coupon.is_a?(Stripe::Coupon)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        coupon = Stripe::Coupon.retrieve("25OFF")
+        coupon = coupon.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/coupons/25OFF"
+        assert coupon.is_a?(Stripe::Coupon)
+      end
     end
   end
 end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -43,6 +43,12 @@ module Stripe
       assert customer.is_a?(Stripe::Customer)
     end
 
+    should "be deletable (class method)" do
+      customer = Stripe::Customer.delete("cus_123")
+      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
+      assert customer.is_a?(Stripe::Customer)
+    end
+
     context "#create_subscription" do
       should "create a new subscription" do
         customer = Stripe::Customer.retrieve("cus_123")

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -36,17 +36,21 @@ module Stripe
       assert customer.is_a?(Stripe::Customer)
     end
 
-    should "be deletable" do
-      customer = Stripe::Customer.retrieve("cus_123")
-      customer = customer.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
-      assert customer.is_a?(Stripe::Customer)
+    context "#delete" do
+      should "be deletable" do
+        customer = Stripe::Customer.retrieve("cus_123")
+        customer = customer.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
+        assert customer.is_a?(Stripe::Customer)
+      end
     end
 
-    should "be deletable (class method)" do
-      customer = Stripe::Customer.delete("cus_123")
-      assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
-      assert customer.is_a?(Stripe::Customer)
+    context ".delete" do
+      should "be deletable" do
+        customer = Stripe::Customer.delete("cus_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123"
+        assert customer.is_a?(Stripe::Customer)
+      end
     end
 
     context "#create_subscription" do

--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -82,5 +82,12 @@ module Stripe
         assert_requested :delete, "#{Stripe.api_base}/v1/ephemeral_keys/#{key.id}"
       end
     end
+
+    context ".delete" do
+      should "succeed" do
+        Stripe::EphemeralKey.delete("ephkey_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/ephemeral_keys/ephkey_123"
+      end
+    end
   end
 end

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -44,12 +44,23 @@ module Stripe
       assert item.is_a?(Stripe::InvoiceItem)
     end
 
-    should "be deletable" do
-      item = Stripe::InvoiceItem.retrieve("ii_123")
-      item = item.delete
-      assert_requested :delete,
-                       "#{Stripe.api_base}/v1/invoiceitems/#{item.id}"
-      assert item.is_a?(Stripe::InvoiceItem)
+    context "#delete" do
+      should "be deletable" do
+        item = Stripe::InvoiceItem.retrieve("ii_123")
+        item = item.delete
+        assert_requested :delete,
+                         "#{Stripe.api_base}/v1/invoiceitems/#{item.id}"
+        assert item.is_a?(Stripe::InvoiceItem)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        item = Stripe::InvoiceItem.delete("ii_123")
+        assert_requested :delete,
+                         "#{Stripe.api_base}/v1/invoiceitems/ii_123"
+        assert item.is_a?(Stripe::InvoiceItem)
+      end
     end
   end
 end

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -39,10 +39,22 @@ module Stripe
     end
 
     should "be deletable" do
-      invoice = Stripe::Invoice.retrieve("in_123")
-      invoice = invoice.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
-      assert invoice.is_a?(Stripe::Invoice)
+    end
+    context "#delete" do
+      should "be deletable" do
+        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = invoice.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
+        assert invoice.is_a?(Stripe::Invoice)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        invoice = Stripe::Invoice.delete("in_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/invoices/in_123"
+        assert invoice.is_a?(Stripe::Invoice)
+      end
     end
 
     context "#finalize" do

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -12,8 +12,8 @@ module Stripe
     end
 
     should "be retrievable" do
-      plan = Stripe::Plan.retrieve("sapphire-elite")
-      assert_requested :get, "#{Stripe.api_base}/v1/plans/sapphire-elite"
+      plan = Stripe::Plan.retrieve("pl_123")
+      assert_requested :get, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
@@ -22,8 +22,7 @@ module Stripe
         amount: 5000,
         interval: "month",
         name: "Sapphire elite",
-        currency: "usd",
-        id: "sapphire-elite"
+        currency: "usd"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/plans"
       assert plan.is_a?(Stripe::Plan)
@@ -35,7 +34,6 @@ module Stripe
         interval: "month",
         name: "Sapphire elite",
         currency: "usd",
-        id: "sapphire-elite",
         usage_type: "metered"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/plans"
@@ -47,7 +45,6 @@ module Stripe
         interval: "month",
         name: "Sapphire elite",
         currency: "usd",
-        id: "sapphire-elite",
         billing_scheme: "tiered",
         tiers_mode: "volume",
         tiers: [{ up_to: 100, amount: 1000 }, { up_to: "inf", amount: 2000 }]
@@ -61,7 +58,6 @@ module Stripe
         interval: "month",
         name: "Sapphire elite",
         currency: "usd",
-        id: "sapphire-elite",
         amount: 5000,
         transform_usage: { round: "up", divide_by: 50 }
       )
@@ -70,23 +66,33 @@ module Stripe
     end
 
     should "be saveable" do
-      plan = Stripe::Plan.retrieve("sapphire-elite")
+      plan = Stripe::Plan.retrieve("pl_123")
       plan.metadata["key"] = "value"
       plan.save
       assert_requested :post, "#{Stripe.api_base}/v1/plans/#{plan.id}"
     end
 
     should "be updateable" do
-      plan = Stripe::Plan.update("sapphire-elite", metadata: { foo: "bar" })
-      assert_requested :post, "#{Stripe.api_base}/v1/plans/sapphire-elite"
+      plan = Stripe::Plan.update("pl_123", metadata: { foo: "bar" })
+      assert_requested :post, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
-    should "be deletable" do
-      plan = Stripe::Plan.retrieve("sapphire-elite")
-      plan = plan.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan.id}"
-      assert plan.is_a?(Stripe::Plan)
+    context "#delete" do
+      should "be deletable" do
+        plan = Stripe::Plan.retrieve("pl_123")
+        plan = plan.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan.id}"
+        assert plan.is_a?(Stripe::Plan)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        plan = Stripe::Plan.delete("pl_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/plans/pl_123"
+        assert plan.is_a?(Stripe::Plan)
+      end
     end
   end
 end

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -39,11 +39,21 @@ module Stripe
       assert product.is_a?(Stripe::Product)
     end
 
-    should "be deletable" do
-      product = Stripe::Product.retrieve("prod_123")
-      product = product.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product.id}"
-      assert product.is_a?(Stripe::Product)
+    context "#delete" do
+      should "be deletable" do
+        product = Stripe::Product.retrieve("prod_123")
+        product = product.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product.id}"
+        assert product.is_a?(Stripe::Product)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        product = Stripe::Product.delete("prod_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/products/prod_123"
+        assert product.is_a?(Stripe::Product)
+      end
     end
   end
 end

--- a/test/stripe/radar/value_list_item_test.rb
+++ b/test/stripe/radar/value_list_item_test.rb
@@ -27,11 +27,21 @@ module Stripe
         assert item.is_a?(Stripe::Radar::ValueListItem)
       end
 
-      should "be deletable" do
-        list = Stripe::Radar::ValueListItem.retrieve("rsli_123")
-        list = list.delete
-        assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
-        assert list.is_a?(Stripe::Radar::ValueListItem)
+      context "#delete" do
+        should "be deletable" do
+          list = Stripe::Radar::ValueListItem.retrieve("rsli_123")
+          list = list.delete
+          assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
+          assert list.is_a?(Stripe::Radar::ValueListItem)
+        end
+      end
+
+      context ".delete" do
+        should "be deletable" do
+          list = Stripe::Radar::ValueListItem.delete("rsli_123")
+          assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
+          assert list.is_a?(Stripe::Radar::ValueListItem)
+        end
       end
     end
   end

--- a/test/stripe/radar/value_list_test.rb
+++ b/test/stripe/radar/value_list_test.rb
@@ -40,11 +40,21 @@ module Stripe
         assert list.is_a?(Stripe::Radar::ValueList)
       end
 
-      should "be deletable" do
-        list = Stripe::Radar::ValueList.retrieve("rsl_123")
-        list = list.delete
-        assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
-        assert list.is_a?(Stripe::Radar::ValueList)
+      context "#delete" do
+        should "be deletable" do
+          list = Stripe::Radar::ValueList.retrieve("rsl_123")
+          list = list.delete
+          assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
+          assert list.is_a?(Stripe::Radar::ValueList)
+        end
+      end
+
+      context ".delete" do
+        should "be deletable" do
+          list = Stripe::Radar::ValueList.delete("rsl_123")
+          assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
+          assert list.is_a?(Stripe::Radar::ValueList)
+        end
       end
     end
   end

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -40,10 +40,23 @@ module Stripe
     end
 
     should "be deletable" do
-      recipient = Stripe::Recipient.retrieve("rp_123")
-      recipient = recipient.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
-      assert recipient.is_a?(Stripe::Recipient)
+    end
+
+    context "#delete" do
+      should "be deletable" do
+        recipient = Stripe::Recipient.retrieve("rp_123")
+        recipient = recipient.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
+        assert recipient.is_a?(Stripe::Recipient)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        recipient = Stripe::Recipient.delete("rp_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/recipients/rp_123"
+        assert recipient.is_a?(Stripe::Recipient)
+      end
     end
   end
 end

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -40,11 +40,21 @@ module Stripe
       assert sku.is_a?(Stripe::SKU)
     end
 
-    should "be deletable" do
-      sku = Stripe::SKU.retrieve("sku_123")
-      sku = sku.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku.id}"
-      assert sku.is_a?(Stripe::SKU)
+    context "#delete" do
+      should "be deletable" do
+        sku = Stripe::SKU.retrieve("sku_123")
+        sku = sku.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku.id}"
+        assert sku.is_a?(Stripe::SKU)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        sku = Stripe::SKU.delete("sku_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/skus/sku_123"
+        assert sku.is_a?(Stripe::SKU)
+      end
     end
   end
 end

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -43,11 +43,21 @@ module Stripe
       assert item.is_a?(Stripe::SubscriptionItem)
     end
 
-    should "be deletable" do
-      item = Stripe::SubscriptionItem.retrieve("si_123")
-      item = item.delete
-      assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
-      assert item.is_a?(Stripe::SubscriptionItem)
+    context "#delete" do
+      should "be deletable" do
+        item = Stripe::SubscriptionItem.retrieve("si_123")
+        item = item.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
+        assert item.is_a?(Stripe::SubscriptionItem)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        item = Stripe::SubscriptionItem.delete("si_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/si_123"
+        assert item.is_a?(Stripe::SubscriptionItem)
+      end
     end
   end
 end

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -41,12 +41,23 @@ module Stripe
       assert subscription.is_a?(Stripe::Subscription)
     end
 
-    should "be deletable" do
-      subscription = Stripe::Subscription.retrieve("sub_123")
-      subscription = subscription.delete
-      assert_requested :delete,
-                       "#{Stripe.api_base}/v1/subscriptions/#{subscription.id}"
-      assert subscription.is_a?(Stripe::Subscription)
+    context "#delete" do
+      should "be deletable" do
+        subscription = Stripe::Subscription.retrieve("sub_123")
+        subscription = subscription.delete
+        assert_requested :delete,
+                         "#{Stripe.api_base}/v1/subscriptions/#{subscription.id}"
+        assert subscription.is_a?(Stripe::Subscription)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        subscription = Stripe::Subscription.delete("sub_123")
+        assert_requested :delete,
+                         "#{Stripe.api_base}/v1/subscriptions/sub_123"
+        assert subscription.is_a?(Stripe::Subscription)
+      end
     end
 
     context "#delete_discount" do

--- a/test/stripe/terminal/location_test.rb
+++ b/test/stripe/terminal/location_test.rb
@@ -47,11 +47,21 @@ module Stripe
         assert location.is_a?(Stripe::Terminal::Location)
       end
 
-      should "be deletable" do
-        location = Stripe::Terminal::Location.retrieve("loc_123")
-        location = location.delete
-        assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/#{location.id}"
-        assert location.is_a?(Stripe::Terminal::Location)
+      context "#delete" do
+        should "be deletable" do
+          location = Stripe::Terminal::Location.retrieve("loc_123")
+          location = location.delete
+          assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/#{location.id}"
+          assert location.is_a?(Stripe::Terminal::Location)
+        end
+      end
+
+      context ".delete" do
+        should "be deletable" do
+          location = Stripe::Terminal::Location.delete("loc_123")
+          assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
+          assert location.is_a?(Stripe::Terminal::Location)
+        end
       end
     end
   end

--- a/test/stripe/terminal/reader_test.rb
+++ b/test/stripe/terminal/reader_test.rb
@@ -41,11 +41,21 @@ module Stripe
         assert reader.is_a?(Stripe::Terminal::Reader)
       end
 
-      should "be deletable" do
-        reader = Stripe::Terminal::Reader.retrieve("rdr_123")
-        reader = reader.delete
-        assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/#{reader.id}"
-        assert reader.is_a?(Stripe::Terminal::Reader)
+      context "#delete" do
+        should "be deletable" do
+          reader = Stripe::Terminal::Reader.retrieve("rdr_123")
+          reader = reader.delete
+          assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/#{reader.id}"
+          assert reader.is_a?(Stripe::Terminal::Reader)
+        end
+      end
+
+      context ".delete" do
+        should "be deletable" do
+          reader = Stripe::Terminal::Reader.delete("rdr_123")
+          assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
+          assert reader.is_a?(Stripe::Terminal::Reader)
+        end
       end
     end
   end

--- a/test/stripe/webhook_endpoint_test.rb
+++ b/test/stripe/webhook_endpoint_test.rb
@@ -38,5 +38,22 @@ module Stripe
       assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
       assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
     end
+
+    context "#delete" do
+      should "be deletable" do
+        webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+        webhook_endpoint = webhook_endpoint.delete
+        assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
+        assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
+      end
+    end
+
+    context ".delete" do
+      should "be deletable" do
+        webhook_endpoint = Stripe::WebhookEndpoint.delete("we_123")
+        assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
+        assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
+      end
+    end
   end
 end


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 

Opening this PR for early feedback.

Things are much easier/less hacky than Python here since Ruby supports class methods and instance methods with same names.

We'll probably need to do some refactoring around the helper URL methods for non-CRUDL methods though.