### PR TITLE
Remove a few more very old deprecated methods

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -196,16 +196,6 @@ module Stripe
       version: version,
     }
   end
-
-  # DEPRECATED. Use `Util#encode_parameters` instead.
-  def self.uri_encode(params)
-    Util.encode_parameters(params)
-  end
-  private_class_method :uri_encode
-  class << self
-    extend Gem::Deprecate
-    deprecate :uri_encode, "Stripe::Util#encode_parameters", 2016, 1
-  end
 end
 
 Stripe.log_level = ENV["STRIPE_LOG"] unless ENV["STRIPE_LOG"].nil?

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -127,18 +127,6 @@ module Stripe
         JSON.pretty_generate(@values)
     end
 
-    # Re-initializes the object based on a hash of values (usually one that's
-    # come back from an API call). Adds or removes value accessors as necessary
-    # and updates the state of internal data.
-    #
-    # Please don't use this method. If you're trying to do mass assignment, try
-    # #initialize_from instead.
-    def refresh_from(values, opts, partial = false)
-      initialize_from(values, opts, partial)
-    end
-    extend Gem::Deprecate
-    deprecate :refresh_from, "#update_attributes", 2016, 1
-
     # Mass assigns attributes on the model.
     #
     # This is a version of +update_attributes+ that takes some extra options
@@ -269,16 +257,6 @@ module Stripe
       update_hash.reject! { |_, v| v.nil? }
 
       update_hash
-    end
-
-    class << self
-      # This class method has been deprecated in favor of the instance method
-      # of the same name.
-      def serialize_params(obj, options = {})
-        obj.serialize_params(options)
-      end
-      extend Gem::Deprecate
-      deprecate :serialize_params, "#serialize_params", 2016, 9
     end
 
     # A protected field is one that doesn't get an accessor assigned to it

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -235,20 +235,6 @@ module Stripe
       assert_equal true, obj.send(:metaclass).method_defined?(:foo)
     end
 
-    should "warn that #refresh_from is deprecated" do
-      old_stderr = $stderr
-      $stderr = StringIO.new
-      begin
-        obj = Stripe::StripeObject.construct_from({})
-        obj.refresh_from({}, {})
-        message = "NOTE: Stripe::StripeObject#refresh_from is " \
-                  "deprecated; use #update_attributes instead"
-        assert_match Regexp.new(message), $stderr.string
-      ensure
-        $stderr = old_stderr
-      end
-    end
-
     should "pass opts down to children when initializing" do
       opts = { custom: "opts" }
 
@@ -473,20 +459,6 @@ module Stripe
                                       metadata: { foo: "bar" })
 
       assert_equal(expected, obj.to_s)
-    end
-
-    should "warn that .serialize_params is deprecated" do
-      old_stderr = $stderr
-      $stderr = StringIO.new
-      begin
-        obj = Stripe::StripeObject.construct_from({})
-        Stripe::StripeObject.serialize_params(obj)
-        message = "NOTE: Stripe::StripeObject.serialize_params is " \
-                  "deprecated; use #serialize_params instead"
-        assert_match Regexp.new(message), $stderr.string
-      ensure
-        $stderr = old_stderr
-      end
     end
 
     should "error on setting a property to an empty string" do

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -3,19 +3,6 @@
 require ::File.expand_path("test_helper", __dir__)
 
 class StripeTest < Test::Unit::TestCase
-  should "warn that #refresh_from is deprecated" do
-    old_stderr = $stderr
-    $stderr = StringIO.new
-    begin
-      Stripe.uri_encode({})
-      message = "NOTE: Stripe.uri_encode is deprecated; use " \
-                "Stripe::Util#encode_parameters instead"
-      assert_match Regexp.new(message), $stderr.string
-    ensure
-      $stderr = old_stderr
-    end
-  end
-
   should "allow app_info to be configured" do
     begin
       old = Stripe.app_info


### PR DESCRIPTION
I noticed that we had a couple of other deprecated methods on `Stripe`
and `StripeObject` that have been around for a long time. May as well
get rid of them too -- luckily they were using `Gem::Deprecate` so
they've been producing annoying deprecated warnings for quite a while
now.

r? @ob-stripe Sorry for the deluge OB. Last one I think.
cc @stripe/api-libraries