### PR TITLE
Remove explicit Util.normalize_opts calls

### DIFF
--- a/lib/stripe/account.rb
+++ b/lib/stripe/account.rb
@@ -48,12 +48,11 @@ module Stripe
     end
 
     def persons(params = {}, opts = {})
-      resp, opts = request(:get, resource_url + "/persons", params, Util.normalize_opts(opts))
+      resp, opts = request(:get, resource_url + "/persons", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
 
     def reject(params = {}, opts = {})
-      opts = Util.normalize_opts(opts)
       resp, opts = request(:post, resource_url + "/reject", params, opts)
       initialize_from(resp.data, opts)
     end

--- a/lib/stripe/api_operations/delete.rb
+++ b/lib/stripe/api_operations/delete.rb
@@ -17,14 +17,12 @@ module Stripe
         #   idempotency_key to be passed in the request headers, or for the
         #   api_key to be overwritten. See {APIOperations::Request.request}.
         def delete(id, params = {}, opts = {})
-          opts = Util.normalize_opts(opts)
           resp, opts = request(:delete, "#{resource_url}/#{id}", params, opts)
           Util.convert_to_stripe_object(resp.data, opts)
         end
       end
 
       def delete(params = {}, opts = {})
-        opts = Util.normalize_opts(opts)
         resp, opts = request(:delete, resource_url, params, opts)
         initialize_from(resp.data, opts)
       end

--- a/lib/stripe/source.rb
+++ b/lib/stripe/source.rb
@@ -17,7 +17,7 @@ module Stripe
       end
 
       url = "#{Customer.resource_url}/#{CGI.escape(customer)}/sources/#{CGI.escape(id)}"
-      resp, opts = request(:delete, url, params, Util.normalize_opts(opts))
+      resp, opts = request(:delete, url, params, opts)
       initialize_from(resp.data, opts)
     end
 
@@ -28,12 +28,12 @@ module Stripe
     deprecate :delete, "#detach", 2017, 10
 
     def source_transactions(params = {}, opts = {})
-      resp, opts = request(:get, resource_url + "/source_transactions", params, Util.normalize_opts(opts))
+      resp, opts = request(:get, resource_url + "/source_transactions", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
 
     def verify(params = {}, opts = {})
-      resp, opts = request(:post, resource_url + "/verify", params, Util.normalize_opts(opts))
+      resp, opts = request(:post, resource_url + "/verify", params, opts)
       initialize_from(resp.data, opts)
     end
   end

--- a/lib/stripe/subscription_item.rb
+++ b/lib/stripe/subscription_item.rb
@@ -10,7 +10,7 @@ module Stripe
     OBJECT_NAME = "subscription_item".freeze
 
     def usage_record_summaries(params = {}, opts = {})
-      resp, opts = request(:get, resource_url + "/usage_record_summaries", params, Util.normalize_opts(opts))
+      resp, opts = request(:get, resource_url + "/usage_record_summaries", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
   end

--- a/lib/stripe/subscription_schedule.rb
+++ b/lib/stripe/subscription_schedule.rb
@@ -28,7 +28,7 @@ module Stripe
     end
 
     def revisions(params = {}, opts = {})
-      resp, opts = request(:get, resource_url + "/revisions", params, Util.normalize_opts(opts))
+      resp, opts = request(:get, resource_url + "/revisions", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
   end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -135,6 +135,8 @@ module Stripe
     # * +opts+ - Options for +StripeObject+ like an API key that will be reused
     #   on subsequent API calls.
     def self.convert_to_stripe_object(data, opts = {})
+      opts = normalize_opts(opts)
+
       case data
       when Array
         data.map { |i| convert_to_stripe_object(i, opts) }


### PR DESCRIPTION
In some places in the code we call `Util.normalize_opts` on `opts` before passing `opts` to `request` or `Util.convert_to_stripe_object `

Thing is, `request` method does it anyways internally here: https://github.com/stripe/stripe-ruby/blob/v4.16.0/lib/stripe/api_operations/request.rb#L10

And `initialize_from` does it here: https://github.com/stripe/stripe-ruby/blob/v4.16.0/lib/stripe/stripe_object.rb#L414

The only "weak" spot was `Util.convert_to_stripe_object`, so I made sure it explicitly normalizes as well.

With this, we can remove `Util.normalize_opts` from a bunch of resources and make them cleaner and more codegen-friendly.

r? @ob-stripe 