### PR TITLE
Add new `.generate_header` method for webhooks

### DIFF
--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -39,6 +39,23 @@ module Stripe
                                 timestamped_payload)
       end
 
+      # Generates a value that would be added to a `Stripe-Signature` for a
+      # given webhook payload.
+      #
+      # Note that this isn't needed to verify webhooks in any way, and is
+      # mainly here for use in test cases (those that are both within this
+      # project and without).
+      def self.generate_header(timestamp, signature, scheme: EXPECTED_SCHEME)
+        raise ArgumentError, "timestamp should be an instance of Time" \
+          unless timestamp.is_a?(Time)
+        raise ArgumentError, "signature should be a string" \
+          unless signature.is_a?(String)
+        raise ArgumentError, "scheme should be a string" \
+          unless scheme.is_a?(String)
+
+        "t=#{timestamp.to_i},#{scheme}=#{signature}"
+      end
+
       # Extracts the timestamp and the signature(s) with the desired scheme
       # from the header
       def self.get_timestamp_and_signatures(header, scheme)


### PR DESCRIPTION
Adds a new `generate_header` method for the webhooks module, following
up #915. This method doesn't help in any way with webhook verification,
but may be useful to users in their test suites as it allows them to
easily simulate the contents of a header that Stripe might have sent.

We briefly discussed an alternative design here, but this one seems like
the best fit:
https://github.com/stripe/stripe-ruby/pull/915#issuecomment-620164654

r? @ob-stripe
cc @stripe/api-libraries