### PR TITLE
Drop support for old versions of Ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
 
 Layout/CaseIndentation:
   EnforcedStyle: end
@@ -38,6 +38,9 @@ Style/AccessModifierDeclarations:
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
+
+Style/NumericPredicate:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Layout/ClosingHeredocIndentation:
-  # As far as I can tell, this lint rule just doesn't work when it comes to
-  # heredoc in `it` blocks.
-  Exclude:
-    - 'test/**/*'
-
 # Offense count: 20
 Metrics/AbcSize:
   Max: 53

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
   - 2.6
-  - jruby-9.0.5.0
+  - jruby-9.2.7.0
 
 notifications:
   email:

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -7,7 +7,7 @@ module Stripe
     include Stripe::APIOperations::Request
     include Stripe::APIOperations::Create
 
-    OBJECT_NAME = "list".freeze
+    OBJECT_NAME = "list"
 
     # This accessor allows a `ListObject` to inherit various filters that were
     # given to a predecessor. This allows for things like consistent limits,

--- a/lib/stripe/multipart_encoder.rb
+++ b/lib/stripe/multipart_encoder.rb
@@ -16,7 +16,7 @@ module Stripe
   # placed in the `Content-Type` header of a subsequent request (which includes
   # a boundary value).
   class MultipartEncoder
-    MULTIPART_FORM_DATA = "multipart/form-data".freeze
+    MULTIPART_FORM_DATA = "multipart/form-data"
 
     # A shortcut for encoding a single set of parameters and finalizing a
     # result.
@@ -35,10 +35,9 @@ module Stripe
 
     # Initializes a new multipart encoder.
     def initialize
-      # We seed this with an empty string so that it encoding defaults to UTF-8
-      # instead of ASCII. The empty string is UTF-8 and new string inherits the
-      # encoding of the string it's seeded with.
-      @body = String.new("")
+      # Kind of weird, but required by Rubocop because the unary plus operator
+      # is considered faster than `Stripe.new`.
+      @body = +""
 
       # Chose the same number of random bytes that Go uses in its standard
       # library implementation. Easily enough entropy to ensure that it won't

--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -9,7 +9,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 
-    OBJECT_NAME = "account".freeze
+    OBJECT_NAME = "account"
 
     custom_method :reject, http_verb: :post
 

--- a/lib/stripe/resources/account_link.rb
+++ b/lib/stripe/resources/account_link.rb
@@ -4,6 +4,6 @@ module Stripe
   class AccountLink < APIResource
     extend Stripe::APIOperations::Create
 
-    OBJECT_NAME = "account_link".freeze
+    OBJECT_NAME = "account_link"
   end
 end

--- a/lib/stripe/resources/alipay_account.rb
+++ b/lib/stripe/resources/alipay_account.rb
@@ -5,7 +5,7 @@ module Stripe
     include Stripe::APIOperations::Save
     include Stripe::APIOperations::Delete
 
-    OBJECT_NAME = "alipay_account".freeze
+    OBJECT_NAME = "alipay_account"
 
     def resource_url
       if !respond_to?(:customer) || customer.nil?

--- a/lib/stripe/resources/apple_pay_domain.rb
+++ b/lib/stripe/resources/apple_pay_domain.rb
@@ -7,7 +7,7 @@ module Stripe
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "apple_pay_domain".freeze
+    OBJECT_NAME = "apple_pay_domain"
 
     def self.resource_url
       "/v1/apple_pay/domains"

--- a/lib/stripe/resources/application_fee.rb
+++ b/lib/stripe/resources/application_fee.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     extend Stripe::APIOperations::NestedResource
 
-    OBJECT_NAME = "application_fee".freeze
+    OBJECT_NAME = "application_fee"
 
     nested_resource_class_methods :refund,
                                   operations: %i[create retrieve update list]

--- a/lib/stripe/resources/application_fee_refund.rb
+++ b/lib/stripe/resources/application_fee_refund.rb
@@ -5,7 +5,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "fee_refund".freeze
+    OBJECT_NAME = "fee_refund"
 
     def resource_url
       "#{ApplicationFee.resource_url}/#{CGI.escape(fee)}/refunds" \

--- a/lib/stripe/resources/balance.rb
+++ b/lib/stripe/resources/balance.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class Balance < SingletonAPIResource
-    OBJECT_NAME = "balance".freeze
+    OBJECT_NAME = "balance"
   end
 end

--- a/lib/stripe/resources/balance_transaction.rb
+++ b/lib/stripe/resources/balance_transaction.rb
@@ -4,7 +4,7 @@ module Stripe
   class BalanceTransaction < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "balance_transaction".freeze
+    OBJECT_NAME = "balance_transaction"
 
     def self.resource_url
       "/v1/balance/history"

--- a/lib/stripe/resources/bank_account.rb
+++ b/lib/stripe/resources/bank_account.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "bank_account".freeze
+    OBJECT_NAME = "bank_account"
 
     def verify(params = {}, opts = {})
       resp, opts = request(:post, resource_url + "/verify", params, opts)

--- a/lib/stripe/resources/bitcoin_receiver.rb
+++ b/lib/stripe/resources/bitcoin_receiver.rb
@@ -6,7 +6,7 @@ module Stripe
   class BitcoinReceiver < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "bitcoin_receiver".freeze
+    OBJECT_NAME = "bitcoin_receiver"
 
     def self.resource_url
       "/v1/bitcoin/receivers"

--- a/lib/stripe/resources/bitcoin_transaction.rb
+++ b/lib/stripe/resources/bitcoin_transaction.rb
@@ -6,7 +6,7 @@ module Stripe
     # Sources API instead: https://stripe.com/docs/sources/bitcoin
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "bitcoin_transaction".freeze
+    OBJECT_NAME = "bitcoin_transaction"
 
     def self.resource_url
       "/v1/bitcoin/transactions"

--- a/lib/stripe/resources/capability.rb
+++ b/lib/stripe/resources/capability.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "capability".freeze
+    OBJECT_NAME = "capability"
 
     def resource_url
       if !respond_to?(:account) || account.nil?

--- a/lib/stripe/resources/card.rb
+++ b/lib/stripe/resources/card.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "card".freeze
+    OBJECT_NAME = "card"
 
     def resource_url
       if respond_to?(:recipient) && !recipient.nil? && !recipient.empty?

--- a/lib/stripe/resources/charge.rb
+++ b/lib/stripe/resources/charge.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "charge".freeze
+    OBJECT_NAME = "charge"
 
     custom_method :capture, http_verb: :post
 

--- a/lib/stripe/resources/checkout/session.rb
+++ b/lib/stripe/resources/checkout/session.rb
@@ -5,7 +5,7 @@ module Stripe
     class Session < APIResource
       extend Stripe::APIOperations::Create
 
-      OBJECT_NAME = "checkout.session".freeze
+      OBJECT_NAME = "checkout.session"
     end
   end
 end

--- a/lib/stripe/resources/country_spec.rb
+++ b/lib/stripe/resources/country_spec.rb
@@ -4,6 +4,6 @@ module Stripe
   class CountrySpec < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "country_spec".freeze
+    OBJECT_NAME = "country_spec"
   end
 end

--- a/lib/stripe/resources/coupon.rb
+++ b/lib/stripe/resources/coupon.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "coupon".freeze
+    OBJECT_NAME = "coupon"
   end
 end

--- a/lib/stripe/resources/credit_note.rb
+++ b/lib/stripe/resources/credit_note.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "credit_note".freeze
+    OBJECT_NAME = "credit_note"
 
     custom_method :void_credit_note, http_verb: :post, http_path: "void"
 

--- a/lib/stripe/resources/customer.rb
+++ b/lib/stripe/resources/customer.rb
@@ -8,7 +8,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 
-    OBJECT_NAME = "customer".freeze
+    OBJECT_NAME = "customer"
 
     nested_resource_class_methods :balance_transaction,
                                   operations: %i[create retrieve update list]

--- a/lib/stripe/resources/customer_balance_transaction.rb
+++ b/lib/stripe/resources/customer_balance_transaction.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "customer_balance_transaction".freeze
+    OBJECT_NAME = "customer_balance_transaction"
 
     def resource_url
       if !respond_to?(:customer) || customer.nil?

--- a/lib/stripe/resources/discount.rb
+++ b/lib/stripe/resources/discount.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class Discount < StripeObject
-    OBJECT_NAME = "discount".freeze
+    OBJECT_NAME = "discount"
   end
 end

--- a/lib/stripe/resources/dispute.rb
+++ b/lib/stripe/resources/dispute.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "dispute".freeze
+    OBJECT_NAME = "dispute"
 
     custom_method :close, http_verb: :post
 

--- a/lib/stripe/resources/ephemeral_key.rb
+++ b/lib/stripe/resources/ephemeral_key.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
 
