### PR TITLE
Transfer the request_id from the http_headers to error.

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -27,7 +27,7 @@ module Stripe
       @http_headers = http_headers || {}
       @json_body = json_body
       @code = code
-      @request_id = @http_headers[:request_id]
+      @request_id = @http_headers["request-id"]
       @error = construct_error_object
     end
 

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -22,7 +22,7 @@ module Stripe
           e = StripeError.new("message", http_status: 200)
           assert_equal "(Status 200) message", e.to_s
 
-          e = StripeError.new("message", http_status: nil, http_body: nil, json_body: nil, http_headers: { request_id: "request-id" })
+          e = StripeError.new("message", http_status: nil, http_body: nil, json_body: nil, http_headers: { "request-id" => "request-id" })
           assert_equal "(Request request-id) message", e.to_s
         end
       end


### PR DESCRIPTION
When requesting error#request_id it returned nil although the request id was available in the request headers. With version 5 and switch to Net::HTTP this value is now a string, not a symbol which means that the request_id was not stored on the error correctly.

This picture shows a live request to stripe:

![image](https://user-images.githubusercontent.com/23100085/64288756-da569d00-cf30-11e9-901f-cff76ef08c95.png)
