### PR TITLE
Add gem version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Stripe Ruby Library
 
+[![Gem Version](https://badge.fury.io/rb/stripe.svg)](https://badge.fury.io/rb/stripe)
 [![Build Status](https://travis-ci.org/stripe/stripe-ruby.svg?branch=master)](https://travis-ci.org/stripe/stripe-ruby)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
 


### PR DESCRIPTION
I was just checking out [stripe-rails](https://github.com/tansengming/stripe-rails) gem and wanted to see whether it supports the latest stripe-ruby version. I added it to my `Gemfile` and it installed stripe-ruby 5.8.0. Then I went here to check the stripe-ruby version number, but without luck. So that's why I'm adding the autogenerated badge from here:
https://badge.fury.io/for/rb/stripe