-    OBJECT_NAME = "ephemeral_key".freeze
+    OBJECT_NAME = "ephemeral_key"
 
     def self.create(params = {}, opts = {})
       opts = Util.normalize_opts(opts)

--- a/lib/stripe/resources/event.rb
+++ b/lib/stripe/resources/event.rb
@@ -4,6 +4,6 @@ module Stripe
   class Event < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "event".freeze
+    OBJECT_NAME = "event"
   end
 end

--- a/lib/stripe/resources/exchange_rate.rb
+++ b/lib/stripe/resources/exchange_rate.rb
@@ -4,6 +4,6 @@ module Stripe
   class ExchangeRate < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "exchange_rate".freeze
+    OBJECT_NAME = "exchange_rate"
   end
 end

--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -5,13 +5,13 @@ module Stripe
     extend Stripe::APIOperations::Create
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "file".freeze
+    OBJECT_NAME = "file"
 
     # This resource can have two different object names. In latter API
     # versions, only `file` is used, but since stripe-ruby may be used with
     # any API version, we need to support deserializing the older
     # `file_upload` object into the same class.
-    OBJECT_NAME_ALT = "file_upload".freeze
+    OBJECT_NAME_ALT = "file_upload"
 
     def self.resource_url
       "/v1/files"

--- a/lib/stripe/resources/file_link.rb
+++ b/lib/stripe/resources/file_link.rb
@@ -6,6 +6,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "file_link".freeze
+    OBJECT_NAME = "file_link"
   end
 end

--- a/lib/stripe/resources/invoice.rb
+++ b/lib/stripe/resources/invoice.rb
@@ -7,7 +7,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "invoice".freeze
+    OBJECT_NAME = "invoice"
 
     custom_method :finalize_invoice, http_verb: :post, http_path: "finalize"
     custom_method :mark_uncollectible, http_verb: :post

--- a/lib/stripe/resources/invoice_item.rb
+++ b/lib/stripe/resources/invoice_item.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "invoiceitem".freeze
+    OBJECT_NAME = "invoiceitem"
   end
 end

--- a/lib/stripe/resources/invoice_line_item.rb
+++ b/lib/stripe/resources/invoice_line_item.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class InvoiceLineItem < StripeObject
-    OBJECT_NAME = "line_item".freeze
+    OBJECT_NAME = "line_item"
   end
 end

--- a/lib/stripe/resources/issuer_fraud_record.rb
+++ b/lib/stripe/resources/issuer_fraud_record.rb
@@ -4,6 +4,6 @@ module Stripe
   class IssuerFraudRecord < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "issuer_fraud_record".freeze
+    OBJECT_NAME = "issuer_fraud_record"
   end
 end

--- a/lib/stripe/resources/issuing/authorization.rb
+++ b/lib/stripe/resources/issuing/authorization.rb
@@ -6,7 +6,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "issuing.authorization".freeze
+      OBJECT_NAME = "issuing.authorization"
 
       custom_method :approve, http_verb: :post
       custom_method :decline, http_verb: :post

--- a/lib/stripe/resources/issuing/card.rb
+++ b/lib/stripe/resources/issuing/card.rb
@@ -7,7 +7,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "issuing.card".freeze
+      OBJECT_NAME = "issuing.card"
 
       custom_method :details, http_verb: :get
 

--- a/lib/stripe/resources/issuing/card_details.rb
+++ b/lib/stripe/resources/issuing/card_details.rb
@@ -3,7 +3,7 @@
 module Stripe
   module Issuing
     class CardDetails < Stripe::StripeObject
-      OBJECT_NAME = "issuing.card_details".freeze
+      OBJECT_NAME = "issuing.card_details"
     end
   end
 end

--- a/lib/stripe/resources/issuing/cardholder.rb
+++ b/lib/stripe/resources/issuing/cardholder.rb
@@ -7,7 +7,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "issuing.cardholder".freeze
+      OBJECT_NAME = "issuing.cardholder"
     end
   end
 end

--- a/lib/stripe/resources/issuing/dispute.rb
+++ b/lib/stripe/resources/issuing/dispute.rb
@@ -7,7 +7,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "issuing.dispute".freeze
+      OBJECT_NAME = "issuing.dispute"
     end
   end
 end

--- a/lib/stripe/resources/issuing/transaction.rb
+++ b/lib/stripe/resources/issuing/transaction.rb
@@ -6,7 +6,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "issuing.transaction".freeze
+      OBJECT_NAME = "issuing.transaction"
     end
   end
 end

