### PR TITLE
Simplify inheritance for nested classes

### DIFF
--- a/lib/stripe/checkout/session.rb
+++ b/lib/stripe/checkout/session.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Checkout
-    class Session < Stripe::APIResource
+    class Session < APIResource
       extend Stripe::APIOperations::Create
 
       OBJECT_NAME = "checkout.session".freeze

--- a/lib/stripe/issuing/authorization.rb
+++ b/lib/stripe/issuing/authorization.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Issuing
-    class Authorization < Stripe::APIResource
+    class Authorization < APIResource
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 

--- a/lib/stripe/issuing/card.rb
+++ b/lib/stripe/issuing/card.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Issuing
-    class Card < Stripe::APIResource
+    class Card < APIResource
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save

--- a/lib/stripe/issuing/cardholder.rb
+++ b/lib/stripe/issuing/cardholder.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Issuing
-    class Cardholder < Stripe::APIResource
+    class Cardholder < APIResource
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save

--- a/lib/stripe/issuing/dispute.rb
+++ b/lib/stripe/issuing/dispute.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Issuing
-    class Dispute < Stripe::APIResource
+    class Dispute < APIResource
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save

--- a/lib/stripe/issuing/transaction.rb
+++ b/lib/stripe/issuing/transaction.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Issuing
-    class Transaction < Stripe::APIResource
+    class Transaction < APIResource
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 

--- a/lib/stripe/radar/value_list.rb
+++ b/lib/stripe/radar/value_list.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Radar
-    class ValueList < Stripe::APIResource
+    class ValueList < APIResource
       extend Stripe::APIOperations::Create
       include Stripe::APIOperations::Delete
       extend Stripe::APIOperations::List

--- a/lib/stripe/reporting/report_run.rb
+++ b/lib/stripe/reporting/report_run.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Reporting
-    class ReportRun < Stripe::APIResource
+    class ReportRun < APIResource
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
 

--- a/lib/stripe/reporting/report_type.rb
+++ b/lib/stripe/reporting/report_type.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Reporting
-    class ReportType < Stripe::APIResource
+    class ReportType < APIResource
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
 

--- a/lib/stripe/terminal/connection_token.rb
+++ b/lib/stripe/terminal/connection_token.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Terminal
-    class ConnectionToken < Stripe::APIResource
+    class ConnectionToken < APIResource
       extend Stripe::APIOperations::Create
 
       OBJECT_NAME = "terminal.connection_token".freeze

--- a/lib/stripe/terminal/location.rb
+++ b/lib/stripe/terminal/location.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Terminal
-    class Location < Stripe::APIResource
+    class Location < APIResource
       extend Stripe::APIOperations::Create
       include Stripe::APIOperations::Delete
       extend Stripe::APIOperations::List

--- a/lib/stripe/terminal/reader.rb
+++ b/lib/stripe/terminal/reader.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   module Terminal
-    class Reader < Stripe::APIResource
+    class Reader < APIResource
       extend Stripe::APIOperations::Create
       include Stripe::APIOperations::Delete
       extend Stripe::APIOperations::List


### PR DESCRIPTION
Simplify inheritance to make code look a bit more like codegen version. There's no need to explicitly mention root module here since all the classes are defined inside it anyway.

r? @rattrayalex-stripe 