### PR TITLE
Add API resource instance methods to StripeClient

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -31,7 +31,6 @@ require "stripe/object_types"
 require "stripe/util"
 require "stripe/connection_manager"
 require "stripe/multipart_encoder"
-require "stripe/stripe_client"
 require "stripe/stripe_object"
 require "stripe/stripe_response"
 require "stripe/list_object"
@@ -40,9 +39,14 @@ require "stripe/api_resource"
 require "stripe/singleton_api_resource"
 require "stripe/webhook"
 require "stripe/stripe_configuration"
+require "stripe/client_api_operations"
 
 # Named API resources
 require "stripe/resources"
+
+# StripeClient requires API Resources to be loaded
+# due to dynamic methods defined by ClientAPIOperations
+require "stripe/stripe_client"
 
 # OAuth
 require "stripe/oauth"
@@ -61,6 +65,8 @@ module Stripe
 
   class << self
     extend Forwardable
+
+    attr_reader :configuration
 
     # User configurable options
     def_delegators :@configuration, :api_key, :api_key=

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -9,6 +9,7 @@ module Stripe
         resp, opts = execute_resource_request(:get, resource_url, filters, opts)
         obj = ListObject.construct_from(resp.data, opts)
 
+        filters ||= {}
         # set filters so that we can fetch the same limit, expansions, and
         # predicates when accessing the next and previous pages
         obj.filters = filters.dup

--- a/lib/stripe/client_api_operations.rb
+++ b/lib/stripe/client_api_operations.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Stripe
+  # Define instance methods on the including class (i.e. StripeClient)
+  # to access API resources.
+  module ClientAPIOperations
+    # Proxy object to inject the client into API resources. When included,
+    # all resources are defined as singleton methods on the client in the
+    # plural form (e.g. Stripe::Account => client.accounts).
+    class ClientProxy
+      def initialize(client:, resource: nil)
+        @client = client
+        @resource = resource
+      end
+
+      attr_reader :client
+
+      def with_client(client)
+        @client = client
+        self
+      end
+
+      # Used to either send a method to the API resource or the nested
+      # ClientProxy when a resource is namespaced. Since the method signature
+      # differs when operating on a collection versus a singular resource, it's
+      # required to perform introspection on the parameters to respect any
+      # passed in options or overrides.
+      def method_missing(method, *args)
+        super unless @resource
+        opts_pos = @resource.method(method).parameters.index(%i[opt opts])
+        normalized_opts = Stripe::Util.normalize_opts(args[opts_pos] || {})
+
+        args[opts_pos] = { client: @client }.merge(normalized_opts)
+
+        @resource.public_send(method, *args) || super
+      end
+
+      def respond_to_missing?(symbol, include_private = false)
+        super unless @resource
+        @resource.respond_to?(symbol) || super
+      end
+    end
+
+    def self.included(base)
+      base.class_eval do
+        # Sigma, unlike other namespaced API objects, is not separated by a
+        # period so we modify the object name to follow the expected convention.
+        api_resources = Stripe::Util.api_object_classes
+        sigma_class = api_resources.delete("scheduled_query_run")
+        api_resources["sigma.scheduled_query_run"] = sigma_class
+
+        # Group namespaces that have mutiple resourses
+        grouped_resources = api_resources.group_by do |key, _|
+          key.include?(".") ? key.split(".").first : key
+        end
+
+        grouped_resources.each do |resource_namespace, resources|
+          # Namespace resource names are separated with a period by convention.
+          if resources[0][0].include?(".")
+
+            # Defines the methods required for chaining calls for resources that
+            # are namespaced. A proxy object is created so that all resource
+            # methods can be defined at once.
+            #
+            # NOTE: At some point, a smarter pluralization scheme may be
+            # necessary for resource names with complex pluralization rules.
+            proxy = ClientProxy.new(client: nil)
+            resources.each do |resource_name, resource_class|
+              method_name = resource_name.split(".").last
+              proxy.define_singleton_method("#{method_name}s") do
+                ClientProxy.new(client: proxy.client, resource: resource_class)
+              end
+            end
+
+            # Defines the first method for resources that are namespaced. By
+            # convention these methods are singular. A proxy object is returned
+            # so that the client can be injected along the method chain.
+            define_method(resource_namespace) do
+              proxy.with_client(self)
+            end
+          else
+            # Defines plural methods for non-namespaced resources
+            define_method("#{resource_namespace}s".to_sym) do
+              ClientProxy.new(client: self, resource: resources[0][1])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -16,7 +16,8 @@ module Stripe
     # garbage collected or not.
     attr_reader :last_used
 