--- a/lib/stripe/resources/login_link.rb
+++ b/lib/stripe/resources/login_link.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   class LoginLink < APIResource
-    OBJECT_NAME = "login_link".freeze
+    OBJECT_NAME = "login_link"
 
     def self.retrieve(_id, _opts = nil)
       raise NotImplementedError,

--- a/lib/stripe/resources/order.rb
+++ b/lib/stripe/resources/order.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "order".freeze
+    OBJECT_NAME = "order"
 
     custom_method :pay, http_verb: :post
     custom_method :return_order, http_verb: :post, http_path: "returns"

--- a/lib/stripe/resources/order_return.rb
+++ b/lib/stripe/resources/order_return.rb
@@ -4,6 +4,6 @@ module Stripe
   class OrderReturn < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "order_return".freeze
+    OBJECT_NAME = "order_return"
   end
 end

--- a/lib/stripe/resources/payment_intent.rb
+++ b/lib/stripe/resources/payment_intent.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "payment_intent".freeze
+    OBJECT_NAME = "payment_intent"
 
     custom_method :cancel, http_verb: :post
     custom_method :capture, http_verb: :post

--- a/lib/stripe/resources/payment_method.rb
+++ b/lib/stripe/resources/payment_method.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "payment_method".freeze
+    OBJECT_NAME = "payment_method"
 
     custom_method :attach, http_verb: :post
     custom_method :detach, http_verb: :post

--- a/lib/stripe/resources/payout.rb
+++ b/lib/stripe/resources/payout.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "payout".freeze
+    OBJECT_NAME = "payout"
 
     custom_method :cancel, http_verb: :post
 

--- a/lib/stripe/resources/person.rb
+++ b/lib/stripe/resources/person.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "person".freeze
+    OBJECT_NAME = "person"
 
     def resource_url
       if !respond_to?(:account) || account.nil?

--- a/lib/stripe/resources/plan.rb
+++ b/lib/stripe/resources/plan.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "plan".freeze
+    OBJECT_NAME = "plan"
   end
 end

--- a/lib/stripe/resources/product.rb
+++ b/lib/stripe/resources/product.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "product".freeze
+    OBJECT_NAME = "product"
   end
 end

--- a/lib/stripe/resources/radar/early_fraud_warning.rb
+++ b/lib/stripe/resources/radar/early_fraud_warning.rb
@@ -5,7 +5,7 @@ module Stripe
     class EarlyFraudWarning < APIResource
       extend Stripe::APIOperations::List
 
-      OBJECT_NAME = "radar.early_fraud_warning".freeze
+      OBJECT_NAME = "radar.early_fraud_warning"
     end
   end
 end

--- a/lib/stripe/resources/radar/value_list.rb
+++ b/lib/stripe/resources/radar/value_list.rb
@@ -8,7 +8,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "radar.value_list".freeze
+      OBJECT_NAME = "radar.value_list"
     end
   end
 end

--- a/lib/stripe/resources/radar/value_list_item.rb
+++ b/lib/stripe/resources/radar/value_list_item.rb
@@ -7,7 +7,7 @@ module Stripe
       include Stripe::APIOperations::Delete
       extend Stripe::APIOperations::List
 
-      OBJECT_NAME = "radar.value_list_item".freeze
+      OBJECT_NAME = "radar.value_list_item"
     end
   end
 end

--- a/lib/stripe/resources/recipient.rb
+++ b/lib/stripe/resources/recipient.rb
@@ -8,7 +8,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "recipient".freeze
+    OBJECT_NAME = "recipient"
 
     def transfers
       Transfer.all({ recipient: id }, @api_key)

--- a/lib/stripe/resources/recipient_transfer.rb
+++ b/lib/stripe/resources/recipient_transfer.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class RecipientTransfer < StripeObject
-    OBJECT_NAME = "recipient_transfer".freeze
+    OBJECT_NAME = "recipient_transfer"
   end
 end

--- a/lib/stripe/resources/refund.rb
+++ b/lib/stripe/resources/refund.rb
@@ -6,6 +6,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "refund".freeze
+    OBJECT_NAME = "refund"
   end
 end

--- a/lib/stripe/resources/reporting/report_run.rb
+++ b/lib/stripe/resources/reporting/report_run.rb
@@ -6,7 +6,7 @@ module Stripe
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
 
-      OBJECT_NAME = "reporting.report_run".freeze
+      OBJECT_NAME = "reporting.report_run"
     end
   end
 end

