### PR TITLE
Include file_link_data parameter in file creation test

### DIFF
--- a/test/stripe/file_test.rb
+++ b/test/stripe/file_test.rb
@@ -31,7 +31,8 @@ module Stripe
       should "be creatable with a File" do
         file = Stripe::File.create(
           purpose: "dispute_evidence",
-          file: ::File.new(__FILE__)
+          file: ::File.new(__FILE__),
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::File)
@@ -44,7 +45,8 @@ module Stripe
 
         file = Stripe::File.create(
           purpose: "dispute_evidence",
-          file: tempfile
+          file: tempfile,
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::File)
@@ -53,7 +55,8 @@ module Stripe
       should "be creatable with Faraday::UploadIO" do
         file = Stripe::File.create(
           purpose: "dispute_evidence",
-          file: Faraday::UploadIO.new(::File.new(__FILE__), nil)
+          file: Faraday::UploadIO.new(::File.new(__FILE__), nil),
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::File)

--- a/test/stripe/file_upload_test.rb
+++ b/test/stripe/file_upload_test.rb
@@ -34,7 +34,8 @@ module Stripe
       should "be creatable with a File" do
         file = Stripe::FileUpload.create(
           purpose: "dispute_evidence",
-          file: ::File.new(__FILE__)
+          file: ::File.new(__FILE__),
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::FileUpload)
@@ -47,7 +48,8 @@ module Stripe
 
         file = Stripe::FileUpload.create(
           purpose: "dispute_evidence",
-          file: tempfile
+          file: tempfile,
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::FileUpload)
@@ -56,7 +58,8 @@ module Stripe
       should "be creatable with Faraday::UploadIO" do
         file = Stripe::FileUpload.create(
           purpose: "dispute_evidence",
-          file: Faraday::UploadIO.new(::File.new(__FILE__), nil)
+          file: Faraday::UploadIO.new(::File.new(__FILE__), nil),
+          file_link_data: { create: true }
         )
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::FileUpload)


### PR DESCRIPTION
cc @brandur-stripe @remi-stripe 

stripe-ruby encodes nested parameters correctly in multipart requests, but let's add a test just to ensure we don't introduce regressions in the future (e.g. if we get rid of Faraday).