### PR TITLE
Upgrade Rubocop to 0.79

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,17 +13,22 @@ AllCops:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # This can be re-enabled once we're 2.3+ only and can use the squiggly heredoc
 # operator. Prior to that, Rubocop recommended bringing in a library like
 # ActiveSupport to get heredoc indentation, which is just terrible.
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
+
+Layout/LineLength:
+  Exclude:
+    - "lib/stripe/resources/**/*.rb"
+    - "test/**/*.rb"
 
 Metrics/BlockLength:
   Max: 40
@@ -36,11 +41,6 @@ Metrics/ClassLength:
   Exclude:
     # Test classes get quite large, so exclude the test directory from having
     # to adhere to this rule.
-    - "test/**/*.rb"
-
-Metrics/LineLength:
-  Exclude:
-    - "lib/stripe/resources/**/*.rb"
     - "test/**/*.rb"
 
 Metrics/MethodLength:

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
   # `Gemfile.lock` checked in, so to prevent good builds from suddenly going
   # bad, pin to a specific version number here. Try to keep this relatively
   # up-to-date, but it's not the end of the world if it's not.
-  gem "rubocop", "0.73"
+  gem "rubocop", "0.79"
 
   platforms :mri do
     gem "byebug"


### PR DESCRIPTION
Basically went through trying to make the whole stripe-ruby test run
Ruby 2.7 friendly. @dennisvdvliet got most of the internal stuff, but we
still have a couple external dependencies that are producing warning.

Here we upgrade Rubocop to 0.79, which curbs some warnings. A few lints
were moved and/or renamed, so I've modified the `.rubocop.yml`
appropriately, but there's no major changes there.

The last broken dependency is Webmock, and luckily I think it's pretty
easy to fix, so I'll send them a PR and see what happens.

r? @ob-stripe
cc @stripe/api-libraries