--- a/lib/stripe/resources/reporting/report_type.rb
+++ b/lib/stripe/resources/reporting/report_type.rb
@@ -6,7 +6,7 @@ module Stripe
       extend Stripe::APIOperations::Create
       extend Stripe::APIOperations::List
 
-      OBJECT_NAME = "reporting.report_type".freeze
+      OBJECT_NAME = "reporting.report_type"
     end
   end
 end

--- a/lib/stripe/resources/reversal.rb
+++ b/lib/stripe/resources/reversal.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "transfer_reversal".freeze
+    OBJECT_NAME = "transfer_reversal"
 
     def resource_url
       "#{Transfer.resource_url}/#{CGI.escape(transfer)}/reversals" \

--- a/lib/stripe/resources/review.rb
+++ b/lib/stripe/resources/review.rb
@@ -4,7 +4,7 @@ module Stripe
   class Review < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "review".freeze
+    OBJECT_NAME = "review"
 
     custom_method :approve, http_verb: :post
 

--- a/lib/stripe/resources/setup_intent.rb
+++ b/lib/stripe/resources/setup_intent.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "setup_intent".freeze
+    OBJECT_NAME = "setup_intent"
 
     custom_method :cancel, http_verb: :post
     custom_method :confirm, http_verb: :post

--- a/lib/stripe/resources/sigma/scheduled_query_run.rb
+++ b/lib/stripe/resources/sigma/scheduled_query_run.rb
@@ -5,7 +5,7 @@ module Stripe
     class ScheduledQueryRun < APIResource
       extend Stripe::APIOperations::List
 
-      OBJECT_NAME = "scheduled_query_run".freeze
+      OBJECT_NAME = "scheduled_query_run"
 
       def self.resource_url
         "/v1/sigma/scheduled_query_runs"

--- a/lib/stripe/resources/sku.rb
+++ b/lib/stripe/resources/sku.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "sku".freeze
+    OBJECT_NAME = "sku"
   end
 end

--- a/lib/stripe/resources/source.rb
+++ b/lib/stripe/resources/source.rb
@@ -5,7 +5,7 @@ module Stripe
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "source".freeze
+    OBJECT_NAME = "source"
 
     custom_method :verify, http_verb: :post
 

--- a/lib/stripe/resources/source_transaction.rb
+++ b/lib/stripe/resources/source_transaction.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class SourceTransaction < StripeObject
-    OBJECT_NAME = "source_transaction".freeze
+    OBJECT_NAME = "source_transaction"
   end
 end

--- a/lib/stripe/resources/subscription.rb
+++ b/lib/stripe/resources/subscription.rb
@@ -7,7 +7,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "subscription".freeze
+    OBJECT_NAME = "subscription"
 
     custom_method :delete_discount, http_verb: :delete, http_path: "discount"
 

--- a/lib/stripe/resources/subscription_item.rb
+++ b/lib/stripe/resources/subscription_item.rb
@@ -7,7 +7,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "subscription_item".freeze
+    OBJECT_NAME = "subscription_item"
 
     def usage_record_summaries(params = {}, opts = {})
       resp, opts = request(:get, resource_url + "/usage_record_summaries", params, opts)

--- a/lib/stripe/resources/subscription_schedule.rb
+++ b/lib/stripe/resources/subscription_schedule.rb
@@ -7,7 +7,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 
-    OBJECT_NAME = "subscription_schedule".freeze
+    OBJECT_NAME = "subscription_schedule"
 
     custom_method :cancel, http_verb: :post
     custom_method :release, http_verb: :post

--- a/lib/stripe/resources/subscription_schedule_revision.rb
+++ b/lib/stripe/resources/subscription_schedule_revision.rb
@@ -4,7 +4,7 @@ module Stripe
   class SubscriptionScheduleRevision < APIResource
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "subscription_schedule_revision".freeze
+    OBJECT_NAME = "subscription_schedule_revision"
 
     def resource_url
       if !respond_to?(:schedule) || schedule.nil?

--- a/lib/stripe/resources/tax_id.rb
+++ b/lib/stripe/resources/tax_id.rb
@@ -5,7 +5,7 @@ module Stripe
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
 
-    OBJECT_NAME = "tax_id".freeze
+    OBJECT_NAME = "tax_id"
 
     def resource_url
       if !respond_to?(:customer) || customer.nil?

