### PR TITLE
Bump version of rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
   Exclude:
     # brandur: Exclude ephmeral script-like files that I use to try and


### PR DESCRIPTION
Version 2.3 (in rubocop.yaml) is no longer supported.  [2.4 seems to operate fine](https://console.muse.dev/result/TomMD/stripe-ruby/01EPG0C0YX4Y3BT71JTTDE3T07), so here's a PR.