-    def initialize
+    def initialize(config = Stripe.configuration)
+      @config = config
       @active_connections = {}
       @last_used = Util.monotonic_time
 
@@ -117,17 +118,17 @@ module Stripe
       # reused Go's default for `DefaultTransport`.
       connection.keep_alive_timeout = 30
 
-      connection.open_timeout = Stripe.open_timeout
-      connection.read_timeout = Stripe.read_timeout
       if connection.respond_to?(:write_timeout=)
-        connection.write_timeout = Stripe.write_timeout
+        connection.write_timeout = @config.write_timeout
       end
+      connection.open_timeout = @config.open_timeout
+      connection.read_timeout = @config.read_timeout
 
       connection.use_ssl = uri.scheme == "https"
 
-      if Stripe.verify_ssl_certs
+      if @config.verify_ssl_certs
         connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        connection.cert_store = Stripe.ca_store
+        connection.cert_store = @config.ca_store
       else
         connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
         warn_ssl_verify_none
@@ -141,10 +142,10 @@ module Stripe
     # out those pieces to make passing them into a new connection a little less
     # ugly.
     private def proxy_parts
-      if Stripe.proxy.nil?
+      if @config.proxy.nil?
         [nil, nil, nil, nil]
       else
-        u = URI.parse(Stripe.proxy)
+        u = URI.parse(@config.proxy)
         [u.host, u.port, u.user, u.password]
       end
     end

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -7,9 +7,10 @@ module Stripe
 
       def self.execute_resource_request(method, url, params, opts)
         opts = Util.normalize_opts(opts)
-        opts[:client] ||= StripeClient.active_client
-        opts[:api_base] ||= Stripe.connect_base
+        opts[:client] ||= params[:client] || StripeClient.active_client
+        opts[:api_base] ||= opts[:client].config.connect_base
 
+        params.delete(:client)
         super(method, url, params, opts)
       end
     end
@@ -29,7 +30,8 @@ module Stripe
     end
 
     def self.authorize_url(params = {}, opts = {})
-      base = opts[:connect_base] || Stripe.connect_base
+      client = params[:client] || StripeClient.active_client
+      base = opts[:connect_base] || client.config.connect_base
 
       path = "/oauth/authorize"
       path = "/express" + path if opts[:express]

--- a/lib/stripe/object_types.rb
+++ b/lib/stripe/object_types.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/MethodLength
-
 module Stripe
   module ObjectTypes
     def self.object_names_to_classes
       {
         # data structures
         ListObject::OBJECT_NAME => ListObject,
+      }.merge(api_object_names_to_classes)
+    end
 
-        # business objects
+    def self.api_object_names_to_classes
+      {
         Account::OBJECT_NAME => Account,
         AccountLink::OBJECT_NAME => AccountLink,
         AlipayAccount::OBJECT_NAME => AlipayAccount,
@@ -97,5 +99,4 @@ module Stripe
     end
   end
 end
-
 # rubocop:enable Metrics/MethodLength

--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -136,6 +136,7 @@ module Stripe
         client_id: client_id,
         stripe_user_id: id,
       }
+      opts = @opts.merge(Util.normalize_opts(opts))
       OAuth.deauthorize(params, opts)
     end
 

--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -25,8 +25,9 @@ module Stripe
         end
       end
 
+      config = opts[:client]&.config || Stripe.configuration
       opts = {
-        api_base: Stripe.uploads_base,
+        api_base: config.uploads_base,
         content_type: MultipartEncoder::MULTIPART_FORM_DATA,
       }.merge(Util.normalize_opts(opts))
       super

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -7,6 +7,8 @@ module Stripe
   # recover both a resource a call returns as well as a response object that
   # contains information on the HTTP call.
   class StripeClient
