### PR TITLE
Tweak retry logic to be a little more like stripe-node

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,16 +19,20 @@ Layout/IndentFirstHashElement:
 Layout/IndentHeredoc:
   Enabled: false
 
-Metrics/LineLength:
+Metrics/ClassLength:
   Exclude:
     - "test/**/*.rb"
+
+Metrics/LineLength:
+  Exclude:
     - "lib/stripe/resources/**/*.rb"
+    - "test/**/*.rb"
 
 Metrics/MethodLength:
   # There's ~2 long methods in `StripeClient`. If we want to truncate those a
   # little, we could move this to be closer to ~30 (but the default of 10 is
   # probably too short).
-  Max: 50
+  Max: 55
 
 Metrics/ModuleLength:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 23
 Metrics/AbcSize:
-  Max: 48
+  Max: 51
 
 # Offense count: 33
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -54,31 +54,43 @@ module Stripe
       end
 
       should "retry on Errno::ECONNREFUSED" do
-        assert StripeClient.should_retry?(Errno::ECONNREFUSED.new, 0)
+        assert StripeClient.should_retry?(Errno::ECONNREFUSED.new,
+                                          method: :post, num_retries: 0)
       end
 
       should "retry on Net::OpenTimeout" do
-        assert StripeClient.should_retry?(Net::OpenTimeout.new, 0)
+        assert StripeClient.should_retry?(Net::OpenTimeout.new,
+                                          method: :post, num_retries: 0)
       end
 
       should "retry on Net::ReadTimeout" do
-        assert StripeClient.should_retry?(Net::ReadTimeout.new, 0)
+        assert StripeClient.should_retry?(Net::ReadTimeout.new,
+                                          method: :post, num_retries: 0)
       end
 
       should "retry on SocketError" do
-        assert StripeClient.should_retry?(SocketError.new, 0)
+        assert StripeClient.should_retry?(SocketError.new,
+                                          method: :post, num_retries: 0)
       end
 
-      should "retry on a conflict" do
-        assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 409), 0)
+      should "retry on a 409 Conflict" do
+        assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 409),
+                                          method: :post, num_retries: 0)
+      end
+
+      should "retry on a 503 Service Unavailable" do
+        assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 503),
+                                          method: :post, num_retries: 0)
       end
 
       should "not retry at maximum count" do
-        refute StripeClient.should_retry?(RuntimeError.new, Stripe.max_network_retries)
+        refute StripeClient.should_retry?(RuntimeError.new,
+                                          method: :post, num_retries: Stripe.max_network_retries)
       end
 
       should "not retry on a certificate validation error" do
-        refute StripeClient.should_retry?(OpenSSL::SSL::SSLError.new, 0)
+        refute StripeClient.should_retry?(OpenSSL::SSL::SSLError.new,
+                                          method: :post, num_retries: 0)
       end
     end
 


### PR DESCRIPTION
Tweaks the retry logic to be a little more like stripe-node's. In
particular, we also retry under these conditions:

* If we receive a 500 on a non-`POST` request.
* If we receive a 503.

I made it slightly different from stripe-node which checks for a 500
with `>= 500`. I don't really like that -- if we want to retry specific
status codes we should be explicit about it.

We're actively re-examining ways on how to make it easier for clients to
figure out when to retry right now, but I figure V5 is a good time to
tweak this because the modifications change the method signature of
`should_retry?` slightly, and it's technically a public method.

r? @ob-stripe
cc @stripe/api-libraries

---

Note: targets the V5 integration branch in #815.