### PR TITLE
Fix formatting in ConnectionFailed error message

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -447,7 +447,7 @@ module Stripe
       case error
       when Faraday::ConnectionFailed
         message = "Unexpected error communicating when trying to connect to " \
-          "Stripe. You may be seeing this message because your DNS is not" \
+          "Stripe. You may be seeing this message because your DNS is not " \
           "working.  To check, try running `host stripe.com` from the " \
           "command line."
 


### PR DESCRIPTION
Add space at the end of the second line so the complete message separates the word `not` and `working`

message before
```
Stripe::APIConnectionError: Unexpected error communicating when trying to connect to Stripe. You may be seeing this message because your DNS is notworking.  To check, try running `host stripe.com` from the command line.
```
message after
```
Stripe::APIConnectionError: Unexpected error communicating when trying to connect to Stripe. You may be seeing this message because your DNS is not working.  To check, try running `host stripe.com` from the command line.
```