### PR TITLE
Allow client_id configuration on instance config

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -79,13 +79,12 @@ module Stripe
     def_delegators :@configuration, :logger, :logger=
     def_delegators :@configuration, :max_network_retries, :max_network_retries=
     def_delegators :@configuration, :enable_telemetry=, :enable_telemetry?
+    def_delegators :@configuration, :client_id=, :client_id
 
     # Internal configurations
     def_delegators :@configuration, :max_network_retry_delay
     def_delegators :@configuration, :initial_network_retry_delay
     def_delegators :@configuration, :ca_store
-
-    attr_accessor :client_id
   end
 
   # Gets the application for a plugin that's identified some. See


### PR DESCRIPTION
While (re)working a PR to support `StripeClient` instances, I realized that it'd likely be desirable to set the `client_id` on the instance. Otherwise, users would always have to set the `client_id` on `Stripe` despite other configurations being provided when initializing a `StripeClient`.

Turns out, it's already set up and tested, but the `attr_accessor` on `Stripe` was still lingering;

Mostly breaking this out so the the `StripeClient` PR isn't as noisy :smile: