### PR TITLE
Lock `shoulda-context` to 2.0.0rc4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,10 @@ group :development do
   gem "mocha", "~> 0.13.2"
   gem "rack", ">= 2.0.6"
   gem "rake"
-  gem "shoulda-context"
+
+  # Update to 2.0.0 once it ships.
+  gem "shoulda-context", "2.0.0.rc4"
+
   gem "test-unit"
 
   # Version doesn't matter that much, but this one contains some fixes for Ruby


### PR DESCRIPTION
Minor changes that locks us on the 2.0.0 release candidate for
`shoulda-context`. This makes almost no difference to our test suite
except that it removes a long-standing warning for an assigned but
unused variable.

See more context here:
https://github.com/thoughtbot/shoulda-context/issues/57#issuecomment-610702695