### PR TITLE
Drop Timecop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development do
   gem "rake"
   gem "shoulda-context"
   gem "test-unit"
-  gem "timecop"
   gem "webmock"
 
   # Rubocop changes pretty quickly: new cops get added and old cops change

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -178,9 +178,8 @@ module Stripe
     # to calculate an elapsed duration.
     #
     # Shortcut for getting monotonic time, mostly for purposes of line length
-    # and stubbing (Timecop doesn't freeze the monotonic clock). Returns time
-    # in seconds since the event used for monotonic reference purposes by the
-    # platform (e.g. system boot time).
+    # and test stubbing. Returns time in seconds since the event used for
+    # monotonic reference purposes by the platform (e.g. system boot time).
     def self.monotonic_time
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -316,11 +316,11 @@ module Stripe
 
       context "logging" do
         setup do
-          # Freeze time for the purposes of the `elapsed` parameter that we emit
-          # for responses. Mocha's `anything` parameter can't match inside of a
-          # hash and is therefore not useful for this purpose, and Timecop
-          # doesn't freeze monotonic time. If we switch over to rspec-mocks at
-          # some point, we can probably remove Timecop from the project.
+          # Freeze time for the purposes of the `elapsed` parameter that we
+          # emit for responses. Mocha's `anything` parameter can't match inside
+          # of a hash and is therefore not useful for this purpose. If we
+          # switch over to rspec-mocks at some point, we can probably remove
+          # this.
           Util.stubs(:monotonic_time).returns(0.0)
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ require "test/unit"
 require "mocha/setup"
 require "stringio"
 require "shoulda/context"
-require "timecop"
 require "webmock/test_unit"
 
 PROJECT_ROOT = ::File.expand_path("../", __dir__)


### PR DESCRIPTION
If #857 comes in, it turns out that we don't need Timecop anymore (it
doesn't freeze the monotic clock, so I had to find another way) -- here
we remove all mentions of it and drop the dependency.

I don't find it causes too much trouble so I'm not against bringing it
back in the future if we need it again, but it seems good for project
cleanliness to take it out for now.

r? @ob-stripe
cc @stripe/api-libraries