### PR TITLE
Reset connections when connection-changing configuration changes

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -73,9 +73,20 @@ module Stripe
   @enable_telemetry = true
 
   class << self
-    attr_accessor :stripe_account, :api_key, :api_base, :verify_ssl_certs,
-                  :api_version, :client_id, :connect_base, :uploads_base,
-                  :open_timeout, :read_timeout, :proxy
+    attr_accessor :api_key
+    attr_accessor :api_version
+    attr_accessor :client_id
+    attr_accessor :stripe_account
+
+    # These all get manual attribute writers so that we can reset connections
+    # if they change.
+    attr_reader :api_base
+    attr_reader :connect_base
+    attr_reader :open_timeout
+    attr_reader :proxy
+    attr_reader :read_timeout
+    attr_reader :uploads_base
+    attr_reader :verify_ssl_certs
 
     attr_reader :max_network_retry_delay, :initial_network_retry_delay
   end
@@ -90,6 +101,11 @@ module Stripe
     @app_info = info
   end
 
+  def self.api_base=(api_base)
+    @api_base = api_base
+    StripeClient.clear_all_connection_managers
+  end
+
   # The location of a file containing a bundle of CA certificates. By default
   # the library will use an included bundle that can successfully validate
   # Stripe certificates.
@@ -102,6 +118,8 @@ module Stripe
 
     # empty this field so a new store is initialized
     @ca_store = nil
+
+    StripeClient.clear_all_connection_managers
   end
 
   # A certificate store initialized from the the bundle in #ca_bundle_path and
@@ -119,6 +137,19 @@ module Stripe
       store.add_file(ca_bundle_path)
       store
     end
+  end
+
+  def self.connection_base=(connection_base)
+    @connection_base = connection_base
+    StripeClient.clear_all_connection_managers
+  end
+
+  def self.enable_telemetry?
+    @enable_telemetry
+  end
+
+  def self.enable_telemetry=(val)
+    @enable_telemetry = val
   end
 
   # map to the same values as the standard library's logger
@@ -175,12 +206,19 @@ module Stripe
     @max_network_retries = val.to_i
   end
 
-  def self.enable_telemetry?
-    @enable_telemetry
+  def self.open_timeout=(open_timeout)
+    @open_timeout = open_timeout
+    StripeClient.clear_all_connection_managers
   end
 
-  def self.enable_telemetry=(val)
-    @enable_telemetry = val
+  def self.proxy=(proxy)
+    @proxy = proxy
+    StripeClient.clear_all_connection_managers
+  end
+
+  def self.read_timeout=(read_timeout)
+    @read_timeout = read_timeout
+    StripeClient.clear_all_connection_managers
   end
 
   # Sets some basic information about the running application that's sent along
@@ -195,6 +233,16 @@ module Stripe
       url: url,
       version: version,
     }
+  end
+
+  def self.uploads_base=(uploads_base)
+    @uploads_base = uploads_base
+    StripeClient.clear_all_connection_managers
+  end
+
+  def self.verify_ssl_certs=(verify_ssl_certs)
+    @verify_ssl_certs = verify_ssl_certs
+    StripeClient.clear_all_connection_managers
   end
 end
 

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -20,6 +20,15 @@ module Stripe
       @active_connections = {}
     end
 
+    # Finishes any active connections by closing their TCP connection and
+    # clears them from internal tracking.
+    def clear
+      @active_connections.each do |_, connection|
+        connection.finish
+      end
+      @active_connections = {}
+    end
+
     # Gets a connection for a given URI. This is for internal use only as it's
     # subject to change (we've moved between HTTP client schemes in the past
     # and may do it again).

--- a/test/stripe/connection_manager_test.rb
+++ b/test/stripe/connection_manager_test.rb
@@ -8,6 +8,23 @@ module Stripe
       @manager = Stripe::ConnectionManager.new
     end
 
+    context "#clear" do
+      should "clear any active connections" do
+        stub_request(:post, "#{Stripe.api_base}/path")
+          .to_return(body: JSON.generate(object: "account"))
+
+        # Making a request lets us know that at least one connection is open.
+        @manager.execute_request(:post, "#{Stripe.api_base}/path")
+
+        # Now clear the manager.
+        @manager.clear
+
+        # This check isn't great, but it's otherwise difficult to tell that
+        # anything happened with just the public-facing API.
+        assert_equal({}, @manager.instance_variable_get(:@active_connections))
+      end
+    end
+
     context "#connection_for" do
       should "correctly initialize a connection" do
         old_proxy = Stripe.proxy


### PR DESCRIPTION
Adds a few basic features around connection and connection manager
management:

* `clear` on connection manager, which calls `finish` on each active
  connection and then disposes of it.

* A centralized cross-thread tracking system for connection managers in
  `StripeClient` and `clear_all_connection_managers` which clears all
  known connection managers across all threads in a thread-safe way.

The addition of these allow us to modify the implementation of some of
our configuration on `Stripe` so that it can reset all currently open
connections when its value changes.

This fixes a currently problem with the library whereby certain
configuration must be set before the first request or it remains fixed
on any open connections. For example, if `Stripe.proxy` is set after a
request is made from the library, it has no effect because the proxy
must have been set when the connection was originally being initialized.

The impetus for getting this out is that I noticed that we will need
this internally in a few places when we're upgrading to stripe-ruby V5.
Those spots used to be able to hack around the unavailability of this
feature by just accessing the Faraday connection directly and resetting
state on it, but in V5 `StripeClient#conn` is gone, and that's no longer
possible.

I don't think this necessarily has to come in for the V5 release, but I
wanted to float it out there for some any high-level feedback on the
approach.

r? @ob-stripe
cc @stripe/api-libraries

---

Note: targets the V5 integration branch in #815.