### PR TITLE
Fix obsoletes rubocop cops.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,10 @@ AllCops:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Metrics/LineLength:


### PR DESCRIPTION
The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.