### PR TITLE
Add gem metadata

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -16,6 +16,16 @@ Gem::Specification.new do |s|
   s.homepage = "https://stripe.com/docs/api/ruby"
   s.license = "MIT"
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/stripe/stripe-ruby/issues",
+    "changelog_uri"     =>
+      "https://github.com/stripe/stripe-ruby/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://stripe.com/docs/api/ruby",
+    "github_repo"       => "ssh://github.com/stripe/stripe-ruby",
+    "homepage_uri"      => "https://stripe.com/docs/api/ruby",
+    "source_code_uri"   => "https://github.com/stripe/stripe-ruby",
+  }
+
   s.add_dependency("faraday", "~> 0.13")
   s.add_dependency("net-http-persistent", "~> 3.0")
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

I wanted to test GitHub's new Package Registry feature and publish the latest stripe-ruby gem there. We need to add a custom `github_repo` entry to the metadata, because otherwise GitHub uses the gem's name as the repository's name, which in our case causes it to fail because the gem is called `stripe` and the repository is called `stripe-ruby`.

While I was at it, I also added standard metadata as documented on https://guides.rubygems.org/specification-reference/#metadata.