+    include Stripe::ClientAPIOperations
+
     # A set of all known thread contexts across all threads and a mutex to
     # synchronize global access to them.
     @thread_contexts_with_connection_managers = []
@@ -14,13 +16,19 @@ module Stripe
     @last_connection_manager_gc = Util.monotonic_time
 
     # Initializes a new `StripeClient`.
-    #
-    # Takes a connection manager object for backwards compatibility only, and
-    # that use is DEPRECATED.
-    def initialize(_connection_manager = nil)
+    def initialize(config_overides = {})
       @system_profiler = SystemProfiler.new
       @last_request_metrics = nil
+      @config_overides = config_overides
     end
+
+    # Always base config off the global Stripe configuration to ensure the
+    # client picks up any changes to the config.
+    def config
+      Stripe.configuration.reverse_duplicate_merge(@config_overides)
+    end
+
+    attr_reader :options
 
     # Gets a currently active `StripeClient`. Set for the current thread when
     # `StripeClient#request` is being run so that API operations being executed
@@ -64,9 +72,9 @@ module Stripe
     end
 
     # A default connection manager for the current thread.
-    def self.default_connection_manager
+    def self.default_connection_manager(config = Stripe.configuration)
       current_thread_context.default_connection_manager ||= begin
-        connection_manager = ConnectionManager.new
+        connection_manager = ConnectionManager.new(config)
 
         @thread_contexts_with_connection_managers_mutex.synchronize do
           maybe_gc_connection_managers
@@ -80,8 +88,9 @@ module Stripe
     # Checks if an error is a problem that we should retry on. This includes
     # both socket errors that may represent an intermittent problem and some
     # special HTTP statuses.
-    def self.should_retry?(error, method:, num_retries:)
-      return false if num_retries >= Stripe.max_network_retries
+    def self.should_retry?(error,
+                           method:, num_retries:, config: Stripe.configuration)
+      return false if num_retries >= config.max_network_retries
 
       case error
       when Net::OpenTimeout, Net::ReadTimeout
@@ -127,13 +136,13 @@ module Stripe
       end
     end
 
-    def self.sleep_time(num_retries)
+    def self.sleep_time(num_retries, config: Stripe.configuration)
       # Apply exponential backoff with initial_network_retry_delay on the
       # number of num_retries so far as inputs. Do not allow the number to
       # exceed max_network_retry_delay.
       sleep_seconds = [
-        Stripe.initial_network_retry_delay * (2**(num_retries - 1)),
-        Stripe.max_network_retry_delay,
+        config.initial_network_retry_delay * (2**(num_retries - 1)),
+        config.max_network_retry_delay,
       ].min
 
       # Apply some jitter by randomizing the value in the range of
@@ -141,7 +150,7 @@ module Stripe
       sleep_seconds *= (0.5 * (1 + rand))
 
       # But never sleep less than the base sleep seconds.
-      sleep_seconds = [Stripe.initial_network_retry_delay, sleep_seconds].max
+      sleep_seconds = [config.initial_network_retry_delay, sleep_seconds].max
 
       sleep_seconds
     end
@@ -187,8 +196,8 @@ module Stripe
       raise ArgumentError, "path should be a string" \
         unless path.is_a?(String)
 
-      api_base ||= Stripe.api_base
-      api_key ||= Stripe.api_key
+      api_base ||= config.api_base
+      api_key ||= config.api_key
       params = Util.objects_to_ids(params)
 
       check_api_key!(api_key)
@@ -231,10 +240,12 @@ module Stripe
       context.query           = query
 
       http_resp = execute_request_with_rescues(method, api_base, context) do
-        self.class.default_connection_manager.execute_request(method, url,
-                                                              body: body,
-                                                              headers: headers,
-                                                              query: query)
+        self.class
+            .default_connection_manager(config)
+            .execute_request(method, url,
+                             body: body,
+                             headers: headers,
+                             query: query)
       end
 
       begin
@@ -246,11 +257,19 @@ module Stripe
       # If being called from `StripeClient#request`, put the last response in
       # thread-local memory so that it can be returned to the user. Don't store
       # anything otherwise so that we don't leak memory.
