### PR TITLE
Sort includes/extends by method name for consistency

### DIFF
--- a/lib/stripe/coupon.rb
+++ b/lib/stripe/coupon.rb
@@ -3,9 +3,9 @@
 module Stripe
   class Coupon < APIResource
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "coupon".freeze
   end

--- a/lib/stripe/credit_note.rb
+++ b/lib/stripe/credit_note.rb
@@ -2,9 +2,9 @@
 
 module Stripe
   class CreditNote < APIResource
+    extend Stripe::APIOperations::Create
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
-    extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "credit_note".freeze
 

--- a/lib/stripe/file_link.rb
+++ b/lib/stripe/file_link.rb
@@ -3,8 +3,8 @@
 module Stripe
   class FileLink < APIResource
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "file_link".freeze
   end

--- a/lib/stripe/invoice.rb
+++ b/lib/stripe/invoice.rb
@@ -2,10 +2,10 @@
 
 module Stripe
   class Invoice < APIResource
+    extend Stripe::APIOperations::Create
+    include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
-    include Stripe::APIOperations::Delete
-    extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "invoice".freeze
 

--- a/lib/stripe/invoice_item.rb
+++ b/lib/stripe/invoice_item.rb
@@ -2,9 +2,9 @@
 
 module Stripe
   class InvoiceItem < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
+    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "invoiceitem".freeze

--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -2,8 +2,8 @@
 
 module Stripe
   class Order < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
+    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "order".freeze

--- a/lib/stripe/payment_method.rb
+++ b/lib/stripe/payment_method.rb
@@ -3,8 +3,8 @@
 module Stripe
   class PaymentMethod < APIResource
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "payment_method".freeze
 

--- a/lib/stripe/payout.rb
+++ b/lib/stripe/payout.rb
@@ -2,8 +2,8 @@
 
 module Stripe
   class Payout < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
+    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "payout".freeze

--- a/lib/stripe/product.rb
+++ b/lib/stripe/product.rb
@@ -2,10 +2,10 @@
 
 module Stripe
   class Product < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     include Stripe::APIOperations::Delete
+    extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "product".freeze
   end

--- a/lib/stripe/recipient.rb
+++ b/lib/stripe/recipient.rb
@@ -5,8 +5,8 @@ module Stripe
   class Recipient < APIResource
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
-    include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "recipient".freeze
 

--- a/lib/stripe/subscription_schedule.rb
+++ b/lib/stripe/subscription_schedule.rb
@@ -2,8 +2,8 @@
 
 module Stripe
   class SubscriptionSchedule < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
+    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 

--- a/lib/stripe/tax_rate.rb
+++ b/lib/stripe/tax_rate.rb
@@ -3,8 +3,8 @@
 module Stripe
   class TaxRate < APIResource
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "tax_rate".freeze
   end

--- a/lib/stripe/transfer.rb
+++ b/lib/stripe/transfer.rb
@@ -2,8 +2,8 @@
 
 module Stripe
   class Transfer < APIResource
-    extend Stripe::APIOperations::List
     extend Stripe::APIOperations::Create
+    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 

--- a/lib/stripe/webhook_endpoint.rb
+++ b/lib/stripe/webhook_endpoint.rb
@@ -3,9 +3,9 @@
 module Stripe
   class WebhookEndpoint < APIResource
     extend Stripe::APIOperations::Create
-    include Stripe::APIOperations::Save
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
+    include Stripe::APIOperations::Save
 
     OBJECT_NAME = "webhook_endpoint".freeze
   end


### PR DESCRIPTION
Codegen sorts normal/non-custom methods by names when it decides to include/extend the class with an appropriate module. This PR changes the order of includes/extens to closer match codegen in classes that are otherwise the same or alsmost the same between current state of the library and codegen.

r? @rattrayalex-stripe 