### PR TITLE
Ruby minimum version increase followup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ cache:
     - stripe-mock
 
 before_install:
-  # Install bundler 1.x, because we need to support Ruby 2.1 for now
-  - gem install bundler -v "~> 1.0"
   # Unpack and start stripe-mock so that the test suite can talk to it
   - |
     if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 group :development do
   gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
+  gem "rack", ">= 2.0.6"
   gem "rake"
   gem "shoulda-context"
   gem "test-unit"
@@ -21,15 +22,6 @@ group :development do
   # Note that 0.57.2 is the most recent version we can use until we drop
   # support for Ruby 2.1.
   gem "rubocop", "0.57.2"
-
-  # Rack 2.0+ requires Ruby >= 2.2.2 which is problematic for the test suite on
-  # older Ruby versions. Check Ruby the version here and put a maximum
-  # constraint on Rack if necessary.
-  if RUBY_VERSION >= "2.2.2"
-    gem "rack", ">= 2.0.6"
-  else
-    gem "rack", ">= 1.6.11", "< 2.0" # rubocop:disable Bundler/DuplicatedGem
-  end
 
   platforms :mri do
     gem "byebug"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gem build stripe.gemspec
 
 ### Requirements
 
-- Ruby 2.1+.
+- Ruby 2.3+.
 
 ### Bundler
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

Clean up a few things that are no longer needed after #817.
