### PR TITLE
Relax constraints on objects that we'll accept as a file

### DIFF
--- a/lib/stripe/file.rb
+++ b/lib/stripe/file.rb
@@ -20,7 +20,11 @@ module Stripe
       # rest-client would accept a vanilla `File` for upload, but Faraday does
       # not. Support the old API by wrapping a `File`-like object with an
       # `UploadIO` object if we're given one.
-      if params[:file] && params[:file].respond_to?(:path) && params[:file].respond_to?(:read)
+      if params[:file] && !params[:file].is_a?(String)
+        unless params[:file].respond_to?(:read)
+          raise ArgumentError, "file must respond to `#read`"
+        end
+
         params[:file] = Faraday::UploadIO.new(params[:file], nil)
       end
 

--- a/test/stripe/file_test.rb
+++ b/test/stripe/file_test.rb
@@ -61,6 +61,27 @@ module Stripe
         assert_requested :post, "#{Stripe.uploads_base}/v1/files"
         assert file.is_a?(Stripe::File)
       end
+
+      should "be creatable with a string" do
+        file = Stripe::File.create(
+          purpose: "dispute_evidence",
+          file: "my-file-contents",
+          file_link_data: { create: true }
+        )
+        assert_requested :post, "#{Stripe.uploads_base}/v1/files"
+        assert file.is_a?(Stripe::File)
+      end
+
+      should "raise given a file object that doesn't respond to #read" do
+        e = assert_raises(ArgumentError) do
+          Stripe::File.create(
+            purpose: "dispute_evidence",
+            file: Object.new,
+            file_link_data: { create: true }
+          )
+        end
+        assert_equal "file must respond to `#read`", e.message
+      end
     end
 
     should "be deserializable when `object=file`" do


### PR DESCRIPTION
When uploading a file, we previously made a check on whether it
supported both `#read` and `#path` before wrapping it in a
`Faraday::UploadIO` and sending it off. The second check on `#path`
isn't strictly necessary, and as reported in #761 can prevent objects
created by `open-uri` from being compatible with file upload.

Here we remove the check `#path` so that we just require that objects
support `#read`, and in addition error when an object is passed that's
not file-compatible and not a string. This should prevent users from
seeing the very confusing "Invalid hash" error in these situations.

Fixes #761.

r? @ob-stripe
cc @stripe/api-libraries