### PR TITLE
Remove total_count from second pagination request

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -82,6 +82,10 @@ module Stripe
 
       params = filters.merge(starting_after: last_id).merge(params)
 
+      if params[:include] && params[:include].include?('total_count')
+        params[:include].delete 'total_count'
+      end
+
       list(params, opts)
     end
 


### PR DESCRIPTION
I'm not sure if I like this change. Here's why I think we should add it, but I could easily be convinced that we shouldn't be modified `filters` for a user automatically:

* If `total_count` is high, it has a higher change of causing the entire request to fail
* However, you'll often want to get the `total_count` via the initial `list` call in order to monitor pagination progress within the `auto_paging_each` block.
* After calling `auto_paging_each`, there's not an easy way to modify the `filter` parameters.
* In order to avoid failing pagination requests, we should automatically remove the `total_count` parameter for the user.