### PR TITLE
Remove all alias for list methods

### DIFF
--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -19,12 +19,6 @@ module Stripe
 
         obj
       end
-
-      # The original version of #list was given the somewhat unfortunate name of
-      # #all, and this alias allows us to maintain backward compatibility (the
-      # choice was somewhat misleading in the way that it only returned a single
-      # page rather than all objects).
-      alias all list
     end
   end
 end

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -132,22 +132,6 @@ module Stripe
       next_list = list.previous_page
       assert_equal({ expand: ["data.source"], limit: 3 }, next_list.filters)
     end
-
-    #
-    # backward compatibility
-    #
-
-    # note that the name #all is deprecated, as is using it fetch the next page
-    # in a list
-    should "be able to retrieve full lists given a listobject" do
-      c = Stripe::Charge.all
-      assert c.is_a?(Stripe::ListObject)
-      assert_equal("/v1/charges", c.resource_url)
-      all = c.all
-      assert all.is_a?(Stripe::ListObject)
-      assert_equal("/v1/charges", all.resource_url)
-      assert all.data.is_a?(Array)
-    end
   end
 end
 


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Remove `all` alias for `list` methods.
