### PR TITLE
Add support for the Issuing Dispute Submit API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 env:
   global:
     # If changing this number, please also change it in `test/test_helper.rb`.
-    - STRIPE_MOCK_VERSION=0.95.0
+    - STRIPE_MOCK_VERSION=0.98.0
 
 cache:
   directories:

--- a/lib/stripe/resources/issuing/dispute.rb
+++ b/lib/stripe/resources/issuing/dispute.rb
@@ -9,6 +9,17 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "issuing.dispute"
+
+      custom_method :submit, http_verb: :post
+
+      def submit(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: resource_url + "/submit",
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -111,15 +111,15 @@ module Stripe
     end
 
     should "send expand when fetching through ListObject" do
-      stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
-        .to_return(body: JSON.generate(customer_fixture))
+      stub_request(:get, "#{Stripe.api_base}/v1/charges/ch_123")
+        .to_return(body: JSON.generate(charge_fixture))
 
-      stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123/sources/cc_test_card")
-        .with(query: { "expand" => ["customer"] })
-        .to_return(body: JSON.generate(customer_fixture))
+      stub_request(:get, "#{Stripe.api_base}/v1/charges/ch_123/refunds/re_123")
+        .with(query: { "expand" => ["balance_transaction"] })
+        .to_return(body: JSON.generate(charge_fixture))
 
-      customer = Stripe::Customer.retrieve("cus_123")
-      customer.sources.retrieve(id: "cc_test_card", expand: [:customer])
+      charge = Stripe::Charge.retrieve("ch_123")
+      charge.refunds.retrieve(id: "re_123", expand: [:balance_transaction])
     end
 
     context "when specifying per-object credentials" do

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -5,6 +5,12 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CustomerCardTest < Test::Unit::TestCase
     setup do
+      # Unfortunately, the OpenAPI spec has an issue where the sources list has the wrong
+      # url so we need to mock this call instead.
+      customer_json = { id: "cus_123", object: "customer", sources: { object: "list", data: [], has_more: true, url: "/v1/customers/cus_123/sources" } }
+      stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
+        .to_return(body: JSON.generate(customer_json))
+
       @customer = Stripe::Customer.retrieve("cus_123")
     end
 

--- a/test/stripe/issuing/dispute_test.rb
+++ b/test/stripe/issuing/dispute_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Issuing
     class DisputeTest < Test::Unit::TestCase
       should "be creatable" do
-        dispute = Stripe::Issuing::Dispute.create
+        dispute = Stripe::Issuing::Dispute.create(transaction: "ipi_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
@@ -29,6 +29,25 @@ module Stripe
         dispute = Stripe::Issuing::Dispute.update("ich_123", {})
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes/ich_123"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
+      end
+
+      context "#submit" do
+        should "submit the dispute" do
+          dispute = Stripe::Issuing::Dispute.retrieve("idp_123")
+          dispute = dispute.submit
+          assert_requested :post,
+                           "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
+          assert dispute.is_a?(Stripe::Issuing::Dispute)
+        end
+      end
+
+      context ".submit" do
+        should "submit the dispute" do
+          dispute = Stripe::Issuing::Dispute.submit("idp_123")
+          assert_requested :post,
+                           "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
+          assert dispute.is_a?(Stripe::Issuing::Dispute)
+        end
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require ::File.expand_path("test_data", __dir__)
 require ::File.expand_path("stripe_mock", __dir__)
 
 # If changing this number, please also change it in `.travis.yml`.
-MOCK_MINIMUM_VERSION = "0.95.0"
+MOCK_MINIMUM_VERSION = "0.98.0"
 MOCK_PORT = Stripe::StripeMock.start
 
 # Disable all real network connections except those that are outgoing to


### PR DESCRIPTION
The change is to add the new `/v1/issuing/disputes/idp_123/submit` endpoint but the tests needed to be fixed due to an ongoing stripe-mock issue around includable sub-lists.

Assigning to Brandur for familiarity with stripe-ruby and the current bug discussed in stripe-mock 

r? @brandur-stripe 
cc @stripe/api-libraries 