### PR TITLE
Revert back to `initialize_from` from `Util.convert_to_stripe_object`

### DIFF
--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -21,7 +21,7 @@ module Stripe
 
     def reject(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/reject", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     save_nested_resource :external_account

--- a/lib/stripe/resources/credit_note.rb
+++ b/lib/stripe/resources/credit_note.rb
@@ -12,7 +12,7 @@ module Stripe
 
     def void_credit_note(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/void", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/dispute.rb
+++ b/lib/stripe/resources/dispute.rb
@@ -11,7 +11,7 @@ module Stripe
 
     def close(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/close", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def close_url

--- a/lib/stripe/resources/invoice.rb
+++ b/lib/stripe/resources/invoice.rb
@@ -17,27 +17,27 @@ module Stripe
 
     def finalize_invoice(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/finalize", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def mark_uncollectible(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/mark_uncollectible", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def pay(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/pay", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def send_invoice(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/send", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def void_invoice(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/void", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def self.upcoming(params, opts = {})

--- a/lib/stripe/resources/issuing/authorization.rb
+++ b/lib/stripe/resources/issuing/authorization.rb
@@ -13,12 +13,12 @@ module Stripe
 
       def approve(params = {}, opts = {})
         resp, opts = request(:post, resource_url + "/approve", params, opts)
-        Util.convert_to_stripe_object(resp.data, opts)
+        initialize_from(resp.data, opts)
       end
 
       def decline(params = {}, opts = {})
         resp, opts = request(:post, resource_url + "/decline", params, opts)
-        Util.convert_to_stripe_object(resp.data, opts)
+        initialize_from(resp.data, opts)
       end
     end
   end

--- a/lib/stripe/resources/issuing/card.rb
+++ b/lib/stripe/resources/issuing/card.rb
@@ -13,7 +13,7 @@ module Stripe
 
       def details(params = {}, opts = {})
         resp, opts = request(:get, resource_url + "/details", params, opts)
-        initialize_from(resp.data, opts)
+        Util.convert_to_stripe_object(resp.data, opts)
       end
     end
   end

--- a/lib/stripe/resources/issuing/card.rb
+++ b/lib/stripe/resources/issuing/card.rb
@@ -13,7 +13,7 @@ module Stripe
 
       def details(params = {}, opts = {})
         resp, opts = request(:get, resource_url + "/details", params, opts)
-        Util.convert_to_stripe_object(resp.data, opts)
+        initialize_from(resp.data, opts)
       end
     end
   end

--- a/lib/stripe/resources/payment_intent.rb
+++ b/lib/stripe/resources/payment_intent.rb
@@ -14,17 +14,17 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def capture(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/capture", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def confirm(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/confirm", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/payment_method.rb
+++ b/lib/stripe/resources/payment_method.rb
@@ -13,12 +13,12 @@ module Stripe
 
     def attach(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/attach", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def detach(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/detach", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/payout.rb
+++ b/lib/stripe/resources/payout.rb
@@ -12,7 +12,7 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def cancel_url

--- a/lib/stripe/resources/review.rb
+++ b/lib/stripe/resources/review.rb
@@ -10,7 +10,7 @@ module Stripe
 
     def approve(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/approve", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/setup_intent.rb
+++ b/lib/stripe/resources/setup_intent.rb
@@ -13,12 +13,12 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def confirm(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/confirm", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/source.rb
+++ b/lib/stripe/resources/source.rb
@@ -11,7 +11,7 @@ module Stripe
 
     def verify(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/verify", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def detach(params = {}, opts = {})

--- a/lib/stripe/resources/subscription_schedule.rb
+++ b/lib/stripe/resources/subscription_schedule.rb
@@ -16,12 +16,12 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def release(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/release", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def revisions(params = {}, opts = {})

--- a/lib/stripe/resources/topup.rb
+++ b/lib/stripe/resources/topup.rb
@@ -12,7 +12,7 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
   end
 end

--- a/lib/stripe/resources/transfer.rb
+++ b/lib/stripe/resources/transfer.rb
@@ -16,7 +16,7 @@ module Stripe
 
     def cancel(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/cancel", params, opts)
-      Util.convert_to_stripe_object(resp.data, opts)
+      initialize_from(resp.data, opts)
     end
 
     def cancel_url


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @brandur-stripe 

In ea736eba1b8f33d8febbf0b1be0957f34f7b04db, on https://github.com/stripe/stripe-ruby/pull/790, we changed most uses of `initialize_from` to be `Util.convert_to_stripe_object`. We believed this to be equivalent, but this was incorrect; as @AnotherJoSmith  [pointed out](https://github.com/stripe/stripe-ruby/pull/790#issuecomment-508257388), this returned new objects without mutating instances in-place (or, more precisely, copying over previous attributes). 

For example, I believe this would have broken flows like this: 
```rb
charge = Stripe::Charge.retrieve id
charge.capture
assert charge.captured == true # broken!
```

I hope to implement a smoother fix to this in a follow-on, but for now, I reverted the offending commit, and tracked down the only new instances of `Util.convert_to_stripe_object` that have happened since (see [this diff](https://github.com/stripe/stripe-ruby/compare/01c5776b06d93f752ab43fbce9827d89bba88fc8..master) and grep `Util.convert_to_stripe_object).

I also hope to add tests shortly, but want to bias to getting this out.