### PR TITLE
Retry requests on a 429 that's a lock timeout

### DIFF
--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -122,6 +122,12 @@ module Stripe
                                           method: :post, num_retries: 0)
       end
 
+      should "retry on a 429 Too Many Requests when lock timeout" do
+        assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 429,
+                                                                  code: "lock_timeout"),
+                                          method: :post, num_retries: 0)
+      end
+
       should "retry on a 500 Internal Server Error when non-POST" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
                                           method: :get, num_retries: 0)
@@ -139,6 +145,12 @@ module Stripe
 
       should "not retry on a certificate validation error" do
         refute StripeClient.should_retry?(OpenSSL::SSL::SSLError.new,
+                                          method: :post, num_retries: 0)
+      end
+
+      should "not retry on a 429 Too Many Requests when not lock timeout" do
+        refute StripeClient.should_retry?(Stripe::StripeError.new(http_status: 429,
+                                                                  code: "rate_limited"),
                                           method: :post, num_retries: 0)
       end
 


### PR DESCRIPTION
Tweaks the retry logic so that 429s which have the special status code
lock_timeout are retried automatically.

Similar to what was recently implemented in Go: stripe/stripe-go#935

r? @ob-stripe
cc @stripe/api-libraries