### PR TITLE
Exclude ephemeral test scripts from Rubocop linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,12 @@ AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.3
 
+  Exclude:
+    # brandur: Exclude ephmeral script-like files that I use to try and
+    # reproduce problems with the library. If you know of a better way of doing
+    # this (e.g. exclude files not tracked by Git), feel free to change it.
+    - "example_*"
+
 Layout/CaseIndentation:
   EnforcedStyle: end
 


### PR DESCRIPTION
One thing I tend to do a lot is create little test scripts to help debug
or reproduce problems with stripe-ruby. The problem is that they get
picked up by Rubocop, produce a whole bunch of errors, and then make it
more difficult if my changes to actual library files are producing
problems.

Here I exclude these by introducing a convention for having them start
with `example_*`. This isn't particularly great, but will work.

r? @ob-stripe You don't happen to know of a better way to do this off
hand do you?