### PR TITLE
Update minimum stripe-mock version to 0.94.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.90.0
+    - STRIPE_MOCK_VERSION=0.94.0
 
 cache:
   directories:

--- a/test/stripe/account_link_test.rb
+++ b/test/stripe/account_link_test.rb
@@ -7,9 +7,9 @@ module Stripe
     should "be creatable" do
       link = Stripe::AccountLink.create(
         account: "acct_123",
-        failure_url: "https://stripe.com/failure",
-        success_url: "https://stripe.com/success",
-        type: "custom_account_verification"
+        refresh_url: "https://stripe.com/refresh",
+        return_url: "https://stripe.com/return",
+        type: "account_onboarding"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/account_links"
       assert link.is_a?(Stripe::AccountLink)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require ::File.expand_path("test_data", __dir__)
 require ::File.expand_path("stripe_mock", __dir__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.90.0"
+MOCK_MINIMUM_VERSION = "0.94.0"
 MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
The params for AccountLink changed in `v0.93.0`, which will cause the test suite to fail unless `stripe-mock` is pinned to an earlier version.

Fixes #934