### PR TITLE
Upgrade to Rubocop 0.80

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,15 @@ Style/AccessModifierDeclarations:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   # `Gemfile.lock` checked in, so to prevent good builds from suddenly going
   # bad, pin to a specific version number here. Try to keep this relatively
   # up-to-date, but it's not the end of the world if it's not.
-  gem "rubocop", "0.79"
+  gem "rubocop", "0.80"
 
   platforms :mri do
     gem "byebug"

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -213,28 +213,28 @@ module Stripe
     should "mass assign values with #update_attributes" do
       obj = Stripe::StripeObject.construct_from(id: 1, name: "Stripe")
 
-      obj.update_attributes({ name: "STRIPE" }) # rubocop:disable Style/BracesAroundHashParameters
+      obj.update_attributes({ name: "STRIPE" })
 
       assert_equal "STRIPE", obj.name
 
       # unfortunately, we even assign unknown properties to duplicate the
       # behavior that we currently have via magic accessors with
       # method_missing
-      obj.update_attributes({ unknown: "foo" }) # rubocop:disable Style/BracesAroundHashParameters
+      obj.update_attributes({ unknown: "foo" })
 
       assert_equal "foo", obj.unknown
     end
 
     should "#update_attributes with a hash" do
       obj = Stripe::StripeObject.construct_from({})
-      obj.update_attributes({ metadata: { foo: "bar" } }) # rubocop:disable Style/BracesAroundHashParameters
+      obj.update_attributes({ metadata: { foo: "bar" } })
       assert_equal Stripe::StripeObject, obj.metadata.class
     end
 
     should "create accessors when #update_attributes is called" do
       obj = Stripe::StripeObject.construct_from({})
       assert_equal false, obj.send(:metaclass).method_defined?(:foo)
-      obj.update_attributes({ foo: "bar" }) # rubocop:disable Style/BracesAroundHashParameters
+      obj.update_attributes({ foo: "bar" })
       assert_equal true, obj.send(:metaclass).method_defined?(:foo)
     end
 
@@ -271,7 +271,7 @@ module Stripe
 
     should "#serialize_params on a basic object" do
       obj = Stripe::StripeObject.construct_from(foo: nil)
-      obj.update_attributes({ foo: "bar" }) # rubocop:disable Style/BracesAroundHashParameters
+      obj.update_attributes({ foo: "bar" })
       assert_equal({ foo: "bar" }, obj.serialize_params)
     end
 


### PR DESCRIPTION
Just noticed that a new version of Rubocop came out today. The upgrade
seemed relatively painless, so just went for it.

r? @ob-stripe
cc @stripe/api-libraries