### PR TITLE
Add a test to make sure request IDs make it into error objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,8 +19,17 @@ Layout/IndentFirstHashElement:
 Layout/IndentHeredoc:
   Enabled: false
 
+Metrics/BlockLength:
+  Max: 40
+  Exclude:
+    # `context` in tests are blocks and get quite large, so exclude the test
+    # directory from having to adhere to this rule.
+    - "test/**/*.rb"
+
 Metrics/ClassLength:
   Exclude:
+    # Test classes get quite large, so exclude the test directory from having
+    # to adhere to this rule.
     - "test/**/*.rb"
 
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,12 +10,6 @@
 Metrics/AbcSize:
   Max: 51
 
-# Offense count: 33
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 509
-
 # Offense count: 12
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -489,6 +489,19 @@ module Stripe
           assert_equal 'Invalid response object from API: "" (HTTP response code was 200)', e.message
         end
 
+        should "feed a request ID through to the error object" do
+          stub_request(:post, "#{Stripe.api_base}/v1/charges")
+            .to_return(body: JSON.generate(make_missing_id_error),
+                       headers: { "Request-ID": "req_123" },
+                       status: 400)
+          client = StripeClient.new
+
+          e = assert_raises Stripe::InvalidRequestError do
+            client.execute_request(:post, "/v1/charges")
+          end
+          assert_equal("req_123", e.request_id)
+        end
+
         should "handle low level error" do
           stub_request(:post, "#{Stripe.api_base}/v1/charges")
             .to_raise(Errno::ECONNREFUSED.new)


### PR DESCRIPTION
Follows up #845 to make sure that this sort of regression is much more
difficult in the future by adding a test that makes sure a request ID is
threaded all the way from an HTTP response back through to an error
object. I verified that the test failed before #845 came in.

r? @ob-stripe