### PR TITLE
User-friendly messages for EOFError network errors

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -88,7 +88,11 @@ module Stripe
       # Destination refused the connection, the connection was reset, or a
       # variety of other connection failures. This could occur from a single
       # saturated server, so retry in case it's intermittent.
+      return true if error.is_a?(EOFError)
       return true if error.is_a?(Errno::ECONNREFUSED)
+      return true if error.is_a?(Errno::ECONNRESET)
+      return true if error.is_a?(Errno::EHOSTUNREACH)
+      return true if error.is_a?(Errno::ETIMEDOUT)
       return true if error.is_a?(SocketError)
 
       if error.is_a?(Stripe::StripeError)
@@ -296,7 +300,11 @@ module Stripe
     # The original error message is also appended onto the final exception for
     # full transparency.
     NETWORK_ERROR_MESSAGES_MAP = {
+      EOFError => ERROR_MESSAGE_CONNECTION,
       Errno::ECONNREFUSED => ERROR_MESSAGE_CONNECTION,
+      Errno::ECONNRESET => ERROR_MESSAGE_CONNECTION,
+      Errno::EHOSTUNREACH => ERROR_MESSAGE_CONNECTION,
+      Errno::ETIMEDOUT => ERROR_MESSAGE_TIMEOUT_CONNECT,
       SocketError => ERROR_MESSAGE_CONNECTION,
 
       Net::OpenTimeout => ERROR_MESSAGE_TIMEOUT_CONNECT,

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -172,6 +172,26 @@ module Stripe
                                           method: :post, num_retries: 0)
       end
 
+      should "retry on EOFError" do
+        assert StripeClient.should_retry?(EOFError.new,
+                                          method: :post, num_retries: 0)
+      end
+
+      should "retry on Errno::ECONNRESET" do
+        assert StripeClient.should_retry?(Errno::ECONNRESET.new,
+                                          method: :post, num_retries: 0)
+      end
+
+      should "retry on Errno::ETIMEDOUT" do
+        assert StripeClient.should_retry?(Errno::ETIMEDOUT.new,
+                                          method: :post, num_retries: 0)
+      end
+
+      should "retry on Errno::EHOSTUNREACH" do
+        assert StripeClient.should_retry?(Errno::EHOSTUNREACH.new,
+                                          method: :post, num_retries: 0)
+      end
+
       should "retry on Net::OpenTimeout" do
         assert StripeClient.should_retry?(Net::OpenTimeout.new,
                                           method: :post, num_retries: 0)


### PR DESCRIPTION
Provide nice errors for more types of network exceptions
`EOFError`
`Errno::ECONNRESET`
`Errno::ETIMEDOUT`
`Errno::EHOSTUNREACH`