### PR TITLE
Add `request_begin` instrumentation callback

### DIFF
--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -2,21 +2,63 @@
 
 module Stripe
   class Instrumentation
-    class RequestEvent
+    # Event emitted on `request_begin` callback.
+    class RequestBeginEvent
+      attr_reader :method
+      attr_reader :path
+
+      # Arbitrary user-provided data in the form of a Ruby hash that's passed
+      # from subscribers on `request_begin` to subscribers on `request_end`.
+      # `request_begin` subscribers can set keys which will then be available
+      # in `request_end`.
+      #
+      # Note that all subscribers of `request_begin` share the same object, so
+      # they must be careful to set unique keys so as to not conflict with data
+      # set by other subscribers.
+      attr_reader :user_data
+
+      def initialize(method:, path:, user_data:)
+        @method = method
+        @path = path
+        @user_data = user_data
+        freeze
+      end
+    end
+
+    # Event emitted on `request_end` callback.
+    class RequestEndEvent
       attr_reader :duration
       attr_reader :http_status
       attr_reader :method
       attr_reader :num_retries
       attr_reader :path
 
-      def initialize(duration:, http_status:, method:, num_retries:, path:)
+      # Arbitrary user-provided data in the form of a Ruby hash that's passed
+      # from subscribers on `request_begin` to subscribers on `request_end`.
+      # `request_begin` subscribers can set keys which will then be available
+      # in `request_end`.
+      attr_reader :user_data
+
+      def initialize(duration:, http_status:, method:, num_retries:, path:,
+                     user_data: nil)
         @duration = duration
         @http_status = http_status
         @method = method
         @num_retries = num_retries
         @path = path
+        @user_data = user_data
         freeze
       end
+    end
+
+    # This class was renamed for consistency. This alias is here for backwards
+    # compatibility.
+    RequestEvent = RequestEndEvent
+
+    # Returns true if there are a non-zero number of subscribers on the given
+    # topic, and false otherwise.
+    def self.any_subscribers?(topic)
+      !subscribers[topic].empty?
     end
 
     def self.subscribe(topic, name = rand, &block)

--- a/test/stripe/instrumentation_test.rb
+++ b/test/stripe/instrumentation_test.rb
@@ -44,14 +44,27 @@ module Stripe
       end
     end
 
-    context "RequestEvent" do
+    context "RequestEventBegin" do
       should "return a frozen object" do
-        event = Stripe::Instrumentation::RequestEvent.new(
+        event = Stripe::Instrumentation::RequestBeginEvent.new(
+          method: :get,
+          path: "/v1/test",
+          user_data: nil
+        )
+
+        assert(event.frozen?)
+      end
+    end
+
+    context "RequestEventEnd" do
+      should "return a frozen object" do
+        event = Stripe::Instrumentation::RequestEndEvent.new(
           duration: 0.1,
           http_status: 200,
           method: :get,
           num_retries: 0,
-          path: "/v1/test"
+          path: "/v1/test",
+          user_data: nil
         )
 
         assert(event.frozen?)


### PR DESCRIPTION
Adds a new instrumentation callback called `request_begin` which, as the
name suggests, is invoked before an HTTP request is dispatched. As
outlined originally in #900, the idea is that this will enable a set of
hooks that can be used for distributed tracing.

The PR also renames the existing `request` callback to `request_end`,
although the old name is still invoked for the time being for backwards
compatibility.

A special `user_data` property is passed to `request_begin` which allows
subscribers to set custom data that will be passed through to
`request_end` for any given request. This allows, for example, a user
assigned ID to be set for the request and recognized on both ends.

I chose the naming `_begin` and `_end` (as opposed to start/finish or
any other combination) based on the naming conventions of Ruby itself.

Fixes #900.

r? @ob-stripe
cc @stripe/api-libraries