-      if self.class.current_thread_context.last_responses&.key?(object_id)
-        self.class.current_thread_context.last_responses[object_id] = resp
-      end
+      store_last_response(object_id, resp)
 
       [resp, api_key]
+    end
+
+    def store_last_response(object_id, resp)
+      return unless last_response_has_key?(object_id)
+
+      self.class.current_thread_context.last_responses[object_id] = resp
+    end
+
+    def last_response_has_key?(object_id)
+      self.class.current_thread_context.last_responses&.key?(object_id)
     end
 
     #
@@ -397,7 +416,7 @@ module Stripe
     end
 
     private def api_url(url = "", api_base = nil)
-      (api_base || Stripe.api_base) + url
+      (api_base || config.api_base) + url
     end
 
     private def check_api_key!(api_key)
@@ -471,7 +490,7 @@ module Stripe
         notify_request_end(context, request_duration, http_status,
                            num_retries, user_data)
 
-        if Stripe.enable_telemetry? && context.request_id
+        if config.enable_telemetry? && context.request_id
           request_duration_ms = (request_duration * 1000).to_i
           @last_request_metrics =
             StripeRequestMetrics.new(context.request_id, request_duration_ms)
@@ -498,9 +517,12 @@ module Stripe
         notify_request_end(context, request_duration, http_status, num_retries,
                            user_data)
 
-        if self.class.should_retry?(e, method: method, num_retries: num_retries)
+        if self.class.should_retry?(e,
+                                    method: method,
+                                    num_retries: num_retries,
+                                    config: config)
           num_retries += 1
-          sleep self.class.sleep_time(num_retries)
+          sleep self.class.sleep_time(num_retries, config: config)
           retry
         end
 
@@ -622,7 +644,8 @@ module Stripe
                      error_param: error_data[:param],
                      error_type: error_data[:type],
                      idempotency_key: context.idempotency_key,
-                     request_id: context.request_id)
+                     request_id: context.request_id,
+                     config: config)
 
       # The standard set of arguments that can be used to initialize most of
       # the exceptions.
@@ -671,7 +694,8 @@ module Stripe
                      error_code: error_code,
                      error_description: description,
                      idempotency_key: context.idempotency_key,
-                     request_id: context.request_id)
+                     request_id: context.request_id,
+                     config: config)
 
       args = {
         http_status: resp.http_status, http_body: resp.http_body,
@@ -703,7 +727,8 @@ module Stripe
       Util.log_error("Stripe network error",
                      error_message: error.message,
                      idempotency_key: context.idempotency_key,
-                     request_id: context.request_id)
+                     request_id: context.request_id,
+                     config: config)
 
       errors, message = NETWORK_ERROR_MESSAGES_MAP.detect do |(e, _)|
         error.is_a?(e)
@@ -714,7 +739,7 @@ module Stripe
           "with Stripe. Please let us know at support@stripe.com."
       end
 
-      api_base ||= Stripe.api_base
+      api_base ||= config.api_base
       message = message % api_base
 
       message += " Request was retried #{num_retries} times." if num_retries > 0
@@ -735,7 +760,7 @@ module Stripe
         "Content-Type" => "application/x-www-form-urlencoded",
       }
 
-      if Stripe.enable_telemetry? && !@last_request_metrics.nil?
+      if config.enable_telemetry? && !@last_request_metrics.nil?
         headers["X-Stripe-Client-Telemetry"] = JSON.generate(
           last_request_metrics: @last_request_metrics.payload
         )
@@ -743,12 +768,12 @@ module Stripe
 
       # It is only safe to retry network failures on post and delete
       # requests if we add an Idempotency-Key header
-      if %i[post delete].include?(method) && Stripe.max_network_retries > 0
+      if %i[post delete].include?(method) && config.max_network_retries > 0
         headers["Idempotency-Key"] ||= SecureRandom.uuid
       end
 
-      headers["Stripe-Version"] = Stripe.api_version if Stripe.api_version
-      headers["Stripe-Account"] = Stripe.stripe_account if Stripe.stripe_account
+      headers["Stripe-Version"] = config.api_version if config.api_version
+      headers["Stripe-Account"] = config.stripe_account if config.stripe_account
 
       user_agent = @system_profiler.user_agent
       begin
