### PR TITLE
Bump minimum version of webmock to 3.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,10 @@ group :development do
   gem "rake"
   gem "shoulda-context"
   gem "test-unit"
-  gem "webmock"
+
+  # Version doesn't matter that much, but this one contains some fixes for Ruby
+  # 2.7 warnings that add noise to the test suite.
+  gem "webmock", ">= 3.8.0"
 
   # Rubocop changes pretty quickly: new cops get added and old cops change
   # names or go into new namespaces. This is a library and we don't have


### PR DESCRIPTION
Bumps the minimum version of webmock to 3.8.0 which contains a fix for a
Ruby 2.7 warning. This last change makes the whole project completely
warning-free!