### PR TITLE
Move to monotonic time for duration calculations

### DIFF
--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -10,14 +10,15 @@ module Stripe
   # Note that this class in itself is *not* thread safe. We expect it to be
   # instantiated once per thread.
   class ConnectionManager
-    # Timestamp indicating when the connection manager last made a request.
-    # This is used by `StripeClient` to determine whether a connection manager
-    # should be garbage collected or not.
+    # Timestamp (in seconds procured from the system's monotonic clock)
+    # indicating when the connection manager last made a request. This is used
+    # by `StripeClient` to determine whether a connection manager should be
+    # garbage collected or not.
     attr_reader :last_used
 
     def initialize
       @active_connections = {}
-      @last_used = Time.now
+      @last_used = Util.monotonic_time
 
       # A connection manager may be accessed across threads as one thread makes
       # requests on it while another is trying to clear it (either because it's
@@ -78,7 +79,7 @@ module Stripe
       raise ArgumentError, "query should be a string" \
         if query && !query.is_a?(String)
 
-      @last_used = Time.now
+      @last_used = Util.monotonic_time
 
       connection = connection_for(uri)
 

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -172,6 +172,19 @@ module Stripe
       result
     end
 
+    # `Time.now` can be unstable in cases like an administrator manually
+    # updating its value or a reconcilation via NTP. For this reason, prefer
+    # the use of the system's monotonic clock especially where comparing times
+    # to calculate an elapsed duration.
+    #
+    # Shortcut for getting monotonic time, mostly for purposes of line length
+    # and stubbing (Timecop doesn't freeze the monotonic clock). Returns time
+    # in seconds since the event used for monotonic reference purposes by the
+    # platform (e.g. system boot time).
+    def self.monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
     def self.normalize_id(id)
       if id.is_a?(Hash) # overloaded id
         params_hash = id.dup


### PR DESCRIPTION
Drops the use of `Time.now` in favor of using the system's monotonic
clock for various operations that calculate and use elapsed duration.
The latter is preferable because in some cases `Time.now` can be
unstable, like if it's set manually by a system administrator or an NTP
daemon.

I don't expect that the previous code would actually have caused trouble
in the vast majority of normal situations, so I'm not going to backport
anything, but this seems like good hygiene.

For better or worse I had to wrap the monotonic time calls in a new
`Util` function because (1) the normal invocation is long enough to have
caused a lot of overruns on our 80 character line lengths, and (2)
Timecop doesn't stub the monotonic clock, so the `Util` method gives us
a nice place that we can stub on where necessary.

r? @ob-stripe
cc @stripe/api-libraries