### PR TITLE
Order#pay without arguments

### DIFF
--- a/lib/stripe/order.rb
+++ b/lib/stripe/order.rb
@@ -11,7 +11,7 @@ module Stripe
     custom_method :pay, http_verb: :post
     custom_method :return_order, http_verb: :post, http_path: "returns"
 
-    def pay(params, opts = {})
+    def pay(params = {}, opts = {})
       resp, opts = request(:post, pay_url, params, opts)
       initialize_from(resp.data, opts)
     end

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -45,6 +45,13 @@ module Stripe
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
         assert order.is_a?(Stripe::Order)
       end
+
+      should "pay an order without additional arguments" do
+        order = Stripe::Order.retrieve("or_123")
+        order = order.pay
+        assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
+        assert order.is_a?(Stripe::Order)
+      end
     end
 
     context ".pay" do


### PR DESCRIPTION
`Order#pay` does not require arguments when an order is attached to a customer. Let's remove the requirement from the API to make paying orders a bit cleaner (`order.pay` vs `order.pay({})`).

Removing this requirement will not throw an argument error locally if the order does not have a customer and is attempted to be paid via the API. However, the API will throw a more descriptive error back to the user if the `source` param is committed which provides a better UX.