### PR TITLE
Better error message when passing non-string to custom method

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -70,6 +70,11 @@ module Stripe
       end
       http_path ||= name.to_s
       define_singleton_method(name) do |id, params = {}, opts = {}|
+        unless id.is_a?(String)
+          raise ArgumentError,
+                "id should be a string representing the ID of an API resource"
+        end
+
         url = "#{resource_url}/#{CGI.escape(id)}/#{CGI.escape(http_path)}"
         resp, opts = request(http_verb, url, params, opts)
         Util.convert_to_stripe_object(resp.data, opts)


### PR DESCRIPTION
Raises a slightly more helpful error message when passing a non-string
to a custom method (currently, it reads "no implicit conversion of Hash
into String", which is terrible).

This a partial remediation for the problem encountered in #809.

r? @ob-stripe