### PR TITLE
Fix inverted sign for 500 retries

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -61,7 +61,7 @@ module Stripe
         # We only bother retrying these for non-POST requests. POSTs end up
         # being cached by the idempotency layer so there's no purpose in
         # retrying them.
-        return true if error.http_status == 500 && method == :post
+        return true if error.http_status == 500 && method != :post
 
         # 503 Service Unavailable
         return true if error.http_status == 503

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -78,6 +78,11 @@ module Stripe
                                           method: :post, num_retries: 0)
       end
 
+      should "retry on a 500 Internal Server Error when non-POST" do
+        assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
+                                          method: :get, num_retries: 0)
+      end
+
       should "retry on a 503 Service Unavailable" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 503),
                                           method: :post, num_retries: 0)
@@ -90,6 +95,11 @@ module Stripe
 
       should "not retry on a certificate validation error" do
         refute StripeClient.should_retry?(OpenSSL::SSL::SSLError.new,
+                                          method: :post, num_retries: 0)
+      end
+
+      should "not retry on a 500 Internal Server Error when POST" do
+        refute StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
                                           method: :post, num_retries: 0)
       end
     end


### PR DESCRIPTION
I messed up in #828 by (1) accidentally flipping the comparison against
`:post` when checking whether to retry on 500, and (2) forgetting to
write new tests for the condition, which is how (1) got through.

This patch fixes both those problems. Thanks @rattrayalex-stripe for the
tip off! Oops.

r? @ob-stripe
cc @stripe/api-libraries