### PR TITLE
Add `Invoice.list_upcoming_line_items` method

### DIFF
--- a/lib/stripe/resources/invoice.rb
+++ b/lib/stripe/resources/invoice.rb
@@ -64,5 +64,10 @@ module Stripe
       resp, opts = request(:get, resource_url + "/upcoming", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
+
+    def self.list_upcoming_line_items(params, opts = {})
+      resp, opts = request(:get, resource_url + "/upcoming/lines", params, opts)
+      Util.convert_to_stripe_object(resp.data, opts)
+    end
   end
 end

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -142,7 +142,7 @@ module Stripe
       end
     end
 
-    context "#upcoming" do
+    context ".upcoming" do
       should "retrieve upcoming invoices" do
         invoice = Stripe::Invoice.upcoming(
           customer: "cus_123",
@@ -189,6 +189,22 @@ module Stripe
                            customer: "cus_123",
                          }
         assert invoice.is_a?(Stripe::Invoice)
+      end
+    end
+
+    context ".list_upcoming_line_items" do
+      should "retrieve upcoming invoices" do
+        line_items = Stripe::Invoice.list_upcoming_line_items(
+          customer: "cus_123",
+          subscription: "sub_123"
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/invoices/upcoming/lines",
+                         query: {
+                           customer: "cus_123",
+                           subscription: "sub_123",
+                         }
+        assert line_items.data.is_a?(Array)
+        assert line_items.data[0].is_a?(Stripe::InvoiceLineItem)
       end
     end
 


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Add a `Stripe::Invoice.list_upcoming_line_items` method, to replace the ugly `Stripe::Invoice.retrieve("upcoming").lines.list` invocation.