### PR TITLE
Add simple instrumentation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ monitoring. The callback supplies the following arguments about the request:
 
 For example:
 ```ruby
-Stripe::Instrumentation.subscribe do |context, response_code, duration, retries|
+Stripe::Instrumentation.subscribe(:request) do |context, response_code, duration, retries|
   tags = {
     method: context.method,
     resource: context.path.split("/")[2],

--- a/README.md
+++ b/README.md
@@ -203,6 +203,29 @@ There are a few options for enabling it:
    Stripe.log_level = Stripe::LEVEL_INFO
    ```
 
+### Instrumentation
+
+The library has a hook for when a HTTP call is made which can be used for
+monitoring. The callback supplies the following arguments about the request:
+- the `RequestLogContext` object, if possible updated with response data
+- HTTP response code (`Integer`) if available, or `nil` in case of a lower
+  level network error
+- request duration in seconds (`Float`)
+- the number of retries (`Integer`)
+
+For example:
+```ruby
+Stripe::Instrumentation.subscribe do |context, response_code, duration, retries|
+  tags = {
+    method: context.method,
+    resource: context.path.split("/")[2],
+    code: response_code,
+    retries: retries
+  }
+  StatsD.distribution('stripe_request', duration, tags: tags)
+end
+```
+
 ### Writing a Plugin
 
 If you're writing a plugin that uses the library, we'd appreciate it if you

--- a/README.md
+++ b/README.md
@@ -206,8 +206,10 @@ There are a few options for enabling it:
 ### Instrumentation
 
 The library has a hook for when a HTTP call is made which can be used for
-monitoring. The callback supplies the following arguments about the request:
-- the `RequestLogContext` object, if possible updated with response data
+monitoring. The callback receives a `RequestEvent` object with the following
+data:
+- HTTP method (`Symbol`)
+- request path (`String`)
 - HTTP response code (`Integer`) if available, or `nil` in case of a lower
   level network error
 - request duration in seconds (`Float`)
@@ -215,14 +217,14 @@ monitoring. The callback supplies the following arguments about the request:
 
 For example:
 ```ruby
-Stripe::Instrumentation.subscribe(:request) do |context, response_code, duration, retries|
+Stripe::Instrumentation.subscribe(:request) do |request_event|
   tags = {
-    method: context.method,
-    resource: context.path.split("/")[2],
-    code: response_code,
-    retries: retries
+    method: request_event.method,
+    resource: request_event.path.split("/")[2],
+    code: request_event.http_status,
+    retries: request_event.num_retries
   }
-  StatsD.distribution('stripe_request', duration, tags: tags)
+  StatsD.distribution('stripe_request', request_event.duration, tags: tags)
 end
 ```
 

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -2,21 +2,21 @@
 
 module Stripe
   class Instrumentation
-    def self.subscribe(name = rand, &block)
-      subscribers[name] = block
+    def self.subscribe(topic, name = rand, &block)
+      subscribers[topic][name] = block
       name
     end
 
-    def self.unsubscribe(name)
-      subscribers.delete(name)
+    def self.unsubscribe(topic, name)
+      subscribers[topic].delete(name)
     end
 
-    def self.notify(*args)
-      subscribers.each_value { |subscriber| subscriber.call(*args) }
+    def self.notify(topic, *args)
+      subscribers[topic].each_value { |subscriber| subscriber.call(*args) }
     end
 
     def self.subscribers
-      @subscribers ||= {}
+      @subscribers ||= Hash.new { |hash, key| hash[key] = {} }
     end
     private_class_method :subscribers
   end

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -2,6 +2,23 @@
 
 module Stripe
   class Instrumentation
+    class RequestEvent
+      attr_reader :duration
+      attr_reader :http_status
+      attr_reader :method
+      attr_reader :num_retries
+      attr_reader :path
+
+      def initialize(duration:, http_status:, method:, num_retries:, path:)
+        @duration = duration
+        @http_status = http_status
+        @method = method
+        @num_retries = num_retries
+        @path = path
+        freeze
+      end
+    end
+
     def self.subscribe(topic, name = rand, &block)
       subscribers[topic][name] = block
       name
@@ -11,8 +28,8 @@ module Stripe
       subscribers[topic].delete(name)
     end
 
