### PR TITLE
Override API key with `client_secret` in `OAuth.token`

### DIFF
--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -43,6 +43,7 @@ module Stripe
 
     def self.token(params = {}, opts = {})
       opts = Util.normalize_opts(opts)
+      opts[:api_key] = params[:client_secret] if params[:client_secret]
       resp, opts = OAuthOperations.request(
         :post, "/oauth/token", params, opts
       )

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -67,6 +67,22 @@ module Stripe
                            code: "this_is_an_authorization_code")
         assert_equal("sk_access_token", resp.access_token)
       end
+
+      should "override the API key when client_secret is passed" do
+        stub_request(:post, "#{Stripe.connect_base}/oauth/token")
+          .with(body: {
+            "client_secret" => "client_secret_override",
+            "grant_type" => "authorization_code",
+            "code" => "this_is_an_authorization_code",
+          })
+          .with(headers: { "Authorization": "Bearer client_secret_override" })
+          .to_return(body: JSON.generate(access_token: "another_access_token"))
+
+        resp = OAuth.token(client_secret: "client_secret_override",
+                           grant_type: "authorization_code",
+                           code: "this_is_an_authorization_code")
+        assert_equal("another_access_token", resp.access_token)
+      end
     end
 
     context ".deauthorize" do


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Override API key when `client_secret` is passed as an argument to `OAuth.token`.

Fixes #866. 
