### PR TITLE
Add native support for URLs sent as a file param

### DIFF
--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -18,9 +18,13 @@ module Stripe
     end
 
     def self.create(params = {}, opts = {})
-      if params[:file] && !params[:file].is_a?(String)
-        unless params[:file].respond_to?(:read)
-          raise ArgumentError, "file must respond to `#read`"
+      if params[:file]
+        if params[:file].is_a?(String)
+          params[:file] = Util.normalize_file_params(params[:file])
+        else
+          unless params[:file].respond_to?(:read)
+            raise ArgumentError, "file must respond to `#read`"
+          end
         end
       end
 

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cgi"
+require "open-uri"
 
 module Stripe
   module Util
@@ -206,6 +207,14 @@ module Stripe
       else
         raise TypeError, "normalize_opts expects a string or a hash"
       end
+    end
+
+    # Will either retrieve the contents of a URL or return the file_param
+    # if the argument does not satisfy the regex
+    def self.normalize_file_params(file_param)
+      return file_param unless file_param =~ /^http.*/
+
+      OpenURI.open_uri(file_param)
     end
 
     def self.check_string_argument!(key)

--- a/test/stripe/file_test.rb
+++ b/test/stripe/file_test.rb
@@ -62,6 +62,18 @@ module Stripe
         assert file.is_a?(Stripe::File)
       end
 
+      should "be creatable with a URL string" do
+        stub_request(:get, "https://example.com/verification.png")
+          .to_return(status: 200, body: "", headers: {})
+        file = Stripe::File.create(
+          purpose: "dispute_evidence",
+          file: "https://example.com/verification.png",
+          file_link_data: { create: true }
+        )
+        assert_requested :post, "#{Stripe.uploads_base}/v1/files"
+        assert file.is_a?(Stripe::File)
+      end
+
       should "raise given a file object that doesn't respond to #read" do
         e = assert_raises(ArgumentError) do
           Stripe::File.create(

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -299,6 +299,22 @@ module Stripe
       end
     end
 
+    context ".normalize_file_params" do
+      should "return the original params when already mutlipart data" do
+        assert_equal("file-contents",
+                     Util.normalize_file_params("file-contents"))
+      end
+
+      should "return an object that respons to #read when the params are a URL" do
+        image_url = "https://example.come/image.png"
+        stub_request(:get, image_url)
+          .to_return(status: 200, body: "file-contents", headers: {})
+
+        assert_equal("file-contents",
+                     Util.normalize_file_params(image_url).read)
+      end
+    end
+
     #
     # private
     #


### PR DESCRIPTION
Came across a feature request to support URLs when performing a file upload (https://github.com/stripe/stripe-ruby/issues/710).

I figured I'd take a stab at the feature, but I'm a bit on the fence about it for a few reasons:
- From what I can tell, no other Stripe clients support this feature
- The API spec stats that the `file` param should follow RFC 2388 specification so this would be a deviation.

I may have just talked myself out of this :smile: