### PR TITLE
Add list_usage_record_summaries and list_source_transactions

### DIFF
--- a/lib/stripe/resources/source.rb
+++ b/lib/stripe/resources/source.rb
@@ -4,10 +4,13 @@ module Stripe
   class Source < APIResource
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Save
+    extend Stripe::APIOperations::NestedResource
 
     OBJECT_NAME = "source"
 
     custom_method :verify, http_verb: :post
+
+    nested_resource_class_methods :source_transaction, operations: %i[list]
 
     def verify(params = {}, opts = {})
       request_stripe_object(
@@ -36,5 +39,7 @@ module Stripe
                            opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
+    extend Gem::Deprecate
+    deprecate :source_transactions, :"Source.list_source_transactions", 2020, 1
   end
 end

--- a/lib/stripe/resources/subscription_item.rb
+++ b/lib/stripe/resources/subscription_item.rb
@@ -11,10 +11,15 @@ module Stripe
     OBJECT_NAME = "subscription_item"
 
     nested_resource_class_methods :usage_record, operations: %i[create]
+    nested_resource_class_methods :usage_record_summary,
+                                  operations: %i[list],
+                                  resource_plural: "usage_record_summaries"
 
     def usage_record_summaries(params = {}, opts = {})
       resp, opts = request(:get, resource_url + "/usage_record_summaries", params, opts)
       Util.convert_to_stripe_object(resp.data, opts)
     end
+    extend Gem::Deprecate
+    deprecate :usage_record_summaries, :"SubscriptionItem.list_usage_record_summaries", 2020, 1
   end
 end

--- a/test/stripe/source_transaction_test.rb
+++ b/test/stripe/source_transaction_test.rb
@@ -8,8 +8,16 @@ module Stripe
       @source = Stripe::Source.retrieve("src_123")
     end
 
-    should "be listable" do
+    should "be listable (DEPRECATED)" do
       transactions = @source.source_transactions
+
+      assert_requested :get, "#{Stripe.api_base}/v1/sources/#{@source.id}/source_transactions"
+      assert transactions.data.is_a?(Array)
+      assert transactions.first.is_a?(Stripe::SourceTransaction)
+    end
+
+    should "be listable" do
+      transactions = Stripe::Source.list_source_transactions(@source.id)
 
       assert_requested :get, "#{Stripe.api_base}/v1/sources/#{@source.id}/source_transactions"
       assert transactions.data.is_a?(Array)

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -75,7 +75,7 @@ module Stripe
     context "#list_usage_record_summaries" do
       should "list usage record summaries" do
         Stripe::SubscriptionItem.list_usage_record_summaries(
-          "si_123",
+          "si_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123/usage_record_summaries"
       end

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -71,5 +71,14 @@ module Stripe
         assert_requested :post, "#{Stripe.api_base}/v1/subscription_items/si_123/usage_records"
       end
     end
+
+    context "#list_usage_record_summaries" do
+      should "list usage record summaries" do
+        Stripe::SubscriptionItem.list_usage_record_summaries(
+          "si_123",
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123/usage_record_summaries"
+      end
+    end
   end
 end


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

As per https://github.com/stripe/stripe-python/pull/627
Not sure if 2020,1 was the right thing to do for the deprecation timeframe, didn't want to promise something far away and then have it be soon.