--- a/lib/stripe/resources/tax_rate.rb
+++ b/lib/stripe/resources/tax_rate.rb
@@ -6,6 +6,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "tax_rate".freeze
+    OBJECT_NAME = "tax_rate"
   end
 end

--- a/lib/stripe/resources/terminal/connection_token.rb
+++ b/lib/stripe/resources/terminal/connection_token.rb
@@ -5,7 +5,7 @@ module Stripe
     class ConnectionToken < APIResource
       extend Stripe::APIOperations::Create
 
-      OBJECT_NAME = "terminal.connection_token".freeze
+      OBJECT_NAME = "terminal.connection_token"
     end
   end
 end

--- a/lib/stripe/resources/terminal/location.rb
+++ b/lib/stripe/resources/terminal/location.rb
@@ -8,7 +8,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "terminal.location".freeze
+      OBJECT_NAME = "terminal.location"
     end
   end
 end

--- a/lib/stripe/resources/terminal/reader.rb
+++ b/lib/stripe/resources/terminal/reader.rb
@@ -8,7 +8,7 @@ module Stripe
       extend Stripe::APIOperations::List
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "terminal.reader".freeze
+      OBJECT_NAME = "terminal.reader"
     end
   end
 end

--- a/lib/stripe/resources/three_d_secure.rb
+++ b/lib/stripe/resources/three_d_secure.rb
@@ -4,7 +4,7 @@ module Stripe
   class ThreeDSecure < APIResource
     extend Stripe::APIOperations::Create
 
-    OBJECT_NAME = "three_d_secure".freeze
+    OBJECT_NAME = "three_d_secure"
 
     def self.resource_url
       "/v1/3d_secure"

--- a/lib/stripe/resources/token.rb
+++ b/lib/stripe/resources/token.rb
@@ -4,6 +4,6 @@ module Stripe
   class Token < APIResource
     extend Stripe::APIOperations::Create
 
-    OBJECT_NAME = "token".freeze
+    OBJECT_NAME = "token"
   end
 end

--- a/lib/stripe/resources/topup.rb
+++ b/lib/stripe/resources/topup.rb
@@ -6,7 +6,7 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "topup".freeze
+    OBJECT_NAME = "topup"
 
     custom_method :cancel, http_verb: :post
 

--- a/lib/stripe/resources/transfer.rb
+++ b/lib/stripe/resources/transfer.rb
@@ -7,7 +7,7 @@ module Stripe
     include Stripe::APIOperations::Save
     extend Stripe::APIOperations::NestedResource
 
-    OBJECT_NAME = "transfer".freeze
+    OBJECT_NAME = "transfer"
 
     custom_method :cancel, http_verb: :post
 

--- a/lib/stripe/resources/usage_record.rb
+++ b/lib/stripe/resources/usage_record.rb
@@ -2,7 +2,7 @@
 
 module Stripe
   class UsageRecord < APIResource
-    OBJECT_NAME = "usage_record".freeze
+    OBJECT_NAME = "usage_record"
 
     def self.create(params = {}, opts = {})
       unless params.key?(:subscription_item)

--- a/lib/stripe/resources/usage_record_summary.rb
+++ b/lib/stripe/resources/usage_record_summary.rb
@@ -2,6 +2,6 @@
 
 module Stripe
   class UsageRecordSummary < StripeObject
-    OBJECT_NAME = "usage_record_summary".freeze
+    OBJECT_NAME = "usage_record_summary"
   end
 end

--- a/lib/stripe/resources/webhook_endpoint.rb
+++ b/lib/stripe/resources/webhook_endpoint.rb
@@ -7,6 +7,6 @@ module Stripe
     extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
-    OBJECT_NAME = "webhook_endpoint".freeze
+    OBJECT_NAME = "webhook_endpoint"
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -185,19 +185,19 @@ module Stripe
       "Unexpected error communicating when trying to connect to " \
         "Stripe (%s). You may be seeing this message because your DNS is not " \
         "working or you don't have an internet connection.  To check, try " \
-        "running `host stripe.com` from the command line.".freeze
+        "running `host stripe.com` from the command line."
     ERROR_MESSAGE_SSL =
       "Could not establish a secure connection to Stripe (%s), you " \
         "may need to upgrade your OpenSSL version. To check, try running " \
         "`openssl s_client -connect api.stripe.com:443` from the command " \
-        "line.".freeze
+        "line."
 
     # Common error suffix sared by both connect and read timeout messages.
     ERROR_MESSAGE_TIMEOUT_SUFFIX =
       "Please check your internet connection and try again. " \
         "If this problem persists, you should check Stripe's service " \
         "status at https://status.stripe.com, or let us know at " \