@@ -772,11 +797,13 @@ module Stripe
                     idempotency_key: context.idempotency_key,
                     method: context.method,
                     num_retries: num_retries,
-                    path: context.path)
+                    path: context.path,
+                    config: config)
       Util.log_debug("Request details",
                      body: context.body,
                      idempotency_key: context.idempotency_key,
-                     query: context.query)
+                     query: context.query,
+                     config: config)
     end
 
     private def log_response(context, request_start, status, body)
@@ -788,11 +815,13 @@ module Stripe
                     method: context.method,
                     path: context.path,
                     request_id: context.request_id,
-                    status: status)
+                    status: status,
+                    config: config)
       Util.log_debug("Response details",
                      body: body,
                      idempotency_key: context.idempotency_key,
-                     request_id: context.request_id)
+                     request_id: context.request_id,
+                     config: config)
 
       return unless context.request_id
 
@@ -800,7 +829,8 @@ module Stripe
                      idempotency_key: context.idempotency_key,
                      request_id: context.request_id,
                      url: Util.request_id_dashboard_url(context.request_id,
-                                                        context.api_key))
+                                                        context.api_key),
+                     config: config)
     end
 
     private def log_response_error(context, request_start, error)
@@ -810,7 +840,8 @@ module Stripe
                      error_message: error.message,
                      idempotency_key: context.idempotency_key,
                      method: context.method,
-                     path: context.path)
+                     path: context.path,
+                     config: config)
     end
 
     # RequestLogContext stores information about a request that's begin made so

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -27,7 +27,6 @@ module Stripe
   class StripeConfiguration
     attr_accessor :api_key
     attr_accessor :api_version
-    attr_accessor :client_id
     attr_accessor :enable_telemetry
     attr_accessor :logger
     attr_accessor :stripe_account
@@ -99,6 +98,14 @@ module Stripe
 
     def max_network_retries=(val)
       @max_network_retries = val.to_i
+    end
+
+    def max_network_retry_delay=(val)
+      @max_network_retry_delay = val.to_i
+    end
+
+    def initial_network_retry_delay=(val)
+      @initial_network_retry_delay = val.to_i
     end
 
     def open_timeout=(open_timeout)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -39,8 +39,14 @@ module Stripe
       end
     end
 
+    # Returns a hash of all Stripe object classes.
     def self.object_classes
       @object_classes ||= Stripe::ObjectTypes.object_names_to_classes
+    end
+
+    # Returns a hash containling only Stripe API object classes.
+    def self.api_object_classes
+      @api_object_classes ||= ::Stripe::ObjectTypes.api_object_names_to_classes
     end
 
     def self.object_name_matches_class?(object_name, klass)
