### PR TITLE
Clean up test output by capturing `$stderr` when we expect warnings

### DIFF
--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -99,10 +99,20 @@ module Stripe
 
     context "#source_transactions" do
       should "list source transactions" do
-        source = Stripe::Source.construct_from(id: "src_123",
-                                               object: "source")
-        source.source_transactions
-        assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
+        old_stderr = $stderr
+        $stderr = StringIO.new
+
+        begin
+          source = Stripe::Source.construct_from(id: "src_123",
+                                                 object: "source")
+          source.source_transactions
+          assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
+
+          assert_include $stderr.string,
+                         "use Source.list_source_transactions instead"
+        ensure
+          $stderr = old_stderr
+        end
       end
     end
   end

--- a/test/stripe/usage_record_summary_test.rb
+++ b/test/stripe/usage_record_summary_test.rb
@@ -9,11 +9,21 @@ module Stripe
     end
 
     should "be listable" do
-      transactions = @sub_item.usage_record_summaries
+      old_stderr = $stderr
+      $stderr = StringIO.new
 
-      assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/#{@sub_item.id}/usage_record_summaries"
-      assert transactions.data.is_a?(Array)
-      assert transactions.first.is_a?(Stripe::UsageRecordSummary)
+      begin
+        transactions = @sub_item.usage_record_summaries
+
+        assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/#{@sub_item.id}/usage_record_summaries"
+        assert transactions.data.is_a?(Array)
+        assert transactions.first.is_a?(Stripe::UsageRecordSummary)
+
+        assert_include $stderr.string,
+                       "use SubscriptionItem.list_usage_record_summaries instead"
+      ensure
+        $stderr = old_stderr
+      end
     end
   end
 end


### PR DESCRIPTION
I just noticed while running tests that we produce some accidental
output because both of `Source#source_transactions` and
`SubscriptionItem#usage_record_summaries` are considered deprecated and
have warnings attached.

Here we capture output to `$stderr` and assert on it from the test cases
that call these deprecated methods -- this pattern is already well
established elsewhere in the test suite.

r? @ob-stripe
cc @stripe/api-libraries