### PR TITLE
Bump stripe-mock to 0.57.0 and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.56.0
+    - STRIPE_MOCK_VERSION=0.57.0
 
 cache:
   directories:

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -307,7 +307,7 @@ module Stripe
         charges = Stripe::Charge.list.data
         assert charges.is_a? Array
         assert charges[0].is_a? Stripe::Charge
-        assert charges[0].source.is_a?(Stripe::StripeObject)
+        assert charges[0].payment_method_details.is_a?(Stripe::StripeObject)
       end
 
       should "passing in a stripe_account header should pass it through on call" do

--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -87,7 +87,7 @@ module Stripe
       should "confirm a payment_intent" do
         payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.confirm(
-          source: "src_123"
+          payment_method: "pm_123"
         )
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/confirm"
@@ -97,7 +97,7 @@ module Stripe
 
     context ".confirm" do
       should "confirm a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.confirm("pi_123", source: "src_123")
+        payment_intent = Stripe::PaymentIntent.confirm("pi_123", payment_method: "pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/confirm"
         assert payment_intent.is_a?(Stripe::PaymentIntent)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require ::File.expand_path("../test_data", __FILE__)
 require ::File.expand_path("../stripe_mock", __FILE__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.56.0".freeze
+MOCK_MINIMUM_VERSION = "0.57.0".freeze
 MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
Fix a few tests to work with latest stripe-mock.
