### PR TITLE
Add `StripeError#idempotent_replayed?`

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -25,6 +25,7 @@ module Stripe
       @http_status = http_status
       @http_body = http_body
       @http_headers = http_headers || {}
+      @idempotent_replayed = @http_headers["idempotent-replayed"] == "true"
       @json_body = json_body
       @code = code
       @request_id = @http_headers["request-id"]
@@ -35,6 +36,13 @@ module Stripe
       return nil if @json_body.nil? || !@json_body.key?(:error)
 
       ErrorObject.construct_from(@json_body[:error])
+    end
+
+    # Whether the error was the result of an idempotent replay, meaning that it
+    # originally occurred on a previous request and is being replayed back
+    # because the user sent the same idempotency key for this one.
+    def idempotent_replayed?
+      @idempotent_replayed
     end
 
     def to_s

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -14,6 +14,18 @@ module Stripe
         end
       end
 
+      context "#idempotent_replayed?" do
+        should "initialize from header" do
+          e = StripeError.new("message", http_headers: { "idempotent-replayed" => "true" })
+          assert_equal true, e.idempotent_replayed?
+        end
+
+        should "be 'falsey' by default" do
+          e = StripeError.new("message")
+          refute_equal true, e.idempotent_replayed?
+        end
+      end
+
       context "#to_s" do
         should "convert to string" do
           e = StripeError.new("message")


### PR DESCRIPTION
Adds an easy accessor on `StripeError` which indicates whether the error
occurred previously, but was replayed on this request because the user
passed the same idempotency key as that original request.

Fixes #905.

r? @ob-stripe
cc @stripe/api-libraries