### PR TITLE
s/connection_base/connect_base/

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -139,8 +139,8 @@ module Stripe
     end
   end
 
-  def self.connection_base=(connection_base)
-    @connection_base = connection_base
+  def self.connect_base=(connect_base)
+    @connect_base = connect_base
     StripeClient.clear_all_connection_managers
   end
 


### PR DESCRIPTION
r? @ob-stripe 

Fixes the misnamed `connection_base=` setter to be named `connect_base=`.