@@ -76,24 +82,30 @@ module Stripe
     end
 
     def self.log_error(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_ERROR
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_ERROR
         log_internal(message, data, color: :cyan, level: Stripe::LEVEL_ERROR,
                                     logger: Stripe.logger, out: $stderr)
       end
     end
 
     def self.log_info(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_INFO
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_INFO
         log_internal(message, data, color: :cyan, level: Stripe::LEVEL_INFO,
                                     logger: Stripe.logger, out: $stdout)
       end
     end
 
     def self.log_debug(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_DEBUG
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_DEBUG
         log_internal(message, data, color: :blue, level: Stripe::LEVEL_DEBUG,
                                     logger: Stripe.logger, out: $stdout)
       end

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -93,6 +93,20 @@ module Stripe
           .to_return(body: JSON.generate("stripe_user_id" => account.id))
         account.deauthorize("ca_1234", "sk_test_1234")
       end
+
+      context "when the caller is a StripeClient" do
+        should "use the StripeClient options" do
+          client = Stripe::StripeClient.new(connect_base: "https://other.stripe.com")
+          account = client.accounts.retrieve("acct_123")
+
+          stub_request(:post, "https://other.stripe.com/oauth/deauthorize")
+            .with(body: { "client_id" => "ca_1234", "stripe_user_id" => account.id })
+            .to_return(body: JSON.generate("stripe_user_id" => account.id))
+          resp = account.deauthorize("ca_1234", "sk_test_1234")
+
+          assert_equal(account.id, resp.stripe_user_id)
+        end
+      end
     end
 
     context "#legal_entity=" do

--- a/test/stripe/file_test.rb
+++ b/test/stripe/file_test.rb
@@ -72,6 +72,21 @@ module Stripe
         end
         assert_equal "file must respond to `#read`", e.message
       end
+
+      context "when the caller is a StripeClient" do
+        should "permit the StripeClient to set the `api_base`" do
+          client = StripeClient.new(uploads_base: Stripe.uploads_base)
+          Stripe.configuration.stubs(:uploads_base).returns("old")
+
+          file = client.files.create(
+            purpose: "dispute_evidence",
+            file: ::File.new(__FILE__),
+            file_link_data: { create: true }
+          )
+          assert_requested :post, "#{client.config.uploads_base}/v1/files"
+          assert file.is_a?(Stripe::File)
+        end
+      end
     end
 
     should "be deserializable when `object=file`" do

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -20,6 +20,7 @@ module Stripe
         assert_equal "https://api.stripe.com", config.api_base
         assert_equal "https://connect.stripe.com", config.connect_base
         assert_equal "https://files.stripe.com", config.uploads_base
+        assert_equal nil, config.api_version
       end
 
       should "allow for overrides when a block is passed" do
@@ -41,7 +42,7 @@ module Stripe
           c.open_timeout = 100
         end
 
-        duped_config = config.reverse_duplicate_merge(read_timeout: 500)
+        duped_config = config.reverse_duplicate_merge(read_timeout: 500, api_version: "2018-08-02")
 
         assert_equal config.open_timeout, duped_config.open_timeout
         assert_equal 500, duped_config.read_timeout
@@ -54,6 +55,24 @@ module Stripe
 
         config.max_network_retries = "10"
         assert_equal 10, config.max_network_retries
+      end
+    end
+
+    context "#max_network_retry_delay=" do
+      should "coerce the option into an integer" do
+        config = Stripe::StripeConfiguration.setup
+
+        config.max_network_retry_delay = "10"
+        assert_equal 10, config.max_network_retry_delay
+      end
+    end
+
+    context "#initial_network_retry_delay=" do
+      should "coerce the option into an integer" do
+        config = Stripe::StripeConfiguration.setup
+
+        config.initial_network_retry_delay = "10"
+        assert_equal 10, config.initial_network_retry_delay
       end
     end
 

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -114,6 +114,11 @@ class StripeTest < Test::Unit::TestCase
       assert_equal "https://other.stripe.com", Stripe.api_base
     end
 
+    should "allow api_version to be configured" do
+      Stripe.api_version = "2018-02-28"
+      assert_equal "2018-02-28", Stripe.api_version
+    end
+
     should "allow connect_base to be configured" do
       Stripe.connect_base = "https://other.stripe.com"
       assert_equal "https://other.stripe.com", Stripe.connect_base


### PR DESCRIPTION
This change introduces a proof-of-concept to add convenience methods to
access API resources through a StripeClient for per-client
configuration. This first iteration only allows for the `api_key` to be
configured but can be extended to allow other options such as
`stripe_version`, which should solve #872.

The primary workhorse for this feature is a new module called
`Stripe::ClientAPIOperations` that defines instance methods on
`StripeClient` when it is included. A `ClientProxy` is used to send any
method calls to an API resource with the instantiated client injected.
There are a few noteworthy aspects of this approach:

- Many resources are namespaced, which introduces a unique challenge
  when it comes to method chaining calls (e.g.
  client.issuing.authorizations).  In order to handle those cases, we
  create a `ClientProxy` object for the root namespace (e.g., "issuing")
  and define all resource methods (e.g. "authorizations") at once to
  avoid re-defining the proxy object when there are multiple resources
  per namespace.

- Sigma deviates from other namespaced API resources and does not have
  an `OBJECT_NAME` separated by a period. We account for that nuance
  directly.

- `method_missing` is substantially slower than direct calls. Therefore,
  methods are defined where possible but `method_missing` is still used
  at the last step when delegating resource methods to the actual
  resource.