### PR TITLE
Raise an error when requests params are invalid

### DIFF
--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -5,6 +5,9 @@ module Stripe
     module Request
       module ClassMethods
         def request(method, url, params = {}, opts = {})
+          params ||= {}
+
+          error_on_invalid_params(params)
           warn_on_opts_in_params(params)
 
           opts = Util.normalize_opts(opts)
@@ -45,6 +48,14 @@ module Stripe
                   "request option '#{opt}' should be a string value " \
                     "(was a #{val.class})"
           end
+        end
+
+        private def error_on_invalid_params(params)
+          return if params.nil? || params.is_a?(Hash)
+
+          raise ArgumentError,
+                "request params should be either a Hash or nil " \
+                  "(was a #{params.class})"
         end
 
         private def warn_on_opts_in_params(params)

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -227,6 +227,22 @@ module Stripe
         end
       end
 
+      should "error if the params is not a Hash" do
+        stub_request(:post, "#{Stripe.api_base}/v1/charges/ch_123/capture")
+          .to_return(body: JSON.generate(charge_fixture))
+
+        e = assert_raises(ArgumentError) { Stripe::Charge.capture("ch_123", "sk_test_secret") }
+
+        assert_equal "request params should be either a Hash or nil (was a String)", e.message
+      end
+
+      should "allow making a request with params set to nil" do
+        stub_request(:post, "#{Stripe.api_base}/v1/charges/ch_123/capture")
+          .to_return(body: JSON.generate(charge_fixture))
+
+        Stripe::Charge.capture("ch_123", nil, "sk_test_secret")
+      end
+
       should "error if a user-specified opt is given a non-nil non-string value" do
         stub_request(:post, "#{Stripe.api_base}/v1/charges")
           .to_return(body: JSON.generate(charge_fixture))


### PR DESCRIPTION
There are two kinds of API operations: collection and element specific.
The signature between the two is slightly different:
  - **collection**: (params, opts)
  - **element specific**: (id, params, opts)

If a user doesn't realize the difference, they may attempt to use the
collection signature when performing an element specific operation like:
```
Stripe::PaymentIntent.cancel('pi_1234', 'sk_test_key')
 # Results in an error: NoMethodError: undefined method `key?' for "sk_test"
```

The resulting error message isn't very useful for debugging.

Instead,this PR adds a message letting the user know what it's expecting:
`request params should be either a Hash or nil (was a String)`

Addresses https://github.com/stripe/stripe-ruby/issues/855