-        "support@stripe.com.".freeze
+        "support@stripe.com."
 
     ERROR_MESSAGE_TIMEOUT_CONNECT = (
       "Timed out connecting to Stripe (%s). " +

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -192,7 +192,8 @@ module Stripe
 
     def to_hash
       maybe_to_hash = lambda do |value|
-        value && value.respond_to?(:to_hash) ? value.to_hash : value
+        return nil if value.nil?
+        value.respond_to?(:to_hash) ? value.to_hash : value
       end
 
       @values.each_with_object({}) do |(key, value), acc|

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -277,10 +277,7 @@ module Stripe
     end
     private_class_method :level_name
 
-    # TODO: Make these named required arguments when we drop support for Ruby
-    # 2.0.
-    def self.log_internal(message, data = {}, color: nil, level: nil,
-                          logger: nil, out: nil)
+    def self.log_internal(message, data = {}, color:, level:, logger:, out:)
       data_str = data.reject { |_k, v| v.nil? }
                      .map do |(k, v)|
         format("%<key>s=%<value>s",

--- a/lib/stripe/version.rb
+++ b/lib/stripe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stripe
-  VERSION = "4.21.3".freeze
+  VERSION = "4.21.3"
 end

--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -22,7 +22,7 @@ module Stripe
     end
 
     module Signature
-      EXPECTED_SCHEME = "v1".freeze
+      EXPECTED_SCHEME = "v1"
 
       def self.compute_signature(payload, secret)
         OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret, payload)

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -7,7 +7,7 @@ require "stripe/version"
 Gem::Specification.new do |s|
   s.name = "stripe"
   s.version = Stripe::VERSION
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.3.0"
   s.summary = "Ruby bindings for the Stripe API"
   s.description = "Stripe is the easiest way to accept payments online.  " \
                   "See https://stripe.com for details."

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -7,7 +7,7 @@ module Stripe
     class UpdateableResource < APIResource
       include Stripe::APIOperations::Save
 
-      OBJECT_NAME = "updateableresource".freeze
+      OBJECT_NAME = "updateableresource"
 
       def self.protected_fields
         [:protected]
@@ -34,7 +34,7 @@ module Stripe
     context ".nested_resource_class_methods" do
       class MainResource < APIResource
         extend Stripe::APIOperations::NestedResource
-        OBJECT_NAME = "mainresource".freeze
+        OBJECT_NAME = "mainresource"
         nested_resource_class_methods :nested,
                                       operations: %i[create retrieve update delete list]
       end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApiResourceTest < Test::Unit::TestCase
     class CustomMethodAPIResource < APIResource
-      OBJECT_NAME = "custom_method".freeze
+      OBJECT_NAME = "custom_method"
       custom_method :my_method, http_verb: :post
     end
 

--- a/test/stripe/multipart_encoder_test.rb
+++ b/test/stripe/multipart_encoder_test.rb
@@ -18,17 +18,17 @@ module Stripe
         encoder.close
         body = encoder.body
 
-        assert_equal <<-BODY.rstrip, body
---#{encoder.boundary}\r
-Content-Disposition: form-data; name="file"; filename="#{::File.basename(f.path)}"\r
-Content-Type: application/octet-stream\r
-\r
-file-content\r
---#{encoder.boundary}\r
-Content-Disposition: form-data; name="other_param"\r
-\r
-other-param-content\r
---#{encoder.boundary}--
+        assert_equal <<~BODY.rstrip, body
+          --#{encoder.boundary}\r
+          Content-Disposition: form-data; name="file"; filename="#{::File.basename(f.path)}"\r
+          Content-Type: application/octet-stream\r
+          \r
+          file-content\r
+          --#{encoder.boundary}\r
+          Content-Disposition: form-data; name="other_param"\r
+          \r
+          other-param-content\r
+          --#{encoder.boundary}--
         BODY
       end
     end
@@ -47,13 +47,13 @@ other-param-content\r
       encoder.close
       body = encoder.body
 
-      assert_equal <<-BODY.rstrip, body
---#{encoder.boundary}\r
-Content-Disposition: form-data; name="file_like"; filename="blob"\r
-Content-Type: application/octet-stream\r
-\r
-klass-read-content\r
---#{encoder.boundary}--
+      assert_equal <<~BODY.rstrip, body
+        --#{encoder.boundary}\r
+        Content-Disposition: form-data; name="file_like"; filename="blob"\r
+        Content-Type: application/octet-stream\r
+        \r
+        klass-read-content\r
+        --#{encoder.boundary}--
       BODY
     end
 
@@ -65,12 +65,12 @@ klass-read-content\r
       encoder.close
       body = encoder.body
 
-      assert_equal <<-BODY.rstrip, body
---#{encoder.boundary}\r
-Content-Disposition: form-data; name="%22quoted  %22"\r
-\r
-content\r
---#{encoder.boundary}--
+      assert_equal <<~BODY.rstrip, body
+        --#{encoder.boundary}\r
+        Content-Disposition: form-data; name="%22quoted  %22"\r
+        \r
+        content\r
+        --#{encoder.boundary}--
       BODY
     end
 

--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -4,7 +4,7 @@ require ::File.expand_path("../test_helper", __dir__)
 
 module Stripe
   class PaymentIntentTest < Test::Unit::TestCase
-    TEST_RESOURCE_ID = "pi_123".freeze
+    TEST_RESOURCE_ID = "pi_123"
 
     should "be listable" do
       payment_intents = Stripe::PaymentIntent.list

--- a/test/stripe/setup_intent_test.rb
+++ b/test/stripe/setup_intent_test.rb
@@ -4,7 +4,7 @@ require ::File.expand_path("../test_helper", __dir__)
 
 module Stripe
   class SetupIntentTest < Test::Unit::TestCase
-    TEST_RESOURCE_ID = "seti_123".freeze
+    TEST_RESOURCE_ID = "seti_123"
 
     should "be listable" do
       setup_intents = Stripe::SetupIntent.list

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -52,9 +52,9 @@ module Stripe
             2,
           ],
           map: {
-            :"0" => StripeObject.construct_from({ id: "index0" }, opts),
-            :"1" => "index1",
-            :"2" => 2,
+            "0": StripeObject.construct_from({ id: "index0" }, opts),
+            "1": "index1",
+            "2": 2,
           },
         }
 

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -4,13 +4,13 @@ require ::File.expand_path("../test_helper", __dir__)
 
 module Stripe
   class WebhookTest < Test::Unit::TestCase