-    def self.notify(topic, *args)
-      subscribers[topic].each_value { |subscriber| subscriber.call(*args) }
+    def self.notify(topic, event)
+      subscribers[topic].each_value { |subscriber| subscriber.call(event) }
     end
 
     def self.subscribers

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Stripe
+  class Instrumentation
+    def self.subscribe(name = rand, &block)
+      subscribers[name] = block
+      name
+    end
+
+    def self.unsubscribe(name)
+      subscribers.delete(name)
+    end
+
+    def self.notify(*args)
+      subscribers.each_value { |subscriber| subscriber.call(*args) }
+    end
+
+    def self.subscribers
+      @subscribers ||= {}
+    end
+    private_class_method :subscribers
+  end
+end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -461,8 +461,8 @@ module Stripe
         handle_error_response(resp, context) if response_code >= 400
 
         log_response(context, request_start, response_code, resp.body)
-        Stripe::Instrumentation.notify(context, response_code, request_duration,
-                                       num_retries)
+        Stripe::Instrumentation.notify(:request, context, response_code,
+                                       request_duration, num_retries)
 
         if Stripe.enable_telemetry? && context.request_id
           request_duration_ms = (request_duration * 1000).to_i
@@ -488,7 +488,7 @@ module Stripe
         else
           log_response_error(error_context, request_start, e)
         end
