### PR TITLE
Minor cleanup in `StripeClient`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Metrics/MethodLength:
   # There's ~2 long methods in `StripeClient`. If we want to truncate those a
   # little, we could move this to be closer to ~30 (but the default of 10 is
   # probably too short).
-  Max: 55
+  Max: 50
 
 Metrics/ModuleLength:
   Enabled: false

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -252,7 +252,7 @@ module Stripe
           Util.expects(:log_debug).with("Request details",
                                         body: "",
                                         idempotency_key: "abc",
-                                        query_params: nil)
+                                        query: nil)
 
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: "acct_123",


### PR DESCRIPTION
I ended up having to relax the maximum method line length in a few
previous PRs, so I wanted to try one more cleanup pass in
`execute_request` to see if I could get it back at all.

The answer was "not by much" (without reducing clarity), but I found a
few places that could be tweaked. Unfortunately, ~50 lines is probably
the "right" length for this method in that you _could_ extract it
further, but you'd end up passing huge amounts of state all over the
place in method parameters, and it really wouldn't look that good.

r? @ob-stripe
cc @stripe/api-libraries

---

Note: targets the V5 integration branch in #815.