### PR TITLE
Make `CardError`'s `code` parameter named instead of positional

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -59,8 +59,7 @@ module Stripe
   class CardError < StripeError
     attr_reader :param
 
-    # TODO: make code a keyword arg in next major release
-    def initialize(message, param, code, http_status: nil, http_body: nil,
+    def initialize(message, param, code: nil, http_status: nil, http_body: nil,
                    json_body: nil, http_headers: nil)
       super(message, http_status: http_status, http_body: http_body,
                      json_body: json_body, http_headers: http_headers,

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -403,11 +403,8 @@ module Stripe
       when 401
         AuthenticationError.new(error_data[:message], opts)
       when 402
-        # TODO: modify CardError constructor to make code a keyword argument
-        #       so we don't have to delete it from opts
-        opts.delete(:code)
         CardError.new(
-          error_data[:message], error_data[:param], error_data[:code],
+          error_data[:message], error_data[:param],
           opts
         )
       when 403


### PR DESCRIPTION
Makes the `code` parameter on `CardError` named instead of positional.
This makes it more consistent with the rest of the constructor's
parameters and makes instantiating `CardError` from `StripeClient`
cleaner.

This is a minor breaking change so we're aiming to release it for the
next major version of stripe-ruby.

(Found this while looking through TODOs in the code to fix up for V5.)

r? @ob-stripe

---

Note: Targets the branch `integration-v5` in #815 instead of `master`.