-        Stripe::Instrumentation.notify(error_context, response_code,
+        Stripe::Instrumentation.notify(:request, error_context, response_code,
                                        request_duration, num_retries)
 
         if self.class.should_retry?(e, method: method, num_retries: num_retries)

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stripe/instrumentation"
+
 module Stripe
   # StripeClient executes requests against the Stripe API and allows a user to
   # recover both a resource a call returns as well as a response object that
@@ -452,15 +454,18 @@ module Stripe
         request_start = Util.monotonic_time
         log_request(context, num_retries)
         resp = yield
+        request_duration = Util.monotonic_time - request_start
+        response_code = resp.code.to_i
         context = context.dup_from_response_headers(resp)
 
-        handle_error_response(resp, context) if resp.code.to_i >= 400
+        handle_error_response(resp, context) if response_code >= 400
 
-        log_response(context, request_start, resp.code.to_i, resp.body)
+        log_response(context, request_start, response_code, resp.body)
+        Stripe::Instrumentation.notify(context, response_code, request_duration,
+                                       num_retries)
 
         if Stripe.enable_telemetry? && context.request_id
-          request_duration_ms =
-            ((Util.monotonic_time - request_start) * 1000).to_int
+          request_duration_ms = (request_duration * 1000).to_i
           @last_request_metrics =
             StripeRequestMetrics.new(context.request_id, request_duration_ms)
         end
@@ -472,14 +477,19 @@ module Stripe
         # If we modify context we copy it into a new variable so as not to
         # taint the original on a retry.
         error_context = context
+        request_duration = Util.monotonic_time - request_start
+        response_code = nil
 
         if e.is_a?(Stripe::StripeError)
           error_context = context.dup_from_response_headers(e.http_headers)
+          response_code = resp.code.to_i
           log_response(error_context, request_start,
                        e.http_status, e.http_body)
         else
           log_response_error(error_context, request_start, e)
         end
+        Stripe::Instrumentation.notify(error_context, response_code,
+                                       request_duration, num_retries)
 
         if self.class.should_retry?(e, method: method, num_retries: num_retries)
           num_retries += 1

--- a/test/stripe/instrumentation_test.rb
+++ b/test/stripe/instrumentation_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Stripe
+  class InstrumentationTest < Test::Unit::TestCase
+    context ".notify" do
+      teardown do
+        Stripe::Instrumentation.send(:subscribers).clear
+      end
+
+      should "notify subscribers for the right topic" do
+        sub1_events = []
+        Stripe::Instrumentation.subscribe(:test1, :sub1) { |event| sub1_events << event }
+        sub2_events = []
+        Stripe::Instrumentation.subscribe(:test2, :sub2) { |event| sub2_events << event }
+
+        Stripe::Instrumentation.notify(:test1, "hello")
+        assert_equal(1, sub1_events.size)
+        assert_equal(0, sub2_events.size)
+      end
+
+      should "notify multiple subscribers of the same topic" do
+        sub1_events = []
+        Stripe::Instrumentation.subscribe(:test, :sub1) { |event| sub1_events << event }
+        sub2_events = []
+        Stripe::Instrumentation.subscribe(:test, :sub2) { |event| sub2_events << event }
+
+        Stripe::Instrumentation.notify(:test, "hello")
+        assert_equal(1, sub1_events.size)
+        assert_equal(1, sub2_events.size)
+      end
+
+      should "not notify a subscriber once it has unsubscribed" do
+        events = []
+        Stripe::Instrumentation.subscribe(:test, :sub) { |event| events << event }
+
+        Stripe::Instrumentation.notify(:test, "hello")
+        assert_equal(1, events.size)
+
+        Stripe::Instrumentation.unsubscribe(:test, :sub)
+        Stripe::Instrumentation.notify(:test, "hello")
+        assert_equal(1, events.size)
+      end
+    end
+
+    context "RequestEvent" do
+      should "return a frozen object" do
+        event = Stripe::Instrumentation::RequestEvent.new(
+          duration: 0.1,
+          http_status: 200,
+          method: :get,
+          num_retries: 0,
+          path: "/v1/test"
+        )
+
+        assert(event.frozen?)
+      end
+    end
+  end
+end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1147,12 +1147,12 @@ module Stripe
 
     context "instrumentation" do
       teardown do
-        Stripe::Instrumentation.unsubscribe(:test)
+        Stripe::Instrumentation.unsubscribe(:request, :test)
       end
 
       should "notify a subscriber of a successful HTTP request" do
         events = []
-        Stripe::Instrumentation.subscribe(:test) { |*args| events << args }
+        Stripe::Instrumentation.subscribe(:request, :test) { |*args| events << args }
 
         stub_request(:get, "#{Stripe.api_base}/v1/charges")
           .to_return(body: JSON.generate(object: "charge"))
@@ -1169,7 +1169,7 @@ module Stripe
 
       should "notify a subscriber of a StripeError" do
         events = []
-        Stripe::Instrumentation.subscribe(:test) { |*args| events << args }
+        Stripe::Instrumentation.subscribe(:request, :test) { |*args| events << args }
 
         error = {
           code: "code",
@@ -1197,7 +1197,7 @@ module Stripe
 
       should "notify a subscriber of a network error" do
         events = []
-        Stripe::Instrumentation.subscribe(:test) { |*args| events << args }
+        Stripe::Instrumentation.subscribe(:request, :test) { |*args| events << args }
 
         stub_request(:get, "#{Stripe.api_base}/v1/charges")
           .to_raise(Net::OpenTimeout)
@@ -1216,12 +1216,12 @@ module Stripe
 
       should "not notify a subscriber once it has unsubscribed" do
         events = []
-        Stripe::Instrumentation.subscribe(:test) { |*args| events << args }
+        Stripe::Instrumentation.subscribe(:request, :test) { |*args| events << args }
 
         stub_request(:get, "#{Stripe.api_base}/v1/charges")
           .to_return(body: JSON.generate(object: "charge"))
         2.times { Stripe::Charge.list }
-        Stripe::Instrumentation.unsubscribe(:test)
+        Stripe::Instrumentation.unsubscribe(:request, :test)
         Stripe::Charge.list
 
         assert_equal(2, events.size)

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1213,19 +1213,6 @@ module Stripe
         assert(event.duration.positive?)
         assert_equal(0, event.num_retries)
       end
-
-      should "not notify a subscriber once it has unsubscribed" do
-        events = []
-        Stripe::Instrumentation.subscribe(:request, :test) { |event| events << event }
-
-        stub_request(:get, "#{Stripe.api_base}/v1/charges")
-          .to_return(body: JSON.generate(object: "charge"))
-        2.times { Stripe::Charge.list }
-        Stripe::Instrumentation.unsubscribe(:request, :test)
-        Stripe::Charge.list
-
-        assert_equal(2, events.size)
-      end
     end
   end
 


### PR DESCRIPTION
We used to insert `Faraday::Request::Instrumentation` (with a monkey patch) into our Faraday middleware stack to be able to instrument Stripe calls with [StatsD](https://github.com/Shopify/statsd-instrument). With Faraday being removed in version 5, this required some rework. This commit implements a simple callback system that can be used with any kind of instrumentation library.

Closes https://github.com/stripe/stripe-ruby/issues/795