-    EVENT_PAYLOAD = <<-PAYLOAD.freeze
+    EVENT_PAYLOAD = <<~PAYLOAD
       {
         "id": "evt_test_webhook",
         "object": "event"
       }
     PAYLOAD
-    SECRET = "whsec_test_secret".freeze
+    SECRET = "whsec_test_secret"
 
     def generate_header(opts = {})
       opts[:timestamp] ||= Time.now.to_i

--- a/test/stripe_mock.rb
+++ b/test/stripe_mock.rb
@@ -4,8 +4,8 @@ module Stripe
   class StripeMock
     include Singleton
 
-    PATH_SPEC = "#{::File.dirname(__FILE__)}/openapi/spec3.json".freeze
-    PATH_FIXTURES = "#{::File.dirname(__FILE__)}/openapi/fixtures3.json".freeze
+    PATH_SPEC = "#{::File.dirname(__FILE__)}/openapi/spec3.json"
+    PATH_FIXTURES = "#{::File.dirname(__FILE__)}/openapi/fixtures3.json"
 
     @pid = nil
     @port = -1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require ::File.expand_path("test_data", __dir__)
 require ::File.expand_path("stripe_mock", __dir__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.60.0".freeze
+MOCK_MINIMUM_VERSION = "0.60.0"
 MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
Drops support for Ruby 2.1 (EOL March 31, 2017) and 2.2 (EOL March 31,
2018). They're removed from `.travis.yml` and the gemspec and RuboCop
configuration have also been updated to the new lower bound.

Most of the diff here are minor updates to styling as required by
RuboCop:

* String literals are frozen by default, so the `.freeze` we had
  everywhere is now considered redundant.

* We can now use Ruby 1.9 style hash syntax with string keys like `{
  "foo": "bar" }`.

* Converted a few heredocs over to use squiggly (leading whitespace
  removed) syntax.

As discussed in Slack, I didn't drop support for Ruby 2.3 (EOL March 31,
2019) as we still have quite a few users on it. As far as I know
dropping it doesn't get us access to any major syntax improvements or
anything, so it's probably not a big deal.

r? @ob-stripe
cc @stripe/api-libraries

---
Note: Targets the branch `integration-v5` in #815 instead of `master`.