### PR TITLE
Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby-9.2.7.0
 
 notifications:

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -641,28 +641,28 @@ module Stripe
                      idempotency_key: context.idempotency_key,
                      request_id: context.request_id)
 
-      args = [error_code, description, {
+      args = {
         http_status: resp.http_status, http_body: resp.http_body,
         json_body: resp.data, http_headers: resp.http_headers,
-      },]
+      }
 
       case error_code
       when "invalid_client"
-        OAuth::InvalidClientError.new(*args)
+        OAuth::InvalidClientError.new(error_code, description, **args)
       when "invalid_grant"
-        OAuth::InvalidGrantError.new(*args)
+        OAuth::InvalidGrantError.new(error_code, description, **args)
       when "invalid_request"
-        OAuth::InvalidRequestError.new(*args)
+        OAuth::InvalidRequestError.new(error_code, description, **args)
       when "invalid_scope"
-        OAuth::InvalidScopeError.new(*args)
+        OAuth::InvalidScopeError.new(error_code, description, **args)
       when "unsupported_grant_type"
-        OAuth::UnsupportedGrantTypeError.new(*args)
+        OAuth::UnsupportedGrantTypeError.new(error_code, description, **args)
       when "unsupported_response_type"
-        OAuth::UnsupportedResponseTypeError.new(*args)
+        OAuth::UnsupportedResponseTypeError.new(error_code, description, **args)
       else
         # We'd prefer that all errors are typed, but we create a generic
         # OAuthError in case we run into a code that we don't recognize.
-        OAuth::OAuthError.new(*args)
+        OAuth::OAuthError.new(error_code, description, **args)
       end
     end
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -606,26 +606,26 @@ module Stripe
       when 400, 404
         case error_data[:type]
         when "idempotency_error"
-          IdempotencyError.new(error_data[:message], opts)
+          IdempotencyError.new(error_data[:message], **opts)
         else
           InvalidRequestError.new(
             error_data[:message], error_data[:param],
-            opts
+            **opts
           )
         end
       when 401
-        AuthenticationError.new(error_data[:message], opts)
+        AuthenticationError.new(error_data[:message], **opts)
       when 402
         CardError.new(
           error_data[:message], error_data[:param],
-          opts
+          **opts
         )
       when 403
-        PermissionError.new(error_data[:message], opts)
+        PermissionError.new(error_data[:message], **opts)
       when 429
-        RateLimitError.new(error_data[:message], opts)
+        RateLimitError.new(error_data[:message], **opts)
       else
-        APIError.new(error_data[:message], opts)
+        APIError.new(error_data[:message], **opts)
       end
     end
 

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -474,7 +474,7 @@ module Stripe
           client = StripeClient.new
           opts = { api_base: Stripe.connect_base }
           assert_raises Stripe::OAuth::InvalidRequestError do
-            client.execute_request(:post, "/oauth/token", opts)
+            client.execute_request(:post, "/oauth/token", **opts)
           end
         end
       end
@@ -727,7 +727,7 @@ module Stripe
 
           opts = { api_base: Stripe.connect_base }
           e = assert_raises Stripe::OAuth::InvalidRequestError do
-            client.execute_request(:post, "/oauth/token", opts)
+            client.execute_request(:post, "/oauth/token", **opts)
           end
 
           assert_equal(400, e.http_status)
@@ -743,7 +743,7 @@ module Stripe
 
           opts = { api_base: Stripe.connect_base }
           e = assert_raises Stripe::OAuth::InvalidGrantError do
-            client.execute_request(:post, "/oauth/token", opts)
+            client.execute_request(:post, "/oauth/token", **opts)
           end
 
           assert_equal(400, e.http_status)
@@ -760,7 +760,7 @@ module Stripe
 
           opts = { api_base: Stripe.connect_base }
           e = assert_raises Stripe::OAuth::InvalidClientError do
-            client.execute_request(:post, "/oauth/deauthorize", opts)
+            client.execute_request(:post, "/oauth/deauthorize", **opts)
           end
 
           assert_equal(401, e.http_status)
@@ -777,7 +777,7 @@ module Stripe
 
           opts = { api_base: Stripe.connect_base }
           e = assert_raises Stripe::OAuth::OAuthError do
-            client.execute_request(:post, "/oauth/deauthorize", opts)
+            client.execute_request(:post, "/oauth/deauthorize", **opts)
           end
 
           assert_equal(401, e.http_status)


### PR DESCRIPTION
Took a stab at making the Stripe gem ruby 2.7 friendly.

I was able to get rid of most of the warnings with very little effort (just adding lots of `**`s). 

The following warnings remain:

* One related to Webmock.
Looks like they are fixing that so we need to wait for the gem to be updated: https://github.com/bblimke/webmock/commit/7e3b4ffbf1ef2cb5cb4cd643cf1f882f6e5b5375
* Caused by the way `.update_attributes` is implemented on `Stripe::Object` (https://github.com/dennisvdvliet/stripe-ruby/blob/master/lib/stripe/stripe_object.rb#L147) 
Not sure what the best way to fix this is since this part of the public api of the gem I belief. Suggestions welcome.

