### PR TITLE
Add API resource instance methods to StripeClient

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -31,7 +31,6 @@ require "stripe/object_types"
 require "stripe/util"
 require "stripe/connection_manager"
 require "stripe/multipart_encoder"
-require "stripe/stripe_client"
 require "stripe/stripe_object"
 require "stripe/stripe_response"
 require "stripe/list_object"
@@ -40,9 +39,14 @@ require "stripe/api_resource"
 require "stripe/singleton_api_resource"
 require "stripe/webhook"
 require "stripe/stripe_configuration"
+require "stripe/client_api_operations"
 
 # Named API resources
 require "stripe/resources"
+
+# StripeClient requires API Resources to be loaded
+# due to dynamic methods defined by ClientAPIOperations
+require "stripe/stripe_client"
 
 # OAuth
 require "stripe/oauth"

--- a/lib/stripe/api_operations/list.rb
+++ b/lib/stripe/api_operations/list.rb
@@ -11,7 +11,7 @@ module Stripe
 
         # set filters so that we can fetch the same limit, expansions, and
         # predicates when accessing the next and previous pages
-        obj.filters = filters.dup
+        obj.filters = filters.dup unless filters.nil?
         obj
       end
     end

--- a/lib/stripe/client_api_operations.rb
+++ b/lib/stripe/client_api_operations.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Stripe
+  # Define instance methods on the including class (i.e. StripeClient)
+  # to access API resources.
+  module ClientAPIOperations
+    # Proxy object to inject the client into API resources. When included,
+    # all resources are defined as singleton methods on the client in the
+    # plural form (e.g. Stripe::Account => client.accounts).
+    class ClientProxy
+      def initialize(client:, resource: nil)
+        @client = client
+        @resource = resource
+      end
+
+      attr_reader :client
+
+      def with_client(client)
+        @client = client
+        self
+      end
+
+      # Used to either send a method to the API resource or the nested
+      # ClientProxy when a resource is namespaced.
+      def method_missing(method, *args)
+        super unless @resource.respond_to?(method)
+
+        update_args_with_client!(method, args)
+
+        @resource.public_send(method, *args)
+      end
+
+      def respond_to_missing?(symbol, include_private = false)
+        super unless @resource
+        @resource.respond_to?(symbol) || super
+      end
+
+      # Since the method signature differs when operating on a collection versus
+      # a singular resource, it's required to perform introspection on the
+      # parameters to respect any passed in options or overrides.
+      #
+      # Two noteworthy caveats:
+      # 1) Does not merge into methods that use `_opts` as that means
+      #    the param is unused.
+      # 2) Preserves incorrect options (e.g. passing nil) so that APIResource
+      #    can handle errors.
+      def update_args_with_client!(method, args)
+        opts_pos = @resource.method(method).parameters.index(%i[opt opts])
+
+        return unless opts_pos
+
+        opts = opts_pos >= args.length ? {} : args[opts_pos]
+
+        normalized_opts = Stripe::Util.normalize_opts(opts)
+        args[opts_pos] = { client: @client }.merge(normalized_opts)
+      end
+    end
+
+    def self.included(base)
+      base.class_eval do
+        # Sigma, unlike other namespaced API objects, is not separated by a
+        # period so we modify the object name to follow the expected convention.
+        api_resources = Stripe::Util.api_object_classes
+        sigma_class = api_resources.delete("scheduled_query_run")
+        api_resources["sigma.scheduled_query_run"] = sigma_class
+
+        # Update `invoiceitems` to match snake case convention
+        invoice_item_class = api_resources.delete("invoiceitem")
+        api_resources["invoice_item"] = invoice_item_class
+
+        # Group namespaces that have mutiple resourses
+        grouped_resources = api_resources.group_by do |key, _|
+          key.include?(".") ? key.split(".").first : key
+        end
+
+        grouped_resources.each do |resource_namespace, resources|
+          # Namespace resource names are separated with a period by convention.
+          if resources[0][0].include?(".")
+
+            # Defines the methods required for chaining calls for resources that
+            # are namespaced. A proxy object is created so that all resource
+            # methods can be defined at once.
+            #
+            # NOTE: At some point, a smarter pluralization scheme may be
+            # necessary for resource names with complex pluralization rules.
+            proxy = ClientProxy.new(client: nil)
+            resources.each do |resource_name, resource_class|
+              method_name = resource_name.split(".").last
+              proxy.define_singleton_method("#{method_name}s") do
+                ClientProxy.new(client: proxy.client, resource: resource_class)
+              end
+            end
+
+            # Defines the first method for resources that are namespaced. By
+            # convention these methods are singular. A proxy object is returned
+            # so that the client can be injected along the method chain.
+            define_method(resource_namespace) do
+              proxy.with_client(self)
+            end
+          else
+            # Defines plural methods for non-namespaced resources
+            define_method("#{resource_namespace}s".to_sym) do
+              ClientProxy.new(client: self, resource: resources[0][1])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe/client_api_operations.rb
+++ b/lib/stripe/client_api_operations.rb
@@ -80,13 +80,10 @@ module Stripe
             # Defines the methods required for chaining calls for resources that
             # are namespaced. A proxy object is created so that all resource
             # methods can be defined at once.
-            #
-            # NOTE: At some point, a smarter pluralization scheme may be
-            # necessary for resource names with complex pluralization rules.
             proxy = ClientProxy.new(client: nil)
             resources.each do |resource_name, resource_class|
               method_name = resource_name.split(".").last
-              proxy.define_singleton_method("#{method_name}s") do
+              proxy.define_singleton_method(method_name) do
                 ClientProxy.new(client: proxy.client, resource: resource_class)
               end
             end
@@ -99,7 +96,7 @@ module Stripe
             end
           else
             # Defines plural methods for non-namespaced resources
-            define_method("#{resource_namespace}s".to_sym) do
+            define_method(resource_namespace.to_sym) do
               ClientProxy.new(client: self, resource: resources[0][1])
             end
           end

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -10,7 +10,6 @@ module Stripe
         opts[:client] ||= opts[:client] || StripeClient.active_client
         opts[:api_base] ||= opts[:client].config.connect_base
 
-        opts.delete(:client)
         super(method, url, params, opts)
       end
     end

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -10,6 +10,7 @@ module Stripe
         opts[:client] ||= opts[:client] || StripeClient.active_client
         opts[:api_base] ||= opts[:client].config.connect_base
 
+        opts.delete(:client)
         super(method, url, params, opts)
       end
     end

--- a/lib/stripe/object_types.rb
+++ b/lib/stripe/object_types.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/MethodLength
-
 module Stripe
   module ObjectTypes
     def self.object_names_to_classes
       {
         # data structures
         ListObject::OBJECT_NAME => ListObject,
+      }.merge(api_object_names_to_classes)
+    end
 
-        # business objects
+    def self.api_object_names_to_classes
+      {
         Account::OBJECT_NAME => Account,
         AccountLink::OBJECT_NAME => AccountLink,
         AlipayAccount::OBJECT_NAME => AlipayAccount,
@@ -98,5 +100,4 @@ module Stripe
     end
   end
 end
-
 # rubocop:enable Metrics/MethodLength

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -7,6 +7,8 @@ module Stripe
   # recover both a resource a call returns as well as a response object that
   # contains information on the HTTP call.
   class StripeClient
+    include Stripe::ClientAPIOperations
+
     # A set of all known thread contexts across all threads and a mutex to
     # synchronize global access to them.
     @thread_contexts_with_connection_managers = Set.new

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -39,8 +39,14 @@ module Stripe
       end
     end
 
+    # Returns a hash of all Stripe object classes.
     def self.object_classes
       @object_classes ||= Stripe::ObjectTypes.object_names_to_classes
+    end
+
+    # Returns a hash containling only Stripe API object classes.
+    def self.api_object_classes
+      @api_object_classes ||= ::Stripe::ObjectTypes.api_object_names_to_classes
     end
 
     def self.object_name_matches_class?(object_name, klass)

--- a/test/stripe/account_link_test.rb
+++ b/test/stripe/account_link_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class AccountLinkTest < Test::Unit::TestCase
     should "be creatable" do
-      link = Stripe::AccountLink.create(
+      link = StripeClient.new.account_links.create(
         account: "acct_123",
         refresh_url: "https://stripe.com/refresh",
         return_url: "https://stripe.com/return",

--- a/test/stripe/account_link_test.rb
+++ b/test/stripe/account_link_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class AccountLinkTest < Test::Unit::TestCase
     should "be creatable" do
-      link = StripeClient.new.account_links.create(
+      link = StripeClient.new.account_link.create(
         account: "acct_123",
         refresh_url: "https://stripe.com/refresh",
         return_url: "https://stripe.com/return",

--- a/test/stripe/account_test.rb
+++ b/test/stripe/account_test.rb
@@ -5,26 +5,26 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class AccountTest < Test::Unit::TestCase
     should "be listable" do
-      accounts = StripeClient.new.accounts.list
+      accounts = StripeClient.new.account.list
       assert_requested :get, "#{Stripe.api_base}/v1/accounts"
       assert accounts.data.is_a?(Array)
       assert accounts.data[0].is_a?(Stripe::Account)
     end
 
     should "be retrievable using singular endpoint" do
-      account = StripeClient.new.accounts.retrieve
+      account = StripeClient.new.account.retrieve
       assert_requested :get, "#{Stripe.api_base}/v1/account"
       assert account.is_a?(Stripe::Account)
     end
 
     should "be retrievable using plural endpoint" do
-      account = StripeClient.new.accounts.retrieve("acct_123")
+      account = StripeClient.new.account.retrieve("acct_123")
       assert_requested :get, "#{Stripe.api_base}/v1/accounts/acct_123"
       assert account.is_a?(Stripe::Account)
     end
 
     should "be rejectable" do
-      account = StripeClient.new.accounts.retrieve("acct_foo")
+      account = StripeClient.new.account.retrieve("acct_foo")
       account = account.reject(reason: "fraud")
       assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{account.id}/reject"
       assert account.is_a?(Stripe::Account)
@@ -32,34 +32,34 @@ module Stripe
 
     context ".reject" do
       should "reject the account" do
-        account = StripeClient.new.accounts.reject("acct_foo", reason: "fraud")
+        account = StripeClient.new.account.reject("acct_foo", reason: "fraud")
         assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{account.id}/reject"
         assert account.is_a?(Stripe::Account)
       end
     end
 
     should "be creatable" do
-      account = StripeClient.new.accounts.create(metadata: {}, type: "standard")
+      account = StripeClient.new.account.create(metadata: {}, type: "standard")
       assert_requested :post, "#{Stripe.api_base}/v1/accounts"
       assert account.is_a?(Stripe::Account)
     end
 
     should "be saveable" do
-      account = StripeClient.new.accounts.retrieve("acct_123")
+      account = StripeClient.new.account.retrieve("acct_123")
       account.metadata["key"] = "value"
       account.save
       assert_requested :post, "#{Stripe.api_base}/v1/accounts/#{account.id}"
     end
 
     should "be updateable" do
-      account = StripeClient.new.accounts.update("acct_123", metadata: { foo: "bar" })
+      account = StripeClient.new.account.update("acct_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/accounts/acct_123"
       assert account.is_a?(Stripe::Account)
     end
 
     context "#delete" do
       should "be deletable" do
-        account = StripeClient.new.accounts.retrieve("acct_123")
+        account = StripeClient.new.account.retrieve("acct_123")
         account = account.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/accounts/#{account.id}"
         assert account.is_a?(Stripe::Account)
@@ -68,14 +68,14 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        account = StripeClient.new.accounts.delete("acct_123")
+        account = StripeClient.new.account.delete("acct_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/accounts/acct_123"
         assert account.is_a?(Stripe::Account)
       end
     end
 
     should "be able to list Persons" do
-      account = StripeClient.new.accounts.retrieve("acct_123")
+      account = StripeClient.new.account.retrieve("acct_123")
       persons = account.persons
       assert_requested :get, "#{Stripe.api_base}/v1/accounts/acct_123/persons"
       assert persons.data.is_a?(Array)
@@ -84,7 +84,7 @@ module Stripe
 
     context "#deauthorize" do
       should "deauthorize an account" do
-        account = StripeClient.new.accounts.retrieve("acct_123")
+        account = StripeClient.new.account.retrieve("acct_123")
 
         # Unfortunately, the OpenAPI spec doesn't yet cover anything under the
         # Connect endpoints, so for just stub this out with Webmock.
@@ -97,7 +97,7 @@ module Stripe
       context "when the caller is a StripeClient" do
         should "use the StripeClient options" do
           client = Stripe::StripeClient.new(connect_base: "https://other.stripe.com")
-          account = client.accounts.retrieve("acct_123")
+          account = client.account.retrieve("acct_123")
 
           stub_request(:post, "https://other.stripe.com/oauth/deauthorize")
             .with(body: { "client_id" => "ca_1234", "stripe_user_id" => account.id })
@@ -111,7 +111,7 @@ module Stripe
 
     context "#legal_entity=" do
       should "disallow direct overrides" do
-        account = StripeClient.new.accounts.construct_from(
+        account = StripeClient.new.account.construct_from(
           id: "acct_123",
           legal_entity: {
             first_name: "name",
@@ -266,7 +266,7 @@ module Stripe
 
     context "#retrieve_capability" do
       should "retrieve a capability" do
-        capability = StripeClient.new.accounts.retrieve_capability(
+        capability = StripeClient.new.account.retrieve_capability(
           "acct_123",
           "acap_123"
         )
@@ -277,7 +277,7 @@ module Stripe
 
     context "#update_capability" do
       should "update a capability" do
-        capability = StripeClient.new.accounts.update_capability(
+        capability = StripeClient.new.account.update_capability(
           "acct_123",
           "acap_123",
           requested: true
@@ -289,7 +289,7 @@ module Stripe
 
     context "#list_capabilities" do
       should "list the account's external accounts" do
-        capabilities = StripeClient.new.accounts.list_capabilities(
+        capabilities = StripeClient.new.account.list_capabilities(
           "acct_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/accounts/acct_123/capabilities"
@@ -300,7 +300,7 @@ module Stripe
 
     context "#create_external_account" do
       should "create an external account" do
-        external_account = StripeClient.new.accounts.create_external_account(
+        external_account = StripeClient.new.account.create_external_account(
           "acct_123",
           external_account: "btok_123"
         )
@@ -311,7 +311,7 @@ module Stripe
 
     context "#retrieve_external_account" do
       should "retrieve an external account" do
-        external_account = StripeClient.new.accounts.retrieve_external_account(
+        external_account = StripeClient.new.account.retrieve_external_account(
           "acct_123",
           "ba_123"
         )
@@ -322,7 +322,7 @@ module Stripe
 
     context "#update_external_account" do
       should "update an external account" do
-        external_account = StripeClient.new.accounts.update_external_account(
+        external_account = StripeClient.new.account.update_external_account(
           "acct_123",
           "ba_123",
           metadata: { foo: "bar" }
@@ -334,7 +334,7 @@ module Stripe
 
     context "#delete_external_account" do
       should "delete an external_account" do
-        external_account = StripeClient.new.accounts.delete_external_account(
+        external_account = StripeClient.new.account.delete_external_account(
           "acct_123",
           "ba_123"
         )
@@ -346,7 +346,7 @@ module Stripe
 
     context "#list_external_accounts" do
       should "list the account's external accounts" do
-        external_accounts = StripeClient.new.accounts.list_external_accounts(
+        external_accounts = StripeClient.new.account.list_external_accounts(
           "acct_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/accounts/acct_123/external_accounts"
@@ -357,7 +357,7 @@ module Stripe
 
     context "#create_login_link" do
       should "create a login link" do
-        login_link = StripeClient.new.accounts.create_login_link(
+        login_link = StripeClient.new.account.create_login_link(
           "acct_123"
         )
         assert_requested :post, "#{Stripe.api_base}/v1/accounts/acct_123/login_links"
@@ -367,7 +367,7 @@ module Stripe
 
     context "#create_person" do
       should "create a person" do
-        person = StripeClient.new.accounts.create_person(
+        person = StripeClient.new.account.create_person(
           "acct_123",
           first_name: "John",
           last_name: "Doe"
@@ -379,7 +379,7 @@ module Stripe
 
     context "#retrieve_person" do
       should "retrieve a person" do
-        person = StripeClient.new.accounts.retrieve_person(
+        person = StripeClient.new.account.retrieve_person(
           "acct_123",
           "person_123"
         )
@@ -390,7 +390,7 @@ module Stripe
 
     context "#update_person" do
       should "update a person" do
-        person = StripeClient.new.accounts.update_person(
+        person = StripeClient.new.account.update_person(
           "acct_123",
           "person_123",
           first_name: "John"
@@ -402,7 +402,7 @@ module Stripe
 
     context "#delete_person" do
       should "delete an person" do
-        person = StripeClient.new.accounts.delete_person(
+        person = StripeClient.new.account.delete_person(
           "acct_123",
           "person_123"
         )
@@ -414,7 +414,7 @@ module Stripe
 
     context "#list_persons" do
       should "list the account's external accounts" do
-        persons = StripeClient.new.accounts.list_persons(
+        persons = StripeClient.new.account.list_persons(
           "acct_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/accounts/acct_123/persons"

--- a/test/stripe/alipay_account_test.rb
+++ b/test/stripe/alipay_account_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class AlipayAccountTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        alipay_account = StripeClient.new.alipay_accounts.construct_from(
+        alipay_account = StripeClient.new.alipay_account.construct_from(
           id: "aliacc_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        alipay_account = StripeClient.new.alipay_accounts.construct_from(id: "aliacc_123")
+        alipay_account = StripeClient.new.alipay_account.construct_from(id: "aliacc_123")
         assert_raises NotImplementedError do
           alipay_account.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        StripeClient.new.alipay_accounts.retrieve("aliacc_123")
+        StripeClient.new.alipay_account.retrieve("aliacc_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        StripeClient.new.alipay_accounts.update("aliacc_123", {})
+        StripeClient.new.alipay_account.update("aliacc_123", {})
       end
     end
   end

--- a/test/stripe/alipay_account_test.rb
+++ b/test/stripe/alipay_account_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class AlipayAccountTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        alipay_account = Stripe::AlipayAccount.construct_from(
+        alipay_account = StripeClient.new.alipay_accounts.construct_from(
           id: "aliacc_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        alipay_account = Stripe::AlipayAccount.construct_from(id: "aliacc_123")
+        alipay_account = StripeClient.new.alipay_accounts.construct_from(id: "aliacc_123")
         assert_raises NotImplementedError do
           alipay_account.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        Stripe::AlipayAccount.retrieve("aliacc_123")
+        StripeClient.new.alipay_accounts.retrieve("aliacc_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        Stripe::AlipayAccount.update("aliacc_123", {})
+        StripeClient.new.alipay_accounts.update("aliacc_123", {})
       end
     end
   end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -46,26 +46,26 @@ module Stripe
     end
 
     should "creating a new APIResource should not fetch over the network" do
-      StripeClient.new.customers.new("someid")
+      StripeClient.new.customer.new("someid")
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
 
     should "creating a new APIResource from a hash should not fetch over the network" do
-      StripeClient.new.customers.construct_from(id: "somecustomer",
-                                                card: { id: "somecard", object: "card" },
-                                                object: "customer")
+      StripeClient.new.customer.construct_from(id: "somecustomer",
+                                               card: { id: "somecard", object: "card" },
+                                               object: "customer")
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
 
     should "setting an attribute should not cause a network request" do
-      c = StripeClient.new.customers.new("cus_123")
+      c = StripeClient.new.customer.new("cus_123")
       c.card = { id: "somecard", object: "card" }
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
       assert_not_requested :post, %r{#{Stripe.api_base}/.*}
     end
 
     should "accessing id should not issue a fetch" do
-      c = StripeClient.new.customers.new("cus_123")
+      c = StripeClient.new.customer.new("cus_123")
       c.id
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
@@ -73,23 +73,23 @@ module Stripe
     should "not specifying api credentials should raise an exception" do
       Stripe.api_key = nil
       assert_raises Stripe::AuthenticationError do
-        StripeClient.new.customers.new("cus_123").refresh
+        StripeClient.new.customer.new("cus_123").refresh
       end
     end
 
     should "using a nil api key should raise an exception" do
       assert_raises TypeError do
-        StripeClient.new.customers.list({}, nil)
+        StripeClient.new.customer.list({}, nil)
       end
       assert_raises TypeError do
-        StripeClient.new.customers.list({}, api_key: nil)
+        StripeClient.new.customer.list({}, api_key: nil)
       end
     end
 
     should "specifying api credentials containing whitespace should raise an exception" do
       Stripe.api_key = "key "
       assert_raises Stripe::AuthenticationError do
-        StripeClient.new.customers.new("cus_123").refresh
+        StripeClient.new.customer.new("cus_123").refresh
       end
     end
 
@@ -263,12 +263,12 @@ module Stripe
       should "requesting with a unicode ID should result in a request" do
         stub_request(:get, "#{Stripe.api_base}/v1/customers/%E2%98%83")
           .to_return(body: JSON.generate(make_missing_id_error), status: 404)
-        c = StripeClient.new.customers.new("☃")
+        c = StripeClient.new.customer.new("☃")
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
       end
 
       should "requesting with no ID should result in an InvalidRequestError with no request" do
-        c = StripeClient.new.customers.new
+        c = StripeClient.new.customer.new
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
       end
 
@@ -308,7 +308,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(body: { "description" => "another_mn" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = StripeClient.new.customers.construct_from(customer_fixture)
+        c = StripeClient.new.customer.construct_from(customer_fixture)
         c.description = "another_mn"
         c.save
       end
@@ -317,14 +317,14 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(body: { "description" => "another_mn" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = StripeClient.new.customers.new("cus_123")
+        c = StripeClient.new.customer.new("cus_123")
         c.description = "another_mn"
         c.save
         assert_equal false, c.livemode
       end
 
       should "updating should fail if api_key is overwritten with nil" do
-        c = StripeClient.new.customers.new
+        c = StripeClient.new.customer.new
         assert_raises TypeError do
           c.save({}, api_key: nil)
         end
@@ -334,7 +334,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers")
           .with(headers: { "Authorization" => "Bearer sk_test_local" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = StripeClient.new.customers.new
+        c = StripeClient.new.customer.new
         c.save({}, api_key: "sk_test_local")
         assert_equal false, c.livemode
       end
@@ -342,7 +342,7 @@ module Stripe
       should "deleting should send no props and result in an object that has no props other deleted" do
         stub_request(:delete, "#{Stripe.api_base}/v1/customers/cus_123")
           .to_return(body: JSON.generate("id" => "cus_123", "deleted" => true))
-        c = StripeClient.new.customers.construct_from(customer_fixture)
+        c = StripeClient.new.customer.construct_from(customer_fixture)
         c.delete
       end
 
@@ -359,14 +359,14 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(customer_fixture))
-        StripeClient.new.customers.retrieve("cus_123", stripe_account: "acct_123")
+        StripeClient.new.customer.retrieve("cus_123", stripe_account: "acct_123")
       end
 
       should "passing in a stripe_account header should pass it through on save" do
         stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = StripeClient.new.customers.retrieve("cus_123", stripe_account: "acct_123")
+        c = StripeClient.new.customer.retrieve("cus_123", stripe_account: "acct_123")
 
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -46,26 +46,26 @@ module Stripe
     end
 
     should "creating a new APIResource should not fetch over the network" do
-      Stripe::Customer.new("someid")
+      StripeClient.new.customers.new("someid")
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
 
     should "creating a new APIResource from a hash should not fetch over the network" do
-      Stripe::Customer.construct_from(id: "somecustomer",
-                                      card: { id: "somecard", object: "card" },
-                                      object: "customer")
+      StripeClient.new.customers.construct_from(id: "somecustomer",
+                                                card: { id: "somecard", object: "card" },
+                                                object: "customer")
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
 
     should "setting an attribute should not cause a network request" do
-      c = Stripe::Customer.new("cus_123")
+      c = StripeClient.new.customers.new("cus_123")
       c.card = { id: "somecard", object: "card" }
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
       assert_not_requested :post, %r{#{Stripe.api_base}/.*}
     end
 
     should "accessing id should not issue a fetch" do
-      c = Stripe::Customer.new("cus_123")
+      c = StripeClient.new.customers.new("cus_123")
       c.id
       assert_not_requested :get, %r{#{Stripe.api_base}/.*}
     end
@@ -73,23 +73,23 @@ module Stripe
     should "not specifying api credentials should raise an exception" do
       Stripe.api_key = nil
       assert_raises Stripe::AuthenticationError do
-        Stripe::Customer.new("cus_123").refresh
+        StripeClient.new.customers.new("cus_123").refresh
       end
     end
 
     should "using a nil api key should raise an exception" do
       assert_raises TypeError do
-        Stripe::Customer.list({}, nil)
+        StripeClient.new.customers.list({}, nil)
       end
       assert_raises TypeError do
-        Stripe::Customer.list({}, api_key: nil)
+        StripeClient.new.customers.list({}, api_key: nil)
       end
     end
 
     should "specifying api credentials containing whitespace should raise an exception" do
       Stripe.api_key = "key "
       assert_raises Stripe::AuthenticationError do
-        Stripe::Customer.new("cus_123").refresh
+        StripeClient.new.customers.new("cus_123").refresh
       end
     end
 
@@ -263,12 +263,12 @@ module Stripe
       should "requesting with a unicode ID should result in a request" do
         stub_request(:get, "#{Stripe.api_base}/v1/customers/%E2%98%83")
           .to_return(body: JSON.generate(make_missing_id_error), status: 404)
-        c = Stripe::Customer.new("☃")
+        c = StripeClient.new.customers.new("☃")
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
       end
 
       should "requesting with no ID should result in an InvalidRequestError with no request" do
-        c = Stripe::Customer.new
+        c = StripeClient.new.customers.new
         assert_raises(Stripe::InvalidRequestError) { c.refresh }
       end
 
@@ -308,7 +308,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(body: { "description" => "another_mn" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = Stripe::Customer.construct_from(customer_fixture)
+        c = StripeClient.new.customers.construct_from(customer_fixture)
         c.description = "another_mn"
         c.save
       end
@@ -317,14 +317,14 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(body: { "description" => "another_mn" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = Stripe::Customer.new("cus_123")
+        c = StripeClient.new.customers.new("cus_123")
         c.description = "another_mn"
         c.save
         assert_equal false, c.livemode
       end
 
       should "updating should fail if api_key is overwritten with nil" do
-        c = Stripe::Customer.new
+        c = StripeClient.new.customers.new
         assert_raises TypeError do
           c.save({}, api_key: nil)
         end
@@ -334,7 +334,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/customers")
           .with(headers: { "Authorization" => "Bearer sk_test_local" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = Stripe::Customer.new
+        c = StripeClient.new.customers.new
         c.save({}, api_key: "sk_test_local")
         assert_equal false, c.livemode
       end
@@ -342,7 +342,7 @@ module Stripe
       should "deleting should send no props and result in an object that has no props other deleted" do
         stub_request(:delete, "#{Stripe.api_base}/v1/customers/cus_123")
           .to_return(body: JSON.generate("id" => "cus_123", "deleted" => true))
-        c = Stripe::Customer.construct_from(customer_fixture)
+        c = StripeClient.new.customers.construct_from(customer_fixture)
         c.delete
       end
 
@@ -359,14 +359,14 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(customer_fixture))
-        Stripe::Customer.retrieve("cus_123", stripe_account: "acct_123")
+        StripeClient.new.customers.retrieve("cus_123", stripe_account: "acct_123")
       end
 
       should "passing in a stripe_account header should pass it through on save" do
         stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(customer_fixture))
-        c = Stripe::Customer.retrieve("cus_123", stripe_account: "acct_123")
+        c = StripeClient.new.customers.retrieve("cus_123", stripe_account: "acct_123")
 
         stub_request(:post, "#{Stripe.api_base}/v1/customers/cus_123")
           .with(headers: { "Stripe-Account" => "acct_123" })

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplePayDomainTest < Test::Unit::TestCase
     should "be listable" do
-      domains = StripeClient.new.apple_pay_domains.list
+      domains = StripeClient.new.apple_pay_domain.list
       assert_requested :get, "#{Stripe.api_base}/v1/apple_pay/domains"
       assert domains.data.is_a?(Array)
       assert domains.data[0].is_a?(Stripe::ApplePayDomain)
     end
 
     should "be retrievable" do
-      domain = StripeClient.new.apple_pay_domains.retrieve("apwc_123")
+      domain = StripeClient.new.apple_pay_domain.retrieve("apwc_123")
       assert_requested :get, "#{Stripe.api_base}/v1/apple_pay/domains/apwc_123"
       assert domain.is_a?(Stripe::ApplePayDomain)
     end
 
     should "be creatable" do
-      domain = StripeClient.new.apple_pay_domains.create(domain_name: "example.com")
+      domain = StripeClient.new.apple_pay_domain.create(domain_name: "example.com")
       assert_requested :post, "#{Stripe.api_base}/v1/apple_pay/domains"
       assert domain.is_a?(Stripe::ApplePayDomain)
     end
@@ -28,7 +28,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        domain = StripeClient.new.apple_pay_domains.retrieve("apwc_123")
+        domain = StripeClient.new.apple_pay_domain.retrieve("apwc_123")
         domain = domain.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain.id}"
         assert domain.is_a?(Stripe::ApplePayDomain)
@@ -37,7 +37,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        domain = StripeClient.new.apple_pay_domains.delete("apwc_123")
+        domain = StripeClient.new.apple_pay_domain.delete("apwc_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/apwc_123"
         assert domain.is_a?(Stripe::ApplePayDomain)
       end

--- a/test/stripe/apple_pay_domain_test.rb
+++ b/test/stripe/apple_pay_domain_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplePayDomainTest < Test::Unit::TestCase
     should "be listable" do
-      domains = Stripe::ApplePayDomain.list
+      domains = StripeClient.new.apple_pay_domains.list
       assert_requested :get, "#{Stripe.api_base}/v1/apple_pay/domains"
       assert domains.data.is_a?(Array)
       assert domains.data[0].is_a?(Stripe::ApplePayDomain)
     end
 
     should "be retrievable" do
-      domain = Stripe::ApplePayDomain.retrieve("apwc_123")
+      domain = StripeClient.new.apple_pay_domains.retrieve("apwc_123")
       assert_requested :get, "#{Stripe.api_base}/v1/apple_pay/domains/apwc_123"
       assert domain.is_a?(Stripe::ApplePayDomain)
     end
 
     should "be creatable" do
-      domain = Stripe::ApplePayDomain.create(domain_name: "example.com")
+      domain = StripeClient.new.apple_pay_domains.create(domain_name: "example.com")
       assert_requested :post, "#{Stripe.api_base}/v1/apple_pay/domains"
       assert domain.is_a?(Stripe::ApplePayDomain)
     end
@@ -28,7 +28,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        domain = Stripe::ApplePayDomain.retrieve("apwc_123")
+        domain = StripeClient.new.apple_pay_domains.retrieve("apwc_123")
         domain = domain.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/#{domain.id}"
         assert domain.is_a?(Stripe::ApplePayDomain)
@@ -37,7 +37,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        domain = Stripe::ApplePayDomain.delete("apwc_123")
+        domain = StripeClient.new.apple_pay_domains.delete("apwc_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/apple_pay/domains/apwc_123"
         assert domain.is_a?(Stripe::ApplePayDomain)
       end

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplicationFeeRefundTest < Test::Unit::TestCase
     setup do
-      @fee = StripeClient.new.application_fees.retrieve("fee_123")
+      @fee = StripeClient.new.application_fee.retrieve("fee_123")
     end
 
     should "be listable" do

--- a/test/stripe/application_fee_refund_test.rb
+++ b/test/stripe/application_fee_refund_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplicationFeeRefundTest < Test::Unit::TestCase
     setup do
-      @fee = Stripe::ApplicationFee.retrieve("fee_123")
+      @fee = StripeClient.new.application_fees.retrieve("fee_123")
     end
 
     should "be listable" do

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplicationFeeTest < Test::Unit::TestCase
     should "be listable" do
-      fees = Stripe::ApplicationFee.list
+      fees = StripeClient.new.application_fees.list
       assert_requested :get, "#{Stripe.api_base}/v1/application_fees"
       assert fees.data.is_a?(Array)
       assert fees.data[0].is_a?(Stripe::ApplicationFee)
@@ -13,7 +13,7 @@ module Stripe
 
     context "#create_refund" do
       should "create a refund" do
-        refund = Stripe::ApplicationFee.create_refund(
+        refund = StripeClient.new.application_fees.create_refund(
           "fee_123"
         )
         assert_requested :post, "#{Stripe.api_base}/v1/application_fees/fee_123/refunds"
@@ -23,7 +23,7 @@ module Stripe
 
     context "#retrieve_refund" do
       should "retrieve a refund" do
-        refund = Stripe::ApplicationFee.retrieve_refund(
+        refund = StripeClient.new.application_fees.retrieve_refund(
           "fee_123",
           "fr_123"
         )
@@ -34,7 +34,7 @@ module Stripe
 
     context "#update_refund" do
       should "update a refund" do
-        refund = Stripe::ApplicationFee.update_refund(
+        refund = StripeClient.new.application_fees.update_refund(
           "fee_123",
           "fr_123",
           metadata: { foo: "bar" }
@@ -46,7 +46,7 @@ module Stripe
 
     context "#list_refunds" do
       should "list the application fee's refuns" do
-        refunds = Stripe::ApplicationFee.list_refunds(
+        refunds = StripeClient.new.application_fees.list_refunds(
           "fee_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/application_fees/fee_123/refunds"

--- a/test/stripe/application_fee_test.rb
+++ b/test/stripe/application_fee_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ApplicationFeeTest < Test::Unit::TestCase
     should "be listable" do
-      fees = StripeClient.new.application_fees.list
+      fees = StripeClient.new.application_fee.list
       assert_requested :get, "#{Stripe.api_base}/v1/application_fees"
       assert fees.data.is_a?(Array)
       assert fees.data[0].is_a?(Stripe::ApplicationFee)
@@ -13,7 +13,7 @@ module Stripe
 
     context "#create_refund" do
       should "create a refund" do
-        refund = StripeClient.new.application_fees.create_refund(
+        refund = StripeClient.new.application_fee.create_refund(
           "fee_123"
         )
         assert_requested :post, "#{Stripe.api_base}/v1/application_fees/fee_123/refunds"
@@ -23,7 +23,7 @@ module Stripe
 
     context "#retrieve_refund" do
       should "retrieve a refund" do
-        refund = StripeClient.new.application_fees.retrieve_refund(
+        refund = StripeClient.new.application_fee.retrieve_refund(
           "fee_123",
           "fr_123"
         )
@@ -34,7 +34,7 @@ module Stripe
 
     context "#update_refund" do
       should "update a refund" do
-        refund = StripeClient.new.application_fees.update_refund(
+        refund = StripeClient.new.application_fee.update_refund(
           "fee_123",
           "fr_123",
           metadata: { foo: "bar" }
@@ -46,7 +46,7 @@ module Stripe
 
     context "#list_refunds" do
       should "list the application fee's refuns" do
-        refunds = StripeClient.new.application_fees.list_refunds(
+        refunds = StripeClient.new.application_fee.list_refunds(
           "fee_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/application_fees/fee_123/refunds"

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class BalanceTest < Test::Unit::TestCase
     should "be retrievable" do
-      balance = StripeClient.new.balances.retrieve
+      balance = StripeClient.new.balance.retrieve
       assert_requested :get, "#{Stripe.api_base}/v1/balance"
       assert balance.is_a?(Stripe::Balance)
     end

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class BalanceTest < Test::Unit::TestCase
     should "be retrievable" do
-      balance = Stripe::Balance.retrieve
+      balance = StripeClient.new.balances.retrieve
       assert_requested :get, "#{Stripe.api_base}/v1/balance"
       assert balance.is_a?(Stripe::Balance)
     end

--- a/test/stripe/balance_transaction_test.rb
+++ b/test/stripe/balance_transaction_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class BalanceTransactionTest < Test::Unit::TestCase
     should "be listable" do
-      balance_transactions = Stripe::BalanceTransaction.list
+      balance_transactions = StripeClient.new.balance_transactions.list
       assert_requested :get, "#{Stripe.api_base}/v1/balance_transactions"
       assert balance_transactions.data.is_a?(Array)
       assert balance_transactions.first.is_a?(Stripe::BalanceTransaction)
     end
 
     should "be retrievable" do
-      balance_transaction = Stripe::BalanceTransaction.retrieve("txn_123")
+      balance_transaction = StripeClient.new.balance_transactions.retrieve("txn_123")
       assert_requested :get, "#{Stripe.api_base}/v1/balance_transactions/txn_123"
       assert balance_transaction.is_a?(Stripe::BalanceTransaction)
     end

--- a/test/stripe/balance_transaction_test.rb
+++ b/test/stripe/balance_transaction_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class BalanceTransactionTest < Test::Unit::TestCase
     should "be listable" do
-      balance_transactions = StripeClient.new.balance_transactions.list
+      balance_transactions = StripeClient.new.balance_transaction.list
       assert_requested :get, "#{Stripe.api_base}/v1/balance_transactions"
       assert balance_transactions.data.is_a?(Array)
       assert balance_transactions.first.is_a?(Stripe::BalanceTransaction)
     end
 
     should "be retrievable" do
-      balance_transaction = StripeClient.new.balance_transactions.retrieve("txn_123")
+      balance_transaction = StripeClient.new.balance_transaction.retrieve("txn_123")
       assert_requested :get, "#{Stripe.api_base}/v1/balance_transactions/txn_123"
       assert balance_transaction.is_a?(Stripe::BalanceTransaction)
     end

--- a/test/stripe/bank_account_test.rb
+++ b/test/stripe/bank_account_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class BankAccountTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return an external account URL" do
-        bank_account = Stripe::BankAccount.construct_from(
+        bank_account = StripeClient.new.bank_accounts.construct_from(
           account: "acct_123",
           id: "ba_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "return a customer URL" do
-        bank_account = Stripe::BankAccount.construct_from(
+        bank_account = StripeClient.new.bank_accounts.construct_from(
           customer: "cus_123",
           id: "ba_123"
         )
@@ -26,8 +26,8 @@ module Stripe
 
     context "#verify" do
       should "verify the account" do
-        bank_account = Stripe::BankAccount.construct_from(customer: "cus_123",
-                                                          id: "ba_123")
+        bank_account = StripeClient.new.bank_accounts.construct_from(customer: "cus_123",
+                                                                     id: "ba_123")
         bank_account = bank_account.verify(amounts: [1, 2])
         assert bank_account.is_a?(Stripe::BankAccount)
       end

--- a/test/stripe/bank_account_test.rb
+++ b/test/stripe/bank_account_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class BankAccountTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return an external account URL" do
-        bank_account = StripeClient.new.bank_accounts.construct_from(
+        bank_account = StripeClient.new.bank_account.construct_from(
           account: "acct_123",
           id: "ba_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "return a customer URL" do
-        bank_account = StripeClient.new.bank_accounts.construct_from(
+        bank_account = StripeClient.new.bank_account.construct_from(
           customer: "cus_123",
           id: "ba_123"
         )
@@ -26,8 +26,8 @@ module Stripe
 
     context "#verify" do
       should "verify the account" do
-        bank_account = StripeClient.new.bank_accounts.construct_from(customer: "cus_123",
-                                                                     id: "ba_123")
+        bank_account = StripeClient.new.bank_account.construct_from(customer: "cus_123",
+                                                                    id: "ba_123")
         bank_account = bank_account.verify(amounts: [1, 2])
         assert bank_account.is_a?(Stripe::BankAccount)
       end

--- a/test/stripe/billing_portal/session_test.rb
+++ b/test/stripe/billing_portal/session_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module BillingPortal
     class SessionTest < Test::Unit::TestCase
       should "be creatable" do
-        session = Stripe::BillingPortal::Session.create(
+        session = StripeClient.new.billing_portal.sessions.create(
           customer: "cus_123",
           return_url: "https://stripe.com/return"
         )

--- a/test/stripe/billing_portal/session_test.rb
+++ b/test/stripe/billing_portal/session_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module BillingPortal
     class SessionTest < Test::Unit::TestCase
       should "be creatable" do
-        session = StripeClient.new.billing_portal.sessions.create(
+        session = StripeClient.new.billing_portal.session.create(
           customer: "cus_123",
           return_url: "https://stripe.com/return"
         )

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ChargeTest < Test::Unit::TestCase
     should "be listable" do
-      charges = StripeClient.new.charges.list
+      charges = StripeClient.new.charge.list
       assert_requested :get, "#{Stripe.api_base}/v1/charges"
       assert charges.data.is_a?(Array)
       assert charges.data[0].is_a?(Stripe::Charge)
     end
 
     should "be retrievable" do
-      charge = StripeClient.new.charges.retrieve("ch_123")
+      charge = StripeClient.new.charge.retrieve("ch_123")
       assert_requested :get, "#{Stripe.api_base}/v1/charges/ch_123"
       assert charge.is_a?(Stripe::Charge)
     end
 
     should "be creatable" do
-      charge = StripeClient.new.charges.create(
+      charge = StripeClient.new.charge.create(
         amount: 100,
         currency: "USD",
         source: "src_123"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      charge = StripeClient.new.charges.retrieve("ch_123")
+      charge = StripeClient.new.charge.retrieve("ch_123")
       charge.metadata["key"] = "value"
       charge.save
       assert_requested :post, "#{Stripe.api_base}/v1/charges/#{charge.id}"
     end
 
     should "be updateable" do
-      charge = StripeClient.new.charges.update("ch_123", metadata: { foo: "bar" })
+      charge = StripeClient.new.charge.update("ch_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/charges/ch_123"
       assert charge.is_a?(Stripe::Charge)
     end
 
     context "#capture" do
       should "capture the charge" do
-        charge = StripeClient.new.charges.retrieve("ch_123")
+        charge = StripeClient.new.charge.retrieve("ch_123")
         charge = charge.capture(amount: 100)
         assert_requested :post,
                          "#{Stripe.api_base}/v1/charges/ch_123/capture",
@@ -53,7 +53,7 @@ module Stripe
 
     context ".capture" do
       should "capture the charge" do
-        charge = StripeClient.new.charges.capture("ch_123", amount: 100)
+        charge = StripeClient.new.charge.capture("ch_123", amount: 100)
         assert_requested :post,
                          "#{Stripe.api_base}/v1/charges/ch_123/capture",
                          body: { amount: 100 }

--- a/test/stripe/charge_test.rb
+++ b/test/stripe/charge_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ChargeTest < Test::Unit::TestCase
     should "be listable" do
-      charges = Stripe::Charge.list
+      charges = StripeClient.new.charges.list
       assert_requested :get, "#{Stripe.api_base}/v1/charges"
       assert charges.data.is_a?(Array)
       assert charges.data[0].is_a?(Stripe::Charge)
     end
 
     should "be retrievable" do
-      charge = Stripe::Charge.retrieve("ch_123")
+      charge = StripeClient.new.charges.retrieve("ch_123")
       assert_requested :get, "#{Stripe.api_base}/v1/charges/ch_123"
       assert charge.is_a?(Stripe::Charge)
     end
 
     should "be creatable" do
-      charge = Stripe::Charge.create(
+      charge = StripeClient.new.charges.create(
         amount: 100,
         currency: "USD",
         source: "src_123"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      charge = Stripe::Charge.retrieve("ch_123")
+      charge = StripeClient.new.charges.retrieve("ch_123")
       charge.metadata["key"] = "value"
       charge.save
       assert_requested :post, "#{Stripe.api_base}/v1/charges/#{charge.id}"
     end
 
     should "be updateable" do
-      charge = Stripe::Charge.update("ch_123", metadata: { foo: "bar" })
+      charge = StripeClient.new.charges.update("ch_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/charges/ch_123"
       assert charge.is_a?(Stripe::Charge)
     end
 
     context "#capture" do
       should "capture the charge" do
-        charge = Stripe::Charge.retrieve("ch_123")
+        charge = StripeClient.new.charges.retrieve("ch_123")
         charge = charge.capture(amount: 100)
         assert_requested :post,
                          "#{Stripe.api_base}/v1/charges/ch_123/capture",
@@ -53,7 +53,7 @@ module Stripe
 
     context ".capture" do
       should "capture the charge" do
-        charge = Stripe::Charge.capture("ch_123", amount: 100)
+        charge = StripeClient.new.charges.capture("ch_123", amount: 100)
         assert_requested :post,
                          "#{Stripe.api_base}/v1/charges/ch_123/capture",
                          body: { amount: 100 }

--- a/test/stripe/checkout/session_test.rb
+++ b/test/stripe/checkout/session_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Checkout
     class SessionTest < Test::Unit::TestCase
       should "be creatable" do
-        session = Stripe::Checkout::Session.create(
+        session = StripeClient.new.checkout.sessions.create(
           cancel_url: "https://stripe.com/cancel",
           client_reference_id: "1234",
           line_items: [
@@ -32,14 +32,14 @@ module Stripe
       end
 
       should "be retrievable" do
-        charge = Stripe::Checkout::Session.retrieve("cs_123")
+        charge = StripeClient.new.checkout.sessions.retrieve("cs_123")
         assert_requested :get, "#{Stripe.api_base}/v1/checkout/sessions/cs_123"
         assert charge.is_a?(Stripe::Checkout::Session)
       end
 
       context "#list_line_items" do
         should "list the session's line items" do
-          sources = Stripe::Checkout::Session.list_line_items(
+          sources = StripeClient.new.checkout.sessions.list_line_items(
             "cs_123"
           )
           assert_requested :get, "#{Stripe.api_base}/v1/checkout/sessions/cs_123/line_items"

--- a/test/stripe/checkout/session_test.rb
+++ b/test/stripe/checkout/session_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Checkout
     class SessionTest < Test::Unit::TestCase
       should "be creatable" do
-        session = StripeClient.new.checkout.sessions.create(
+        session = StripeClient.new.checkout.session.create(
           cancel_url: "https://stripe.com/cancel",
           client_reference_id: "1234",
           line_items: [
@@ -32,14 +32,14 @@ module Stripe
       end
 
       should "be retrievable" do
-        charge = StripeClient.new.checkout.sessions.retrieve("cs_123")
+        charge = StripeClient.new.checkout.session.retrieve("cs_123")
         assert_requested :get, "#{Stripe.api_base}/v1/checkout/sessions/cs_123"
         assert charge.is_a?(Stripe::Checkout::Session)
       end
 
       context "#list_line_items" do
         should "list the session's line items" do
-          sources = StripeClient.new.checkout.sessions.list_line_items(
+          sources = StripeClient.new.checkout.session.list_line_items(
             "cs_123"
           )
           assert_requested :get, "#{Stripe.api_base}/v1/checkout/sessions/cs_123/line_items"

--- a/test/stripe/client_api_operations_test.rb
+++ b/test/stripe/client_api_operations_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require ::File.expand_path("../test_helper", __dir__)
+
+module Stripe
+  class ClientAPIOperationsTest < Test::Unit::TestCase
+    class TestAPIResource < APIResource
+      extend Stripe::APIOperations::List
+
+      OBJECT_NAME = "test_resource"
+      EXPECTED = Object.new
+
+      # rubocop:disable Lint/UnderscorePrefixedVariableName
+      def self.retrieve(_id, _opts = EXPECTED)
+        unless _opts == EXPECTED
+          raise "The ClientProxy should not send options when they are unused"
+        end
+
+        raise NotImplementedError
+      end
+      # rubocop:enable Lint/UnderscorePrefixedVariableName
+    end
+
+    context "API resource instance methods" do
+      should "define methods for all api resources" do
+        client = StripeClient.new
+
+        # Update Sigma name to account for nuance
+        api_resources = Stripe::Util.api_object_classes
+        sigma_class = api_resources.delete("scheduled_query_run")
+        api_resources["sigma.scheduled_query_run"] = sigma_class
+
+        api_resources.each do |string, _|
+          if string.include?(".")
+            resource_module, resource_name = string.split(".")
+
+            assert client.respond_to?(resource_module), "#{resource_module} not found"
+            assert client.send(resource_module).respond_to?("#{resource_name}s"), "#{resource_name} not found"
+          else
+            assert client.respond_to?("#{string}s"), "#{string} not found"
+          end
+        end
+      end
+
+      should "raise when the resource doesn't respond to a method" do
+        Stripe::Util.stubs(:api_object_classes)
+                    .returns({ "test_resource" => TestAPIResource })
+        proxied_resource = ClientAPIOperations::ClientProxy
+                           .new(client: StripeClient.new, resource: TestAPIResource)
+
+        assert_raises NoMethodError do
+          proxied_resource.not_a_method
+        end
+      end
+
+      context "setting configurable options" do
+        should "allow for listing a resource with filters" do
+          client = StripeClient.new
+          accounts = client.accounts.list({ limit: 10 })
+          assert_requested(:get, "#{Stripe.api_base}/v1/accounts?limit=10")
+          assert accounts.data.is_a?(Array)
+          assert accounts.data[0].is_a?(Stripe::Account)
+        end
+
+        should "override any global configurations" do
+          Stripe.api_key = "sk_test_old"
+
+          client = StripeClient.new(api_key: "sk_test_new")
+          client.accounts.retrieve("acct_1234")
+          assert_requested(:get,
+                           "#{Stripe.api_base}/v1/accounts/acct_1234",
+                           headers: {
+                             "Authorization" => "Bearer sk_test_new",
+                           })
+        end
+
+        should "use global settings by default" do
+          client = StripeClient.new
+          client.accounts.retrieve("acct_1234")
+          assert_requested(:get,
+                           "#{Stripe.api_base}/v1/accounts/acct_1234",
+                           headers: {
+                             "Authorization" => "Bearer #{Stripe.api_key}",
+                           })
+        end
+
+        should "not modify options when the param is set as `_opt`" do
+          Stripe::Util.stubs(:api_object_classes)
+                      .returns({ "test_resource" => TestAPIResource })
+          proxied_resource = ClientAPIOperations::ClientProxy
+                             .new(client: StripeClient.new, resource: TestAPIResource)
+
+          assert_raises TypeError do
+            proxied_resource.list({}, nil)
+          end
+
+          assert_raises TypeError do
+            proxied_resource.list({}, api_key: nil)
+          end
+        end
+
+        should "preserve nil when passed as an option for downstream error handling" do
+          Stripe::Util.stubs(:api_object_classes)
+                      .returns({ "test_resource" => TestAPIResource })
+          proxied_resource = ClientAPIOperations::ClientProxy
+                             .new(client: StripeClient.new, resource: TestAPIResource)
+
+          assert_raises NotImplementedError do
+            proxied_resource.retrieve("1")
+          end
+        end
+
+        should "allow for overrides when retrieving a resource" do
+          client = StripeClient.new(api_key: "sk_test_local")
+          account = client.accounts.retrieve("acct_123", { api_key: "sk_test_other" })
+          assert_requested(:get, "#{Stripe.api_base}/v1/accounts/acct_123",
+                           headers: { "Authorization" => "Bearer sk_test_other" })
+          assert account.is_a?(Stripe::Account)
+        end
+
+        should "allow for retrieving a resource with options" do
+          client = Stripe::StripeClient.new(api_key: "sk_test_local")
+          account = client.charges.retrieve(id: "acct_123", expand: ["customer"])
+          assert_requested(:get, "#{Stripe.api_base}/v1/charges/acct_123",
+                           headers: { "Authorization" => "Bearer sk_test_local" },
+                           query: { "expand[]" => "customer" })
+          assert account.is_a?(Stripe::Charge)
+        end
+
+        should "allow for overrides when operating on a collection" do
+          client = StripeClient.new(api_key: "sk_test_local")
+          accounts = client.accounts.list({}, { api_key: "sk_test_other" })
+          assert_requested(:get,
+                           "#{Stripe.api_base}/v1/accounts",
+                           headers: { "Authorization" => "Bearer sk_test_other" })
+          assert accounts.data.is_a?(Array)
+          assert accounts.data[0].is_a?(Stripe::Account)
+        end
+
+        should "allow for overrides when operating on a resource" do
+          client = StripeClient.new(api_key: "sk_test_local")
+          account = client.accounts.update("acct_123",
+                                           {},
+                                           { api_key: "sk_test_other" })
+          assert_requested(:post,
+                           "#{Stripe.api_base}/v1/accounts/acct_123",
+                           headers: { "Authorization" => "Bearer sk_test_other" })
+          assert account.is_a?(Stripe::Account)
+        end
+
+        should "allow for overrides when operating on an instance" do
+          client = StripeClient.new(api_key: "sk_test_new")
+          account = client.accounts.retrieve("acct_123")
+          account.metadata = { foo: "bar" }
+          account.save
+          assert_requested(:post,
+                           "#{Stripe.api_base}/v1/accounts/acct_123",
+                           body: { metadata: { foo: "bar" } },
+                           headers: {
+                             "Authorization" => "Bearer sk_test_new",
+                           })
+          assert account.is_a?(Stripe::Account)
+        end
+
+        context "when the api key is provided as a string" do
+          should "correctly normalize the options when operating on an instance" do
+            client = StripeClient.new
+            account = client.accounts.retrieve("acct_123", "sk_test_new")
+            account.metadata = { foo: "bar" }
+            account.save
+            assert_requested(:post,
+                             "#{Stripe.api_base}/v1/accounts/acct_123",
+                             body: { metadata: { foo: "bar" } },
+                             headers: {
+                               "Authorization" => "Bearer sk_test_new",
+                             })
+          end
+
+          should "correctly normalize the options when operating on a collection" do
+            client = StripeClient.new(api_key: "sk_test_local")
+            client.accounts.list({}, "sk_test_other")
+            assert_requested(:get,
+                             "#{Stripe.api_base}/v1/accounts",
+                             headers: { "Authorization" => "Bearer sk_test_other" })
+          end
+
+          should "correctly normalize  the options when operationg on a resource" do
+            client = StripeClient.new(api_key: "sk_test_local")
+            client.accounts.update("acct_123", {}, "sk_test_other")
+            assert_requested(:post,
+                             "#{Stripe.api_base}/v1/accounts/acct_123",
+                             headers: { "Authorization" => "Bearer sk_test_other" })
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/stripe/country_spec_test.rb
+++ b/test/stripe/country_spec_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CountrySpecTest < Test::Unit::TestCase
     should "be listable" do
-      c = StripeClient.new.country_specs.list
+      c = StripeClient.new.country_spec.list
       assert_requested :get, "#{Stripe.api_base}/v1/country_specs"
       assert c.data.is_a?(Array)
       assert c.data[0].is_a?(Stripe::CountrySpec)
     end
 
     should "be retrievable" do
-      s = StripeClient.new.country_specs.retrieve("US")
+      s = StripeClient.new.country_spec.retrieve("US")
       assert_requested :get, "#{Stripe.api_base}/v1/country_specs/US"
       assert(s.is_a?(Stripe::CountrySpec))
     end

--- a/test/stripe/country_spec_test.rb
+++ b/test/stripe/country_spec_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CountrySpecTest < Test::Unit::TestCase
     should "be listable" do
-      c = Stripe::CountrySpec.list
+      c = StripeClient.new.country_specs.list
       assert_requested :get, "#{Stripe.api_base}/v1/country_specs"
       assert c.data.is_a?(Array)
       assert c.data[0].is_a?(Stripe::CountrySpec)
     end
 
     should "be retrievable" do
-      s = Stripe::CountrySpec.retrieve("US")
+      s = StripeClient.new.country_specs.retrieve("US")
       assert_requested :get, "#{Stripe.api_base}/v1/country_specs/US"
       assert(s.is_a?(Stripe::CountrySpec))
     end

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CouponTest < Test::Unit::TestCase
     should "be listable" do
-      coupons = Stripe::Coupon.list
+      coupons = StripeClient.new.coupons.list
       assert_requested :get, "#{Stripe.api_base}/v1/coupons"
       assert coupons.data.is_a?(Array)
       assert coupons.first.is_a?(Stripe::Coupon)
     end
 
     should "be retrievable" do
-      coupon = Stripe::Coupon.retrieve("25OFF")
+      coupon = StripeClient.new.coupons.retrieve("25OFF")
       assert_requested :get, "#{Stripe.api_base}/v1/coupons/25OFF"
       assert coupon.is_a?(Stripe::Coupon)
     end
 
     should "be creatable" do
-      coupon = Stripe::Coupon.create(
+      coupon = StripeClient.new.coupons.create(
         percent_off: 25,
         duration: "repeating",
         duration_in_months: 3,
@@ -29,21 +29,21 @@ module Stripe
     end
 
     should "be saveable" do
-      coupon = Stripe::Coupon.retrieve("25OFF")
+      coupon = StripeClient.new.coupons.retrieve("25OFF")
       coupon.metadata["key"] = "value"
       coupon.save
       assert_requested :post, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
     end
 
     should "be updateable" do
-      coupon = Stripe::Coupon.update("25OFF", metadata: { key: "value" })
+      coupon = StripeClient.new.coupons.update("25OFF", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/coupons/25OFF"
       assert coupon.is_a?(Stripe::Coupon)
     end
 
     context "#delete" do
       should "be deletable" do
-        coupon = Stripe::Coupon.delete("25OFF")
+        coupon = StripeClient.new.coupons.delete("25OFF")
         assert_requested :delete, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
         assert coupon.is_a?(Stripe::Coupon)
       end
@@ -51,7 +51,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        coupon = Stripe::Coupon.retrieve("25OFF")
+        coupon = StripeClient.new.coupons.retrieve("25OFF")
         coupon = coupon.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/coupons/25OFF"
         assert coupon.is_a?(Stripe::Coupon)

--- a/test/stripe/coupon_test.rb
+++ b/test/stripe/coupon_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CouponTest < Test::Unit::TestCase
     should "be listable" do
-      coupons = StripeClient.new.coupons.list
+      coupons = StripeClient.new.coupon.list
       assert_requested :get, "#{Stripe.api_base}/v1/coupons"
       assert coupons.data.is_a?(Array)
       assert coupons.first.is_a?(Stripe::Coupon)
     end
 
     should "be retrievable" do
-      coupon = StripeClient.new.coupons.retrieve("25OFF")
+      coupon = StripeClient.new.coupon.retrieve("25OFF")
       assert_requested :get, "#{Stripe.api_base}/v1/coupons/25OFF"
       assert coupon.is_a?(Stripe::Coupon)
     end
 
     should "be creatable" do
-      coupon = StripeClient.new.coupons.create(
+      coupon = StripeClient.new.coupon.create(
         percent_off: 25,
         duration: "repeating",
         duration_in_months: 3,
@@ -29,21 +29,21 @@ module Stripe
     end
 
     should "be saveable" do
-      coupon = StripeClient.new.coupons.retrieve("25OFF")
+      coupon = StripeClient.new.coupon.retrieve("25OFF")
       coupon.metadata["key"] = "value"
       coupon.save
       assert_requested :post, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
     end
 
     should "be updateable" do
-      coupon = StripeClient.new.coupons.update("25OFF", metadata: { key: "value" })
+      coupon = StripeClient.new.coupon.update("25OFF", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/coupons/25OFF"
       assert coupon.is_a?(Stripe::Coupon)
     end
 
     context "#delete" do
       should "be deletable" do
-        coupon = StripeClient.new.coupons.delete("25OFF")
+        coupon = StripeClient.new.coupon.delete("25OFF")
         assert_requested :delete, "#{Stripe.api_base}/v1/coupons/#{coupon.id}"
         assert coupon.is_a?(Stripe::Coupon)
       end
@@ -51,7 +51,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        coupon = StripeClient.new.coupons.retrieve("25OFF")
+        coupon = StripeClient.new.coupon.retrieve("25OFF")
         coupon = coupon.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/coupons/25OFF"
         assert coupon.is_a?(Stripe::Coupon)

--- a/test/stripe/credit_note_test.rb
+++ b/test/stripe/credit_note_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CreditNoteTest < Test::Unit::TestCase
     should "be listable" do
-      credit_notes = Stripe::CreditNote.list
+      credit_notes = StripeClient.new.credit_notes.list
       assert_requested :get, "#{Stripe.api_base}/v1/credit_notes"
       assert credit_notes.data.is_a?(Array)
       assert credit_notes.first.is_a?(Stripe::CreditNote)
     end
 
     should "be retrievable" do
-      credit_note = Stripe::CreditNote.retrieve("cn_123")
+      credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
       assert_requested :get, "#{Stripe.api_base}/v1/credit_notes/cn_123"
       assert credit_note.is_a?(Stripe::CreditNote)
     end
 
     should "be creatable" do
-      credit_note = Stripe::CreditNote.create(
+      credit_note = StripeClient.new.credit_notes.create(
         amount: 100,
         invoice: "in_123",
         reason: "duplicate"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      credit_note = Stripe::CreditNote.retrieve("cn_123")
+      credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
       credit_note.metadata["key"] = "value"
       credit_note.save
       assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/#{credit_note.id}"
     end
 
     should "be updateable" do
-      credit_note = Stripe::CreditNote.update("cn_123", metadata: { key: "value" })
+      credit_note = StripeClient.new.credit_notes.update("cn_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/cn_123"
       assert credit_note.is_a?(Stripe::CreditNote)
     end
 
     context ".preview" do
       should "preview a credit note" do
-        invoice = Stripe::CreditNote.preview(
+        invoice = StripeClient.new.credit_notes.preview(
           invoice: "in_123",
           amount: 500
         )
@@ -57,7 +57,7 @@ module Stripe
 
     context "#void_credit_note" do
       should "void credit_note" do
-        credit_note = Stripe::CreditNote.retrieve("cn_123")
+        credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
         credit_note = credit_note.void_credit_note
         assert_requested :post,
                          "#{Stripe.api_base}/v1/credit_notes/#{credit_note.id}/void"
@@ -67,7 +67,7 @@ module Stripe
 
     context ".void_credit_note" do
       should "void credit_note" do
-        credit_note = Stripe::CreditNote.void_credit_note("cn_123")
+        credit_note = StripeClient.new.credit_notes.void_credit_note("cn_123")
         assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/cn_123/void"
         assert credit_note.is_a?(Stripe::CreditNote)
       end
@@ -75,7 +75,7 @@ module Stripe
 
     context ".list_preview_line_items" do
       should "list_preview_line_items" do
-        line_items = Stripe::CreditNote.list_preview_line_items(
+        line_items = StripeClient.new.credit_notes.list_preview_line_items(
           invoice: "in_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/credit_notes/preview/lines",

--- a/test/stripe/credit_note_test.rb
+++ b/test/stripe/credit_note_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CreditNoteTest < Test::Unit::TestCase
     should "be listable" do
-      credit_notes = StripeClient.new.credit_notes.list
+      credit_notes = StripeClient.new.credit_note.list
       assert_requested :get, "#{Stripe.api_base}/v1/credit_notes"
       assert credit_notes.data.is_a?(Array)
       assert credit_notes.first.is_a?(Stripe::CreditNote)
     end
 
     should "be retrievable" do
-      credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
+      credit_note = StripeClient.new.credit_note.retrieve("cn_123")
       assert_requested :get, "#{Stripe.api_base}/v1/credit_notes/cn_123"
       assert credit_note.is_a?(Stripe::CreditNote)
     end
 
     should "be creatable" do
-      credit_note = StripeClient.new.credit_notes.create(
+      credit_note = StripeClient.new.credit_note.create(
         amount: 100,
         invoice: "in_123",
         reason: "duplicate"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
+      credit_note = StripeClient.new.credit_note.retrieve("cn_123")
       credit_note.metadata["key"] = "value"
       credit_note.save
       assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/#{credit_note.id}"
     end
 
     should "be updateable" do
-      credit_note = StripeClient.new.credit_notes.update("cn_123", metadata: { key: "value" })
+      credit_note = StripeClient.new.credit_note.update("cn_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/cn_123"
       assert credit_note.is_a?(Stripe::CreditNote)
     end
 
     context ".preview" do
       should "preview a credit note" do
-        invoice = StripeClient.new.credit_notes.preview(
+        invoice = StripeClient.new.credit_note.preview(
           invoice: "in_123",
           amount: 500
         )
@@ -57,7 +57,7 @@ module Stripe
 
     context "#void_credit_note" do
       should "void credit_note" do
-        credit_note = StripeClient.new.credit_notes.retrieve("cn_123")
+        credit_note = StripeClient.new.credit_note.retrieve("cn_123")
         credit_note = credit_note.void_credit_note
         assert_requested :post,
                          "#{Stripe.api_base}/v1/credit_notes/#{credit_note.id}/void"
@@ -67,7 +67,7 @@ module Stripe
 
     context ".void_credit_note" do
       should "void credit_note" do
-        credit_note = StripeClient.new.credit_notes.void_credit_note("cn_123")
+        credit_note = StripeClient.new.credit_note.void_credit_note("cn_123")
         assert_requested :post, "#{Stripe.api_base}/v1/credit_notes/cn_123/void"
         assert credit_note.is_a?(Stripe::CreditNote)
       end
@@ -75,7 +75,7 @@ module Stripe
 
     context ".list_preview_line_items" do
       should "list_preview_line_items" do
-        line_items = StripeClient.new.credit_notes.list_preview_line_items(
+        line_items = StripeClient.new.credit_note.list_preview_line_items(
           invoice: "in_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/credit_notes/preview/lines",

--- a/test/stripe/customer_balance_transaction_test.rb
+++ b/test/stripe/customer_balance_transaction_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class CustomerBalanceTransactionTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        transaction = StripeClient.new.customer_balance_transactions.construct_from(
+        transaction = StripeClient.new.customer_balance_transaction.construct_from(
           id: "cbtxn_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        transaction = StripeClient.new.customer_balance_transactions.construct_from(id: "cbtxn_123")
+        transaction = StripeClient.new.customer_balance_transaction.construct_from(id: "cbtxn_123")
         assert_raises NotImplementedError do
           transaction.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        StripeClient.new.customer_balance_transactions.retrieve("cbtxn_123")
+        StripeClient.new.customer_balance_transaction.retrieve("cbtxn_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        StripeClient.new.customer_balance_transactions.update("cbtxn_123")
+        StripeClient.new.customer_balance_transaction.update("cbtxn_123")
       end
     end
   end

--- a/test/stripe/customer_balance_transaction_test.rb
+++ b/test/stripe/customer_balance_transaction_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class CustomerBalanceTransactionTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        transaction = Stripe::CustomerBalanceTransaction.construct_from(
+        transaction = StripeClient.new.customer_balance_transactions.construct_from(
           id: "cbtxn_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        transaction = Stripe::CustomerBalanceTransaction.construct_from(id: "cbtxn_123")
+        transaction = StripeClient.new.customer_balance_transactions.construct_from(id: "cbtxn_123")
         assert_raises NotImplementedError do
           transaction.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        Stripe::CustomerBalanceTransaction.retrieve("cbtxn_123")
+        StripeClient.new.customer_balance_transactions.retrieve("cbtxn_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        Stripe::CustomerBalanceTransaction.update("cbtxn_123")
+        StripeClient.new.customer_balance_transactions.update("cbtxn_123")
       end
     end
   end

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -11,7 +11,7 @@ module Stripe
       stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
         .to_return(body: JSON.generate(customer_json))
 
-      @customer = Stripe::Customer.retrieve("cus_123")
+      @customer = StripeClient.new.customers.retrieve("cus_123")
     end
 
     should "be listable" do
@@ -30,16 +30,16 @@ module Stripe
     end
 
     should "be deletable" do
-      card = Stripe::Card.construct_from(customer: @customer.id,
-                                         id: "card_123")
+      card = StripeClient.new.cards.construct_from(customer: @customer.id,
+                                                   id: "card_123")
       card.delete
       assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{@customer.id}/sources/card_123"
     end
 
     should "be saveable" do
-      card = Stripe::Card.construct_from(customer: @customer.id,
-                                         id: "card_123",
-                                         metadata: {})
+      card = StripeClient.new.cards.construct_from(customer: @customer.id,
+                                                   id: "card_123",
+                                                   metadata: {})
       card.metadata["key"] = "value"
       card.save
       assert_requested :post, "#{Stripe.api_base}/v1/customers/#{@customer.id}/sources/card_123"

--- a/test/stripe/customer_card_test.rb
+++ b/test/stripe/customer_card_test.rb
@@ -11,7 +11,7 @@ module Stripe
       stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
         .to_return(body: JSON.generate(customer_json))
 
-      @customer = StripeClient.new.customers.retrieve("cus_123")
+      @customer = StripeClient.new.customer.retrieve("cus_123")
     end
 
     should "be listable" do
@@ -30,16 +30,16 @@ module Stripe
     end
 
     should "be deletable" do
-      card = StripeClient.new.cards.construct_from(customer: @customer.id,
-                                                   id: "card_123")
+      card = StripeClient.new.card.construct_from(customer: @customer.id,
+                                                  id: "card_123")
       card.delete
       assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{@customer.id}/sources/card_123"
     end
 
     should "be saveable" do
-      card = StripeClient.new.cards.construct_from(customer: @customer.id,
-                                                   id: "card_123",
-                                                   metadata: {})
+      card = StripeClient.new.card.construct_from(customer: @customer.id,
+                                                  id: "card_123",
+                                                  metadata: {})
       card.metadata["key"] = "value"
       card.save
       assert_requested :post, "#{Stripe.api_base}/v1/customers/#{@customer.id}/sources/card_123"

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -5,40 +5,40 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CustomerTest < Test::Unit::TestCase
     should "be listable" do
-      customers = Stripe::Customer.list
+      customers = StripeClient.new.customers.list
       assert_requested :get, "#{Stripe.api_base}/v1/customers"
       assert customers.data.is_a?(Array)
       assert customers.first.is_a?(Stripe::Customer)
     end
 
     should "be retrievable" do
-      customer = Stripe::Customer.retrieve("cus_123")
+      customer = StripeClient.new.customers.retrieve("cus_123")
       assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123"
       assert customer.is_a?(Stripe::Customer)
     end
 
     should "be creatable" do
-      customer = Stripe::Customer.create
+      customer = StripeClient.new.customers.create
       assert_requested :post, "#{Stripe.api_base}/v1/customers"
       assert customer.is_a?(Stripe::Customer)
     end
 
     should "be saveable" do
-      customer = Stripe::Customer.retrieve("cus_123")
+      customer = StripeClient.new.customers.retrieve("cus_123")
       customer.metadata["key"] = "value"
       customer.save
       assert_requested :post, "#{Stripe.api_base}/v1/customers/#{customer.id}"
     end
 
     should "be updateable" do
-      customer = Stripe::Customer.update("cus_123", metadata: { key: "value" })
+      customer = StripeClient.new.customers.update("cus_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/customers/cus_123"
       assert customer.is_a?(Stripe::Customer)
     end
 
     context "#delete" do
       should "be deletable" do
-        customer = Stripe::Customer.retrieve("cus_123")
+        customer = StripeClient.new.customers.retrieve("cus_123")
         customer = customer.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
         assert customer.is_a?(Stripe::Customer)
@@ -47,7 +47,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        customer = Stripe::Customer.delete("cus_123")
+        customer = StripeClient.new.customers.delete("cus_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123"
         assert customer.is_a?(Stripe::Customer)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context ".delete_discount" do
       should "delete a discount" do
-        discount = Stripe::Customer.delete_discount("cus_123")
+        discount = StripeClient.new.customers.delete_discount("cus_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/discount"
         assert discount.is_a?(Stripe::Discount)
       end
@@ -72,7 +72,7 @@ module Stripe
 
     context "#create_source" do
       should "create a source" do
-        Stripe::Customer.create_source(
+        StripeClient.new.customers.create_source(
           "cus_123",
           source: "tok_123"
         )
@@ -82,7 +82,7 @@ module Stripe
 
     context "#retrieve_source" do
       should "retrieve a source" do
-        Stripe::Customer.retrieve_source(
+        StripeClient.new.customers.retrieve_source(
           "cus_123",
           "ba_123"
         )
@@ -92,7 +92,7 @@ module Stripe
 
     context "#update_source" do
       should "update a source" do
-        Stripe::Customer.update_source(
+        StripeClient.new.customers.update_source(
           "cus_123",
           "ba_123",
           metadata: { foo: "bar" }
@@ -103,7 +103,7 @@ module Stripe
 
     context "#delete_source" do
       should "delete a source" do
-        Stripe::Customer.delete_source(
+        StripeClient.new.customers.delete_source(
           "cus_123",
           "ba_123"
         )
@@ -113,7 +113,7 @@ module Stripe
 
     context "#list_sources" do
       should "list the customer's sources" do
-        sources = Stripe::Customer.list_sources(
+        sources = StripeClient.new.customers.list_sources(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/sources"
@@ -124,13 +124,13 @@ module Stripe
 
     context "source field" do
       should "allow setting source with token" do
-        c = Stripe::Customer.new("test_customer")
+        c = StripeClient.new.customers.new("test_customer")
         c.source = "tok_123"
         assert_equal "tok_123", c.source
       end
 
       should "allow setting source with hash and set flag" do
-        c = Stripe::Customer.new("test_customer")
+        c = StripeClient.new.customers.new("test_customer")
         c.source = {
           object: "card",
         }
@@ -140,7 +140,7 @@ module Stripe
 
     context "#create_tax_id" do
       should "create a tax id" do
-        Stripe::Customer.create_tax_id(
+        StripeClient.new.customers.create_tax_id(
           "cus_123",
           type: "eu_vat",
           value: "11111"
@@ -151,7 +151,7 @@ module Stripe
 
     context "#retrieve_tax_id" do
       should "retrieve a tax id" do
-        Stripe::Customer.retrieve_tax_id(
+        StripeClient.new.customers.retrieve_tax_id(
           "cus_123",
           "txi_123"
         )
@@ -161,7 +161,7 @@ module Stripe
 
     context "#delete_tax_id" do
       should "delete a tax id" do
-        Stripe::Customer.delete_tax_id(
+        StripeClient.new.customers.delete_tax_id(
           "cus_123",
           "txi_123"
         )
@@ -171,7 +171,7 @@ module Stripe
 
     context "#list_tax_ids" do
       should "list the customer's tax ids" do
-        sources = Stripe::Customer.list_tax_ids(
+        sources = StripeClient.new.customers.list_tax_ids(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/tax_ids"
@@ -182,7 +182,7 @@ module Stripe
 
     context "#create_balance_transaction" do
       should "create a customer balance transaction" do
-        Stripe::Customer.create_balance_transaction(
+        StripeClient.new.customers.create_balance_transaction(
           "cus_123",
           amount: 1234,
           currency: "usd"
@@ -193,7 +193,7 @@ module Stripe
 
     context "#retrieve_balance_transaction" do
       should "retrieve a customer balance transaction" do
-        Stripe::Customer.retrieve_balance_transaction(
+        StripeClient.new.customers.retrieve_balance_transaction(
           "cus_123",
           "cbtxn_123"
         )
@@ -203,7 +203,7 @@ module Stripe
 
     context "#update_balance_transaction" do
       should "update a customer balance transaction" do
-        Stripe::Customer.update_balance_transaction(
+        StripeClient.new.customers.update_balance_transaction(
           "cus_123",
           "cbtxn_123",
           description: "new"
@@ -214,7 +214,7 @@ module Stripe
 
     context "#list_balance_transactions" do
       should "list the customer balance transactions" do
-        sources = Stripe::Customer.list_balance_transactions(
+        sources = StripeClient.new.customers.list_balance_transactions(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/balance_transactions"

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -5,40 +5,40 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class CustomerTest < Test::Unit::TestCase
     should "be listable" do
-      customers = StripeClient.new.customers.list
+      customers = StripeClient.new.customer.list
       assert_requested :get, "#{Stripe.api_base}/v1/customers"
       assert customers.data.is_a?(Array)
       assert customers.first.is_a?(Stripe::Customer)
     end
 
     should "be retrievable" do
-      customer = StripeClient.new.customers.retrieve("cus_123")
+      customer = StripeClient.new.customer.retrieve("cus_123")
       assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123"
       assert customer.is_a?(Stripe::Customer)
     end
 
     should "be creatable" do
-      customer = StripeClient.new.customers.create
+      customer = StripeClient.new.customer.create
       assert_requested :post, "#{Stripe.api_base}/v1/customers"
       assert customer.is_a?(Stripe::Customer)
     end
 
     should "be saveable" do
-      customer = StripeClient.new.customers.retrieve("cus_123")
+      customer = StripeClient.new.customer.retrieve("cus_123")
       customer.metadata["key"] = "value"
       customer.save
       assert_requested :post, "#{Stripe.api_base}/v1/customers/#{customer.id}"
     end
 
     should "be updateable" do
-      customer = StripeClient.new.customers.update("cus_123", metadata: { key: "value" })
+      customer = StripeClient.new.customer.update("cus_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/customers/cus_123"
       assert customer.is_a?(Stripe::Customer)
     end
 
     context "#delete" do
       should "be deletable" do
-        customer = StripeClient.new.customers.retrieve("cus_123")
+        customer = StripeClient.new.customer.retrieve("cus_123")
         customer = customer.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/#{customer.id}"
         assert customer.is_a?(Stripe::Customer)
@@ -47,7 +47,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        customer = StripeClient.new.customers.delete("cus_123")
+        customer = StripeClient.new.customer.delete("cus_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123"
         assert customer.is_a?(Stripe::Customer)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context ".delete_discount" do
       should "delete a discount" do
-        discount = StripeClient.new.customers.delete_discount("cus_123")
+        discount = StripeClient.new.customer.delete_discount("cus_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/discount"
         assert discount.is_a?(Stripe::Discount)
       end
@@ -72,7 +72,7 @@ module Stripe
 
     context "#create_source" do
       should "create a source" do
-        StripeClient.new.customers.create_source(
+        StripeClient.new.customer.create_source(
           "cus_123",
           source: "tok_123"
         )
@@ -82,7 +82,7 @@ module Stripe
 
     context "#retrieve_source" do
       should "retrieve a source" do
-        StripeClient.new.customers.retrieve_source(
+        StripeClient.new.customer.retrieve_source(
           "cus_123",
           "ba_123"
         )
@@ -92,7 +92,7 @@ module Stripe
 
     context "#update_source" do
       should "update a source" do
-        StripeClient.new.customers.update_source(
+        StripeClient.new.customer.update_source(
           "cus_123",
           "ba_123",
           metadata: { foo: "bar" }
@@ -103,7 +103,7 @@ module Stripe
 
     context "#delete_source" do
       should "delete a source" do
-        StripeClient.new.customers.delete_source(
+        StripeClient.new.customer.delete_source(
           "cus_123",
           "ba_123"
         )
@@ -113,7 +113,7 @@ module Stripe
 
     context "#list_sources" do
       should "list the customer's sources" do
-        sources = StripeClient.new.customers.list_sources(
+        sources = StripeClient.new.customer.list_sources(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/sources"
@@ -124,13 +124,13 @@ module Stripe
 
     context "source field" do
       should "allow setting source with token" do
-        c = StripeClient.new.customers.new("test_customer")
+        c = StripeClient.new.customer.new("test_customer")
         c.source = "tok_123"
         assert_equal "tok_123", c.source
       end
 
       should "allow setting source with hash and set flag" do
-        c = StripeClient.new.customers.new("test_customer")
+        c = StripeClient.new.customer.new("test_customer")
         c.source = {
           object: "card",
         }
@@ -140,7 +140,7 @@ module Stripe
 
     context "#create_tax_id" do
       should "create a tax id" do
-        StripeClient.new.customers.create_tax_id(
+        StripeClient.new.customer.create_tax_id(
           "cus_123",
           type: "eu_vat",
           value: "11111"
@@ -151,7 +151,7 @@ module Stripe
 
     context "#retrieve_tax_id" do
       should "retrieve a tax id" do
-        StripeClient.new.customers.retrieve_tax_id(
+        StripeClient.new.customer.retrieve_tax_id(
           "cus_123",
           "txi_123"
         )
@@ -161,7 +161,7 @@ module Stripe
 
     context "#delete_tax_id" do
       should "delete a tax id" do
-        StripeClient.new.customers.delete_tax_id(
+        StripeClient.new.customer.delete_tax_id(
           "cus_123",
           "txi_123"
         )
@@ -171,7 +171,7 @@ module Stripe
 
     context "#list_tax_ids" do
       should "list the customer's tax ids" do
-        sources = StripeClient.new.customers.list_tax_ids(
+        sources = StripeClient.new.customer.list_tax_ids(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/tax_ids"
@@ -182,7 +182,7 @@ module Stripe
 
     context "#create_balance_transaction" do
       should "create a customer balance transaction" do
-        StripeClient.new.customers.create_balance_transaction(
+        StripeClient.new.customer.create_balance_transaction(
           "cus_123",
           amount: 1234,
           currency: "usd"
@@ -193,7 +193,7 @@ module Stripe
 
     context "#retrieve_balance_transaction" do
       should "retrieve a customer balance transaction" do
-        StripeClient.new.customers.retrieve_balance_transaction(
+        StripeClient.new.customer.retrieve_balance_transaction(
           "cus_123",
           "cbtxn_123"
         )
@@ -203,7 +203,7 @@ module Stripe
 
     context "#update_balance_transaction" do
       should "update a customer balance transaction" do
-        StripeClient.new.customers.update_balance_transaction(
+        StripeClient.new.customer.update_balance_transaction(
           "cus_123",
           "cbtxn_123",
           description: "new"
@@ -214,7 +214,7 @@ module Stripe
 
     context "#list_balance_transactions" do
       should "list the customer balance transactions" do
-        sources = StripeClient.new.customers.list_balance_transactions(
+        sources = StripeClient.new.customer.list_balance_transactions(
           "cus_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/customers/cus_123/balance_transactions"

--- a/test/stripe/dispute_test.rb
+++ b/test/stripe/dispute_test.rb
@@ -5,34 +5,34 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class DisputeTest < Test::Unit::TestCase
     should "be listable" do
-      disputes = Stripe::Dispute.list
+      disputes = StripeClient.new.disputes.list
       assert_requested :get, "#{Stripe.api_base}/v1/disputes"
       assert disputes.data.is_a?(Array)
       assert disputes.first.is_a?(Stripe::Dispute)
     end
 
     should "be retrievable" do
-      dispute = Stripe::Dispute.retrieve("dp_123")
+      dispute = StripeClient.new.disputes.retrieve("dp_123")
       assert_requested :get, "#{Stripe.api_base}/v1/disputes/dp_123"
       assert dispute.is_a?(Stripe::Dispute)
     end
 
     should "be saveable" do
-      dispute = Stripe::Dispute.retrieve("dp_123")
+      dispute = StripeClient.new.disputes.retrieve("dp_123")
       dispute.metadata["key"] = "value"
       dispute.save
       assert_requested :post, "#{Stripe.api_base}/v1/disputes/#{dispute.id}"
     end
 
     should "be updateable" do
-      dispute = Stripe::Dispute.update("dp_123", metadata: { key: "value" })
+      dispute = StripeClient.new.disputes.update("dp_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/disputes/dp_123"
       assert dispute.is_a?(Stripe::Dispute)
     end
 
     context "#close" do
       should "be closeable" do
-        dispute = Stripe::Dispute.retrieve("dp_123")
+        dispute = StripeClient.new.disputes.retrieve("dp_123")
         dispute.close
         assert_requested :post,
                          "#{Stripe.api_base}/v1/disputes/#{dispute.id}/close"
@@ -42,7 +42,7 @@ module Stripe
 
     context ".close" do
       should "close a dispute" do
-        dispute = Stripe::Dispute.close("dp_123")
+        dispute = StripeClient.new.disputes.close("dp_123")
         assert_requested :post, "#{Stripe.api_base}/v1/disputes/dp_123/close"
         assert dispute.is_a?(Stripe::Dispute)
       end

--- a/test/stripe/dispute_test.rb
+++ b/test/stripe/dispute_test.rb
@@ -5,34 +5,34 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class DisputeTest < Test::Unit::TestCase
     should "be listable" do
-      disputes = StripeClient.new.disputes.list
+      disputes = StripeClient.new.dispute.list
       assert_requested :get, "#{Stripe.api_base}/v1/disputes"
       assert disputes.data.is_a?(Array)
       assert disputes.first.is_a?(Stripe::Dispute)
     end
 
     should "be retrievable" do
-      dispute = StripeClient.new.disputes.retrieve("dp_123")
+      dispute = StripeClient.new.dispute.retrieve("dp_123")
       assert_requested :get, "#{Stripe.api_base}/v1/disputes/dp_123"
       assert dispute.is_a?(Stripe::Dispute)
     end
 
     should "be saveable" do
-      dispute = StripeClient.new.disputes.retrieve("dp_123")
+      dispute = StripeClient.new.dispute.retrieve("dp_123")
       dispute.metadata["key"] = "value"
       dispute.save
       assert_requested :post, "#{Stripe.api_base}/v1/disputes/#{dispute.id}"
     end
 
     should "be updateable" do
-      dispute = StripeClient.new.disputes.update("dp_123", metadata: { key: "value" })
+      dispute = StripeClient.new.dispute.update("dp_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/disputes/dp_123"
       assert dispute.is_a?(Stripe::Dispute)
     end
 
     context "#close" do
       should "be closeable" do
-        dispute = StripeClient.new.disputes.retrieve("dp_123")
+        dispute = StripeClient.new.dispute.retrieve("dp_123")
         dispute.close
         assert_requested :post,
                          "#{Stripe.api_base}/v1/disputes/#{dispute.id}/close"
@@ -42,7 +42,7 @@ module Stripe
 
     context ".close" do
       should "close a dispute" do
-        dispute = StripeClient.new.disputes.close("dp_123")
+        dispute = StripeClient.new.dispute.close("dp_123")
         assert_requested :post, "#{Stripe.api_base}/v1/disputes/dp_123/close"
         assert dispute.is_a?(Stripe::Dispute)
       end

--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class EphemeralKeyTest < Test::Unit::TestCase
     context "#create" do
       should "succeed" do
-        key = StripeClient.new.ephemeral_keys.create(
+        key = StripeClient.new.ephemeral_key.create(
           { customer: "cus_123" },
           stripe_version: "2017-05-25"
         )
@@ -22,7 +22,7 @@ module Stripe
 
       context "#no global version" do
         should "use the correct api version" do
-          key = StripeClient.new.ephemeral_keys.create(
+          key = StripeClient.new.ephemeral_key.create(
             { customer: "cus_123" },
             stripe_version: "2017-06-05"
           )
@@ -38,7 +38,7 @@ module Stripe
 
         should "error without an explicit api version" do
           e = assert_raises(ArgumentError) do
-            StripeClient.new.ephemeral_keys.create(customer: "cus_123")
+            StripeClient.new.ephemeral_key.create(customer: "cus_123")
           end
           assert_match("stripe_version must be specified", e.message)
         end
@@ -54,7 +54,7 @@ module Stripe
         end
 
         should "use the correct api version" do
-          key = StripeClient.new.ephemeral_keys.create(
+          key = StripeClient.new.ephemeral_key.create(
             { customer: "cus_123" },
             stripe_version: "2017-05-25"
           )
@@ -64,7 +64,7 @@ module Stripe
 
         should "error without an explicit api version" do
           e = assert_raises(ArgumentError) do
-            StripeClient.new.ephemeral_keys.create(customer: "cus_123")
+            StripeClient.new.ephemeral_key.create(customer: "cus_123")
           end
           assert_match("stripe_version must be specified", e.message)
         end
@@ -73,7 +73,7 @@ module Stripe
 
     context "#delete" do
       should "succeed" do
-        key = StripeClient.new.ephemeral_keys.create(
+        key = StripeClient.new.ephemeral_key.create(
           { customer: "cus_123" },
           stripe_version: "2017-05-25"
         )
@@ -85,7 +85,7 @@ module Stripe
 
     context ".delete" do
       should "succeed" do
-        StripeClient.new.ephemeral_keys.delete("ephkey_123")
+        StripeClient.new.ephemeral_key.delete("ephkey_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/ephemeral_keys/ephkey_123"
       end
     end

--- a/test/stripe/ephemeral_key_test.rb
+++ b/test/stripe/ephemeral_key_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class EphemeralKeyTest < Test::Unit::TestCase
     context "#create" do
       should "succeed" do
-        key = Stripe::EphemeralKey.create(
+        key = StripeClient.new.ephemeral_keys.create(
           { customer: "cus_123" },
           stripe_version: "2017-05-25"
         )
@@ -22,7 +22,7 @@ module Stripe
 
       context "#no global version" do
         should "use the correct api version" do
-          key = Stripe::EphemeralKey.create(
+          key = StripeClient.new.ephemeral_keys.create(
             { customer: "cus_123" },
             stripe_version: "2017-06-05"
           )
@@ -38,7 +38,7 @@ module Stripe
 
         should "error without an explicit api version" do
           e = assert_raises(ArgumentError) do
-            Stripe::EphemeralKey.create(customer: "cus_123")
+            StripeClient.new.ephemeral_keys.create(customer: "cus_123")
           end
           assert_match("stripe_version must be specified", e.message)
         end
@@ -54,7 +54,7 @@ module Stripe
         end
 
         should "use the correct api version" do
-          key = Stripe::EphemeralKey.create(
+          key = StripeClient.new.ephemeral_keys.create(
             { customer: "cus_123" },
             stripe_version: "2017-05-25"
           )
@@ -64,7 +64,7 @@ module Stripe
 
         should "error without an explicit api version" do
           e = assert_raises(ArgumentError) do
-            Stripe::EphemeralKey.create(customer: "cus_123")
+            StripeClient.new.ephemeral_keys.create(customer: "cus_123")
           end
           assert_match("stripe_version must be specified", e.message)
         end
@@ -73,7 +73,7 @@ module Stripe
 
     context "#delete" do
       should "succeed" do
-        key = Stripe::EphemeralKey.create(
+        key = StripeClient.new.ephemeral_keys.create(
           { customer: "cus_123" },
           stripe_version: "2017-05-25"
         )
@@ -85,7 +85,7 @@ module Stripe
 
     context ".delete" do
       should "succeed" do
-        Stripe::EphemeralKey.delete("ephkey_123")
+        StripeClient.new.ephemeral_keys.delete("ephkey_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/ephemeral_keys/ephkey_123"
       end
     end

--- a/test/stripe/exchange_rate_test.rb
+++ b/test/stripe/exchange_rate_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ExchangeRateTest < Test::Unit::TestCase
     should "be listable" do
-      list_rates = Stripe::ExchangeRate.list
+      list_rates = StripeClient.new.exchange_rates.list
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates"
       assert list_rates.data.is_a?(Array)
       assert list_rates.data.first.is_a?(Stripe::ExchangeRate)
     end
 
     should "be retrievable" do
-      rates = Stripe::ExchangeRate.retrieve("usd")
+      rates = StripeClient.new.exchange_rates.retrieve("usd")
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates/usd"
       assert rates.is_a?(Stripe::ExchangeRate)
     end

--- a/test/stripe/exchange_rate_test.rb
+++ b/test/stripe/exchange_rate_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ExchangeRateTest < Test::Unit::TestCase
     should "be listable" do
-      list_rates = StripeClient.new.exchange_rates.list
+      list_rates = StripeClient.new.exchange_rate.list
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates"
       assert list_rates.data.is_a?(Array)
       assert list_rates.data.first.is_a?(Stripe::ExchangeRate)
     end
 
     should "be retrievable" do
-      rates = StripeClient.new.exchange_rates.retrieve("usd")
+      rates = StripeClient.new.exchange_rate.retrieve("usd")
       assert_requested :get, "#{Stripe.api_base}/v1/exchange_rates/usd"
       assert rates.is_a?(Stripe::ExchangeRate)
     end

--- a/test/stripe/file_link_test.rb
+++ b/test/stripe/file_link_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class FileLinkTest < Test::Unit::TestCase
     should "be listable" do
-      file_links = StripeClient.new.file_links.list
+      file_links = StripeClient.new.file_link.list
       assert_requested :get, "#{Stripe.api_base}/v1/file_links"
       assert file_links.data.is_a?(Array)
       assert file_links.first.is_a?(Stripe::FileLink)
     end
 
     should "be retrievable" do
-      file_link = StripeClient.new.file_links.retrieve("link_123")
+      file_link = StripeClient.new.file_link.retrieve("link_123")
       assert_requested :get, "#{Stripe.api_base}/v1/file_links/link_123"
       assert file_link.is_a?(Stripe::FileLink)
     end
 
     should "be creatable" do
-      file_link = StripeClient.new.file_links.create(
+      file_link = StripeClient.new.file_link.create(
         file: "file_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/file_links"
@@ -26,14 +26,14 @@ module Stripe
     end
 
     should "be saveable" do
-      file_link = StripeClient.new.file_links.retrieve("link_123")
+      file_link = StripeClient.new.file_link.retrieve("link_123")
       file_link.metadata["key"] = "value"
       file_link.save
       assert_requested :post, "#{Stripe.api_base}/v1/file_links/#{file_link.id}"
     end
 
     should "be updateable" do
-      file_link = StripeClient.new.file_links.update("link_123", metadata: { key: "value" })
+      file_link = StripeClient.new.file_link.update("link_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/file_links/link_123"
       assert file_link.is_a?(Stripe::FileLink)
     end

--- a/test/stripe/file_link_test.rb
+++ b/test/stripe/file_link_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class FileLinkTest < Test::Unit::TestCase
     should "be listable" do
-      file_links = Stripe::FileLink.list
+      file_links = StripeClient.new.file_links.list
       assert_requested :get, "#{Stripe.api_base}/v1/file_links"
       assert file_links.data.is_a?(Array)
       assert file_links.first.is_a?(Stripe::FileLink)
     end
 
     should "be retrievable" do
-      file_link = Stripe::FileLink.retrieve("link_123")
+      file_link = StripeClient.new.file_links.retrieve("link_123")
       assert_requested :get, "#{Stripe.api_base}/v1/file_links/link_123"
       assert file_link.is_a?(Stripe::FileLink)
     end
 
     should "be creatable" do
-      file_link = Stripe::FileLink.create(
+      file_link = StripeClient.new.file_links.create(
         file: "file_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/file_links"
@@ -26,14 +26,14 @@ module Stripe
     end
 
     should "be saveable" do
-      file_link = Stripe::FileLink.retrieve("link_123")
+      file_link = StripeClient.new.file_links.retrieve("link_123")
       file_link.metadata["key"] = "value"
       file_link.save
       assert_requested :post, "#{Stripe.api_base}/v1/file_links/#{file_link.id}"
     end
 
     should "be updateable" do
-      file_link = Stripe::FileLink.update("link_123", metadata: { key: "value" })
+      file_link = StripeClient.new.file_links.update("link_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/file_links/link_123"
       assert file_link.is_a?(Stripe::FileLink)
     end

--- a/test/stripe/file_test.rb
+++ b/test/stripe/file_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class FileTest < Test::Unit::TestCase
     should "be listable" do
-      files = StripeClient.new.files.list
+      files = StripeClient.new.file.list
       assert_requested :get, "#{Stripe.api_base}/v1/files"
       assert files.data.is_a?(Array)
       assert files.data[0].is_a?(Stripe::File)
     end
 
     should "be retrievable" do
-      file = StripeClient.new.files.retrieve("file_123")
+      file = StripeClient.new.file.retrieve("file_123")
       assert_requested :get, "#{Stripe.api_base}/v1/files/file_123"
       assert file.is_a?(Stripe::File)
     end
@@ -29,7 +29,7 @@ module Stripe
       end
 
       should "be creatable with a File" do
-        file = StripeClient.new.files.create(
+        file = StripeClient.new.file.create(
           purpose: "dispute_evidence",
           file: ::File.new(__FILE__),
           file_link_data: { create: true }
@@ -43,7 +43,7 @@ module Stripe
         tempfile.write("Hello world")
         tempfile.rewind
 
-        file = StripeClient.new.files.create(
+        file = StripeClient.new.file.create(
           purpose: "dispute_evidence",
           file: tempfile,
           file_link_data: { create: true }
@@ -53,7 +53,7 @@ module Stripe
       end
 
       should "be creatable with a string" do
-        file = StripeClient.new.files.create(
+        file = StripeClient.new.file.create(
           purpose: "dispute_evidence",
           file: "my-file-contents",
           file_link_data: { create: true }
@@ -64,7 +64,7 @@ module Stripe
 
       should "raise given a file object that doesn't respond to #read" do
         e = assert_raises(ArgumentError) do
-          StripeClient.new.files.create(
+          StripeClient.new.file.create(
             purpose: "dispute_evidence",
             file: Object.new,
             file_link_data: { create: true }
@@ -78,7 +78,7 @@ module Stripe
           client = StripeClient.new(uploads_base: Stripe.uploads_base)
           Stripe.config.stubs(:uploads_base).returns("old")
 
-          file = client.files.create(
+          file = client.file.create(
             purpose: "dispute_evidence",
             file: ::File.new(__FILE__),
             file_link_data: { create: true }

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class InvoiceItemTest < Test::Unit::TestCase
     should "be listable" do
-      invoiceitems = StripeClient.new.invoiceitems.list
+      invoice_item = StripeClient.new.invoice_item.list
       assert_requested :get, "#{Stripe.api_base}/v1/invoiceitems"
-      assert invoiceitems.data.is_a?(Array)
-      assert invoiceitems.first.is_a?(Stripe::InvoiceItem)
+      assert invoice_item.data.is_a?(Array)
+      assert invoice_item.first.is_a?(Stripe::InvoiceItem)
     end
 
     should "be retrievable" do
-      item = StripeClient.new.invoiceitems.retrieve("ii_123")
+      item = StripeClient.new.invoice_item.retrieve("ii_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/invoiceitems/ii_123"
       assert item.is_a?(Stripe::InvoiceItem)
     end
 
     should "be creatable" do
-      item = StripeClient.new.invoiceitems.create(
+      item = StripeClient.new.invoice_item.create(
         amount: 100,
         currency: "USD",
         customer: "cus_123"
@@ -30,7 +30,7 @@ module Stripe
     end
 
     should "be saveable" do
-      item = StripeClient.new.invoiceitems.retrieve("ii_123")
+      item = StripeClient.new.invoice_item.retrieve("ii_123")
       item.metadata["key"] = "value"
       item.save
       assert_requested :post,
@@ -38,7 +38,7 @@ module Stripe
     end
 
     should "be updateable" do
-      item = StripeClient.new.invoiceitems.update("ii_123", metadata: { key: "value" })
+      item = StripeClient.new.invoice_item.update("ii_123", metadata: { key: "value" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/invoiceitems/ii_123"
       assert item.is_a?(Stripe::InvoiceItem)
@@ -46,7 +46,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        item = StripeClient.new.invoiceitems.retrieve("ii_123")
+        item = StripeClient.new.invoice_item.retrieve("ii_123")
         item = item.delete
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/invoiceitems/#{item.id}"
@@ -56,7 +56,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        item = StripeClient.new.invoiceitems.delete("ii_123")
+        item = StripeClient.new.invoice_item.delete("ii_123")
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/invoiceitems/ii_123"
         assert item.is_a?(Stripe::InvoiceItem)

--- a/test/stripe/invoice_item_test.rb
+++ b/test/stripe/invoice_item_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class InvoiceItemTest < Test::Unit::TestCase
     should "be listable" do
-      invoiceitems = Stripe::InvoiceItem.list
+      invoiceitems = StripeClient.new.invoiceitems.list
       assert_requested :get, "#{Stripe.api_base}/v1/invoiceitems"
       assert invoiceitems.data.is_a?(Array)
       assert invoiceitems.first.is_a?(Stripe::InvoiceItem)
     end
 
     should "be retrievable" do
-      item = Stripe::InvoiceItem.retrieve("ii_123")
+      item = StripeClient.new.invoiceitems.retrieve("ii_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/invoiceitems/ii_123"
       assert item.is_a?(Stripe::InvoiceItem)
     end
 
     should "be creatable" do
-      item = Stripe::InvoiceItem.create(
+      item = StripeClient.new.invoiceitems.create(
         amount: 100,
         currency: "USD",
         customer: "cus_123"
@@ -30,7 +30,7 @@ module Stripe
     end
 
     should "be saveable" do
-      item = Stripe::InvoiceItem.retrieve("ii_123")
+      item = StripeClient.new.invoiceitems.retrieve("ii_123")
       item.metadata["key"] = "value"
       item.save
       assert_requested :post,
@@ -38,7 +38,7 @@ module Stripe
     end
 
     should "be updateable" do
-      item = Stripe::InvoiceItem.update("ii_123", metadata: { key: "value" })
+      item = StripeClient.new.invoiceitems.update("ii_123", metadata: { key: "value" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/invoiceitems/ii_123"
       assert item.is_a?(Stripe::InvoiceItem)
@@ -46,7 +46,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        item = Stripe::InvoiceItem.retrieve("ii_123")
+        item = StripeClient.new.invoiceitems.retrieve("ii_123")
         item = item.delete
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/invoiceitems/#{item.id}"
@@ -56,7 +56,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        item = Stripe::InvoiceItem.delete("ii_123")
+        item = StripeClient.new.invoiceitems.delete("ii_123")
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/invoiceitems/ii_123"
         assert item.is_a?(Stripe::InvoiceItem)

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class InvoiceTest < Test::Unit::TestCase
     should "be listable" do
-      invoices = Stripe::Invoice.list
+      invoices = StripeClient.new.invoices.list
       assert_requested :get, "#{Stripe.api_base}/v1/invoices"
       assert invoices.data.is_a?(Array)
       assert invoices.first.is_a?(Stripe::Invoice)
     end
 
     should "be retrievable" do
-      invoice = Stripe::Invoice.retrieve("in_123")
+      invoice = StripeClient.new.invoices.retrieve("in_123")
       assert_requested :get, "#{Stripe.api_base}/v1/invoices/in_123"
       assert invoice.is_a?(Stripe::Invoice)
     end
 
     should "be creatable" do
-      invoice = Stripe::Invoice.create(
+      invoice = StripeClient.new.invoices.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/invoices"
@@ -26,21 +26,21 @@ module Stripe
     end
 
     should "be saveable" do
-      invoice = Stripe::Invoice.retrieve("in_123")
+      invoice = StripeClient.new.invoices.retrieve("in_123")
       invoice.metadata["key"] = "value"
       invoice.save
       assert_requested :post, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
     end
 
     should "be updateable" do
-      invoice = Stripe::Invoice.update("in_123", metadata: { key: "value" })
+      invoice = StripeClient.new.invoices.update("in_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123"
       assert invoice.is_a?(Stripe::Invoice)
     end
 
     context "#delete" do
       should "be deletable" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
         assert invoice.is_a?(Stripe::Invoice)
@@ -49,7 +49,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        invoice = Stripe::Invoice.delete("in_123")
+        invoice = StripeClient.new.invoices.delete("in_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/invoices/in_123"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -57,7 +57,7 @@ module Stripe
 
     context "#finalize" do
       should "finalize invoice" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.finalize_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/finalize"
@@ -67,7 +67,7 @@ module Stripe
 
     context ".finalize" do
       should "finalize invoice" do
-        invoice = Stripe::Invoice.finalize_invoice("in_123")
+        invoice = StripeClient.new.invoices.finalize_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/finalize"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -75,7 +75,7 @@ module Stripe
 
     context "#mark_uncollectible" do
       should "mark invoice as uncollectible" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.mark_uncollectible
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/mark_uncollectible"
@@ -85,7 +85,7 @@ module Stripe
 
     context ".mark_uncollectible" do
       should "mark invoice as uncollectible" do
-        invoice = Stripe::Invoice.mark_uncollectible("in_123")
+        invoice = StripeClient.new.invoices.mark_uncollectible("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/mark_uncollectible"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -93,7 +93,7 @@ module Stripe
 
     context "#pay" do
       should "pay invoice" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.pay
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/pay"
@@ -101,7 +101,7 @@ module Stripe
       end
 
       should "pay invoice with a specific source" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.pay(
           source: "src_123"
         )
@@ -116,7 +116,7 @@ module Stripe
 
     context ".pay" do
       should "pay invoice" do
-        invoice = Stripe::Invoice.pay("in_123", source: "src_123")
+        invoice = StripeClient.new.invoices.pay("in_123", source: "src_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/in_123/pay",
                          body: { source: "src_123" }
@@ -126,7 +126,7 @@ module Stripe
 
     context "#send_invoice" do
       should "send invoice" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.send_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/send"
@@ -136,7 +136,7 @@ module Stripe
 
     context ".send_invoice" do
       should "send invoice" do
-        invoice = Stripe::Invoice.send_invoice("in_123")
+        invoice = StripeClient.new.invoices.send_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/send"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -144,7 +144,7 @@ module Stripe
 
     context ".upcoming" do
       should "retrieve upcoming invoices" do
-        invoice = Stripe::Invoice.upcoming(
+        invoice = StripeClient.new.invoices.upcoming(
           customer: "cus_123",
           subscription: "sub_123"
         )
@@ -162,7 +162,7 @@ module Stripe
           { id: "si_123", deleted: true },
         ]
 
-        invoice = Stripe::Invoice.upcoming(
+        invoice = StripeClient.new.invoices.upcoming(
           customer: "cus_123",
           subscription_items: items
         )
@@ -179,7 +179,7 @@ module Stripe
       end
 
       should "be callable with an empty string" do
-        invoice = Stripe::Invoice.upcoming(
+        invoice = StripeClient.new.invoices.upcoming(
           coupon: "",
           customer: "cus_123"
         )
@@ -194,7 +194,7 @@ module Stripe
 
     context ".list_upcoming_line_items" do
       should "retrieve upcoming invoices" do
-        line_items = Stripe::Invoice.list_upcoming_line_items(
+        line_items = StripeClient.new.invoices.list_upcoming_line_items(
           customer: "cus_123",
           subscription: "sub_123"
         )
@@ -210,7 +210,7 @@ module Stripe
 
     context "#void_invoice" do
       should "void invoice" do
-        invoice = Stripe::Invoice.retrieve("in_123")
+        invoice = StripeClient.new.invoices.retrieve("in_123")
         invoice = invoice.void_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/void"
@@ -220,7 +220,7 @@ module Stripe
 
     context ".void_invoice" do
       should "void invoice" do
-        invoice = Stripe::Invoice.void_invoice("in_123")
+        invoice = StripeClient.new.invoices.void_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/void"
         assert invoice.is_a?(Stripe::Invoice)
       end

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class InvoiceTest < Test::Unit::TestCase
     should "be listable" do
-      invoices = StripeClient.new.invoices.list
+      invoices = StripeClient.new.invoice.list
       assert_requested :get, "#{Stripe.api_base}/v1/invoices"
       assert invoices.data.is_a?(Array)
       assert invoices.first.is_a?(Stripe::Invoice)
     end
 
     should "be retrievable" do
-      invoice = StripeClient.new.invoices.retrieve("in_123")
+      invoice = StripeClient.new.invoice.retrieve("in_123")
       assert_requested :get, "#{Stripe.api_base}/v1/invoices/in_123"
       assert invoice.is_a?(Stripe::Invoice)
     end
 
     should "be creatable" do
-      invoice = StripeClient.new.invoices.create(
+      invoice = StripeClient.new.invoice.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/invoices"
@@ -26,21 +26,21 @@ module Stripe
     end
 
     should "be saveable" do
-      invoice = StripeClient.new.invoices.retrieve("in_123")
+      invoice = StripeClient.new.invoice.retrieve("in_123")
       invoice.metadata["key"] = "value"
       invoice.save
       assert_requested :post, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
     end
 
     should "be updateable" do
-      invoice = StripeClient.new.invoices.update("in_123", metadata: { key: "value" })
+      invoice = StripeClient.new.invoice.update("in_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123"
       assert invoice.is_a?(Stripe::Invoice)
     end
 
     context "#delete" do
       should "be deletable" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/invoices/#{invoice.id}"
         assert invoice.is_a?(Stripe::Invoice)
@@ -49,7 +49,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        invoice = StripeClient.new.invoices.delete("in_123")
+        invoice = StripeClient.new.invoice.delete("in_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/invoices/in_123"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -57,7 +57,7 @@ module Stripe
 
     context "#finalize" do
       should "finalize invoice" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.finalize_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/finalize"
@@ -67,7 +67,7 @@ module Stripe
 
     context ".finalize" do
       should "finalize invoice" do
-        invoice = StripeClient.new.invoices.finalize_invoice("in_123")
+        invoice = StripeClient.new.invoice.finalize_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/finalize"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -75,7 +75,7 @@ module Stripe
 
     context "#mark_uncollectible" do
       should "mark invoice as uncollectible" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.mark_uncollectible
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/mark_uncollectible"
@@ -85,7 +85,7 @@ module Stripe
 
     context ".mark_uncollectible" do
       should "mark invoice as uncollectible" do
-        invoice = StripeClient.new.invoices.mark_uncollectible("in_123")
+        invoice = StripeClient.new.invoice.mark_uncollectible("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/mark_uncollectible"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -93,7 +93,7 @@ module Stripe
 
     context "#pay" do
       should "pay invoice" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.pay
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/pay"
@@ -101,7 +101,7 @@ module Stripe
       end
 
       should "pay invoice with a specific source" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.pay(
           source: "src_123"
         )
@@ -116,7 +116,7 @@ module Stripe
 
     context ".pay" do
       should "pay invoice" do
-        invoice = StripeClient.new.invoices.pay("in_123", source: "src_123")
+        invoice = StripeClient.new.invoice.pay("in_123", source: "src_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/in_123/pay",
                          body: { source: "src_123" }
@@ -126,7 +126,7 @@ module Stripe
 
     context "#send_invoice" do
       should "send invoice" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.send_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/send"
@@ -136,7 +136,7 @@ module Stripe
 
     context ".send_invoice" do
       should "send invoice" do
-        invoice = StripeClient.new.invoices.send_invoice("in_123")
+        invoice = StripeClient.new.invoice.send_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/send"
         assert invoice.is_a?(Stripe::Invoice)
       end
@@ -144,7 +144,7 @@ module Stripe
 
     context ".upcoming" do
       should "retrieve upcoming invoices" do
-        invoice = StripeClient.new.invoices.upcoming(
+        invoice = StripeClient.new.invoice.upcoming(
           customer: "cus_123",
           subscription: "sub_123"
         )
@@ -162,7 +162,7 @@ module Stripe
           { id: "si_123", deleted: true },
         ]
 
-        invoice = StripeClient.new.invoices.upcoming(
+        invoice = StripeClient.new.invoice.upcoming(
           customer: "cus_123",
           subscription_items: items
         )
@@ -179,7 +179,7 @@ module Stripe
       end
 
       should "be callable with an empty string" do
-        invoice = StripeClient.new.invoices.upcoming(
+        invoice = StripeClient.new.invoice.upcoming(
           coupon: "",
           customer: "cus_123"
         )
@@ -194,7 +194,7 @@ module Stripe
 
     context ".list_upcoming_line_items" do
       should "retrieve upcoming invoices" do
-        line_items = StripeClient.new.invoices.list_upcoming_line_items(
+        line_items = StripeClient.new.invoice.list_upcoming_line_items(
           customer: "cus_123",
           subscription: "sub_123"
         )
@@ -210,7 +210,7 @@ module Stripe
 
     context "#void_invoice" do
       should "void invoice" do
-        invoice = StripeClient.new.invoices.retrieve("in_123")
+        invoice = StripeClient.new.invoice.retrieve("in_123")
         invoice = invoice.void_invoice
         assert_requested :post,
                          "#{Stripe.api_base}/v1/invoices/#{invoice.id}/void"
@@ -220,7 +220,7 @@ module Stripe
 
     context ".void_invoice" do
       should "void invoice" do
-        invoice = StripeClient.new.invoices.void_invoice("in_123")
+        invoice = StripeClient.new.invoice.void_invoice("in_123")
         assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/void"
         assert invoice.is_a?(Stripe::Invoice)
       end

--- a/test/stripe/issuing/authorization_test.rb
+++ b/test/stripe/issuing/authorization_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Issuing
     class AuthorizationTest < Test::Unit::TestCase
       should "be listable" do
-        authorizations = Stripe::Issuing::Authorization.list
+        authorizations = StripeClient.new.issuing.authorizations.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/authorizations"
         assert authorizations.data.is_a?(Array)
         assert authorizations.data[0].is_a?(Stripe::Issuing::Authorization)
       end
 
       should "be retrievable" do
-        authorization = Stripe::Issuing::Authorization.retrieve("iauth_123")
+        authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123"
         assert authorization.is_a?(Stripe::Issuing::Authorization)
       end
 
       should "be saveable" do
-        authorization = Stripe::Issuing::Authorization.retrieve("iauth_123")
+        authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
         authorization.metadata["key"] = "value"
         authorization.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/#{authorization.id}"
@@ -27,14 +27,14 @@ module Stripe
       end
 
       should "be updateable" do
-        authorization = Stripe::Issuing::Authorization.update("iauth_123", metadata: { foo: "bar" })
+        authorization = StripeClient.new.issuing.authorizations.update("iauth_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123"
         assert authorization.is_a?(Stripe::Issuing::Authorization)
       end
 
       context ".approve" do
         should "approve an authorization" do
-          payment_intent = Stripe::Issuing::Authorization.approve("iauth_123")
+          payment_intent = StripeClient.new.issuing.authorizations.approve("iauth_123")
 
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/approve"
           assert payment_intent.is_a?(Stripe::Issuing::Authorization)
@@ -43,7 +43,7 @@ module Stripe
 
       context "#approve" do
         should "approve an authorization" do
-          authorization = Stripe::Issuing::Authorization.retrieve("iauth_123")
+          authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
           authorization.approve
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/approve"
           assert authorization.is_a?(Stripe::Issuing::Authorization)
@@ -52,7 +52,7 @@ module Stripe
 
       context ".decline" do
         should "decline an authorization" do
-          payment_intent = Stripe::Issuing::Authorization.decline("iauth_123")
+          payment_intent = StripeClient.new.issuing.authorizations.decline("iauth_123")
 
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/decline"
           assert payment_intent.is_a?(Stripe::Issuing::Authorization)
@@ -61,7 +61,7 @@ module Stripe
 
       context "#decline" do
         should "decline an authorization" do
-          authorization = Stripe::Issuing::Authorization.retrieve("iauth_123")
+          authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
           authorization.decline
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/decline"
           assert authorization.is_a?(Stripe::Issuing::Authorization)

--- a/test/stripe/issuing/authorization_test.rb
+++ b/test/stripe/issuing/authorization_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Issuing
     class AuthorizationTest < Test::Unit::TestCase
       should "be listable" do
-        authorizations = StripeClient.new.issuing.authorizations.list
+        authorizations = StripeClient.new.issuing.authorization.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/authorizations"
         assert authorizations.data.is_a?(Array)
         assert authorizations.data[0].is_a?(Stripe::Issuing::Authorization)
       end
 
       should "be retrievable" do
-        authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
+        authorization = StripeClient.new.issuing.authorization.retrieve("iauth_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123"
         assert authorization.is_a?(Stripe::Issuing::Authorization)
       end
 
       should "be saveable" do
-        authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
+        authorization = StripeClient.new.issuing.authorization.retrieve("iauth_123")
         authorization.metadata["key"] = "value"
         authorization.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/#{authorization.id}"
@@ -27,14 +27,14 @@ module Stripe
       end
 
       should "be updateable" do
-        authorization = StripeClient.new.issuing.authorizations.update("iauth_123", metadata: { foo: "bar" })
+        authorization = StripeClient.new.issuing.authorization.update("iauth_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123"
         assert authorization.is_a?(Stripe::Issuing::Authorization)
       end
 
       context ".approve" do
         should "approve an authorization" do
-          payment_intent = StripeClient.new.issuing.authorizations.approve("iauth_123")
+          payment_intent = StripeClient.new.issuing.authorization.approve("iauth_123")
 
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/approve"
           assert payment_intent.is_a?(Stripe::Issuing::Authorization)
@@ -43,7 +43,7 @@ module Stripe
 
       context "#approve" do
         should "approve an authorization" do
-          authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
+          authorization = StripeClient.new.issuing.authorization.retrieve("iauth_123")
           authorization.approve
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/approve"
           assert authorization.is_a?(Stripe::Issuing::Authorization)
@@ -52,7 +52,7 @@ module Stripe
 
       context ".decline" do
         should "decline an authorization" do
-          payment_intent = StripeClient.new.issuing.authorizations.decline("iauth_123")
+          payment_intent = StripeClient.new.issuing.authorization.decline("iauth_123")
 
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/decline"
           assert payment_intent.is_a?(Stripe::Issuing::Authorization)
@@ -61,7 +61,7 @@ module Stripe
 
       context "#decline" do
         should "decline an authorization" do
-          authorization = StripeClient.new.issuing.authorizations.retrieve("iauth_123")
+          authorization = StripeClient.new.issuing.authorization.retrieve("iauth_123")
           authorization.decline
           assert_requested :post, "#{Stripe.api_base}/v1/issuing/authorizations/iauth_123/decline"
           assert authorization.is_a?(Stripe::Issuing::Authorization)

--- a/test/stripe/issuing/card_test.rb
+++ b/test/stripe/issuing/card_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Issuing
     class CardTest < Test::Unit::TestCase
       should "be creatable" do
-        card = StripeClient.new.issuing.cards.create(
+        card = StripeClient.new.issuing.card.create(
           currency: "usd",
           type: "physical"
         )
@@ -15,20 +15,20 @@ module Stripe
       end
 
       should "be listable" do
-        cards = StripeClient.new.issuing.cards.list
+        cards = StripeClient.new.issuing.card.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards"
         assert cards.data.is_a?(Array)
         assert cards.data[0].is_a?(Stripe::Issuing::Card)
       end
 
       should "be retrievable" do
-        card = StripeClient.new.issuing.cards.retrieve("ic_123")
+        card = StripeClient.new.issuing.card.retrieve("ic_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
         assert card.is_a?(Stripe::Issuing::Card)
       end
 
       should "be saveable" do
-        card = StripeClient.new.issuing.cards.retrieve("ic_123")
+        card = StripeClient.new.issuing.card.retrieve("ic_123")
         card.metadata["key"] = "value"
         card.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
@@ -36,7 +36,7 @@ module Stripe
       end
 
       should "be updateable" do
-        card = StripeClient.new.issuing.cards.update("ic_123", metadata: { foo: "bar" })
+        card = StripeClient.new.issuing.card.update("ic_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
         assert card.is_a?(Stripe::Issuing::Card)
       end
@@ -47,7 +47,7 @@ module Stripe
           stub_request(:get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details")
             .to_return(body: JSON.generate(object: "issuing.card_details"))
 
-          card_details = StripeClient.new.issuing.cards.details("ic_123")
+          card_details = StripeClient.new.issuing.card.details("ic_123")
           assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details"
           assert card_details.is_a?(Stripe::Issuing::CardDetails)
         end
@@ -59,7 +59,7 @@ module Stripe
           stub_request(:get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details")
             .to_return(body: JSON.generate(object: "issuing.card_details"))
 
-          card = StripeClient.new.issuing.cards.construct_from(
+          card = StripeClient.new.issuing.card.construct_from(
             id: "ic_123",
             object: "issuing.card_details"
           )

--- a/test/stripe/issuing/card_test.rb
+++ b/test/stripe/issuing/card_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Issuing
     class CardTest < Test::Unit::TestCase
       should "be creatable" do
-        card = Stripe::Issuing::Card.create(
+        card = StripeClient.new.issuing.cards.create(
           currency: "usd",
           type: "physical"
         )
@@ -15,20 +15,20 @@ module Stripe
       end
 
       should "be listable" do
-        cards = Stripe::Issuing::Card.list
+        cards = StripeClient.new.issuing.cards.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards"
         assert cards.data.is_a?(Array)
         assert cards.data[0].is_a?(Stripe::Issuing::Card)
       end
 
       should "be retrievable" do
-        card = Stripe::Issuing::Card.retrieve("ic_123")
+        card = StripeClient.new.issuing.cards.retrieve("ic_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
         assert card.is_a?(Stripe::Issuing::Card)
       end
 
       should "be saveable" do
-        card = Stripe::Issuing::Card.retrieve("ic_123")
+        card = StripeClient.new.issuing.cards.retrieve("ic_123")
         card.metadata["key"] = "value"
         card.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
@@ -36,7 +36,7 @@ module Stripe
       end
 
       should "be updateable" do
-        card = Stripe::Issuing::Card.update("ic_123", metadata: { foo: "bar" })
+        card = StripeClient.new.issuing.cards.update("ic_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cards/ic_123"
         assert card.is_a?(Stripe::Issuing::Card)
       end
@@ -47,7 +47,7 @@ module Stripe
           stub_request(:get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details")
             .to_return(body: JSON.generate(object: "issuing.card_details"))
 
-          card_details = Stripe::Issuing::Card.details("ic_123")
+          card_details = StripeClient.new.issuing.cards.details("ic_123")
           assert_requested :get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details"
           assert card_details.is_a?(Stripe::Issuing::CardDetails)
         end
@@ -59,7 +59,7 @@ module Stripe
           stub_request(:get, "#{Stripe.api_base}/v1/issuing/cards/ic_123/details")
             .to_return(body: JSON.generate(object: "issuing.card_details"))
 
-          card = Stripe::Issuing::Card.construct_from(
+          card = StripeClient.new.issuing.cards.construct_from(
             id: "ic_123",
             object: "issuing.card_details"
           )

--- a/test/stripe/issuing/cardholder_test.rb
+++ b/test/stripe/issuing/cardholder_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Issuing
     class CardholderTest < Test::Unit::TestCase
       should "be creatable" do
-        cardholder = Stripe::Issuing::Cardholder.create(
+        cardholder = StripeClient.new.issuing.cardholders.create(
           billing: {
             address: {
               city: "city",
@@ -23,20 +23,20 @@ module Stripe
       end
 
       should "be listable" do
-        cardholders = Stripe::Issuing::Cardholder.list
+        cardholders = StripeClient.new.issuing.cardholders.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cardholders"
         assert cardholders.data.is_a?(Array)
         assert cardholders.data[0].is_a?(Stripe::Issuing::Cardholder)
       end
 
       should "be retrievable" do
-        cardholder = Stripe::Issuing::Cardholder.retrieve("ich_123")
+        cardholder = StripeClient.new.issuing.cardholders.retrieve("ich_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cardholders/ich_123"
         assert cardholder.is_a?(Stripe::Issuing::Cardholder)
       end
 
       should "be saveable" do
-        cardholder = Stripe::Issuing::Cardholder.retrieve("ich_123")
+        cardholder = StripeClient.new.issuing.cardholders.retrieve("ich_123")
         cardholder.metadata["key"] = "value"
         cardholder.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cardholders/#{cardholder.id}"
@@ -44,7 +44,7 @@ module Stripe
       end
 
       should "be updateable" do
-        cardholder = Stripe::Issuing::Cardholder.update("ich_123", metadata: { foo: "bar" })
+        cardholder = StripeClient.new.issuing.cardholders.update("ich_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cardholders/ich_123"
         assert cardholder.is_a?(Stripe::Issuing::Cardholder)
       end

--- a/test/stripe/issuing/cardholder_test.rb
+++ b/test/stripe/issuing/cardholder_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Issuing
     class CardholderTest < Test::Unit::TestCase
       should "be creatable" do
-        cardholder = StripeClient.new.issuing.cardholders.create(
+        cardholder = StripeClient.new.issuing.cardholder.create(
           billing: {
             address: {
               city: "city",
@@ -23,20 +23,20 @@ module Stripe
       end
 
       should "be listable" do
-        cardholders = StripeClient.new.issuing.cardholders.list
+        cardholders = StripeClient.new.issuing.cardholder.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cardholders"
         assert cardholders.data.is_a?(Array)
         assert cardholders.data[0].is_a?(Stripe::Issuing::Cardholder)
       end
 
       should "be retrievable" do
-        cardholder = StripeClient.new.issuing.cardholders.retrieve("ich_123")
+        cardholder = StripeClient.new.issuing.cardholder.retrieve("ich_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/cardholders/ich_123"
         assert cardholder.is_a?(Stripe::Issuing::Cardholder)
       end
 
       should "be saveable" do
-        cardholder = StripeClient.new.issuing.cardholders.retrieve("ich_123")
+        cardholder = StripeClient.new.issuing.cardholder.retrieve("ich_123")
         cardholder.metadata["key"] = "value"
         cardholder.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cardholders/#{cardholder.id}"
@@ -44,7 +44,7 @@ module Stripe
       end
 
       should "be updateable" do
-        cardholder = StripeClient.new.issuing.cardholders.update("ich_123", metadata: { foo: "bar" })
+        cardholder = StripeClient.new.issuing.cardholder.update("ich_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/cardholders/ich_123"
         assert cardholder.is_a?(Stripe::Issuing::Cardholder)
       end

--- a/test/stripe/issuing/dispute_test.rb
+++ b/test/stripe/issuing/dispute_test.rb
@@ -6,34 +6,34 @@ module Stripe
   module Issuing
     class DisputeTest < Test::Unit::TestCase
       should "be creatable" do
-        dispute = Stripe::Issuing::Dispute.create(transaction: "ipi_123")
+        dispute = StripeClient.new.issuing.disputes.create(transaction: "ipi_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be listable" do
-        disputes = Stripe::Issuing::Dispute.list
+        disputes = StripeClient.new.issuing.disputes.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/disputes"
         assert disputes.data.is_a?(Array)
         assert disputes.data[0].is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be retrievable" do
-        dispute = Stripe::Issuing::Dispute.retrieve("ich_123")
+        dispute = StripeClient.new.issuing.disputes.retrieve("ich_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/disputes/ich_123"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be updateable" do
-        dispute = Stripe::Issuing::Dispute.update("ich_123", {})
+        dispute = StripeClient.new.issuing.disputes.update("ich_123", {})
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes/ich_123"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       context "#submit" do
         should "submit the dispute" do
-          dispute = Stripe::Issuing::Dispute.retrieve("idp_123")
+          dispute = StripeClient.new.issuing.disputes.retrieve("idp_123")
           dispute = dispute.submit
           assert_requested :post,
                            "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
@@ -43,7 +43,7 @@ module Stripe
 
       context ".submit" do
         should "submit the dispute" do
-          dispute = Stripe::Issuing::Dispute.submit("idp_123")
+          dispute = StripeClient.new.issuing.disputes.submit("idp_123")
           assert_requested :post,
                            "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
           assert dispute.is_a?(Stripe::Issuing::Dispute)

--- a/test/stripe/issuing/dispute_test.rb
+++ b/test/stripe/issuing/dispute_test.rb
@@ -6,34 +6,34 @@ module Stripe
   module Issuing
     class DisputeTest < Test::Unit::TestCase
       should "be creatable" do
-        dispute = StripeClient.new.issuing.disputes.create(transaction: "ipi_123")
+        dispute = StripeClient.new.issuing.dispute.create(transaction: "ipi_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be listable" do
-        disputes = StripeClient.new.issuing.disputes.list
+        disputes = StripeClient.new.issuing.dispute.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/disputes"
         assert disputes.data.is_a?(Array)
         assert disputes.data[0].is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be retrievable" do
-        dispute = StripeClient.new.issuing.disputes.retrieve("ich_123")
+        dispute = StripeClient.new.issuing.dispute.retrieve("ich_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/disputes/ich_123"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       should "be updateable" do
-        dispute = StripeClient.new.issuing.disputes.update("ich_123", {})
+        dispute = StripeClient.new.issuing.dispute.update("ich_123", {})
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/disputes/ich_123"
         assert dispute.is_a?(Stripe::Issuing::Dispute)
       end
 
       context "#submit" do
         should "submit the dispute" do
-          dispute = StripeClient.new.issuing.disputes.retrieve("idp_123")
+          dispute = StripeClient.new.issuing.dispute.retrieve("idp_123")
           dispute = dispute.submit
           assert_requested :post,
                            "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
@@ -43,7 +43,7 @@ module Stripe
 
       context ".submit" do
         should "submit the dispute" do
-          dispute = StripeClient.new.issuing.disputes.submit("idp_123")
+          dispute = StripeClient.new.issuing.dispute.submit("idp_123")
           assert_requested :post,
                            "#{Stripe.api_base}/v1/issuing/disputes/idp_123/submit"
           assert dispute.is_a?(Stripe::Issuing::Dispute)

--- a/test/stripe/issuing/transaction_test.rb
+++ b/test/stripe/issuing/transaction_test.rb
@@ -9,7 +9,7 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/issuing/transactions")
           .to_return(body: JSON.generate(object: "list", data: [{ id: "ipi_123", object: "issuing.transaction" }]))
 
-        transactions = StripeClient.new.issuing.transactions.list
+        transactions = StripeClient.new.issuing.transaction.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/transactions"
         assert transactions.data.is_a?(Array)
         assert transactions.data[0].is_a?(Stripe::Issuing::Transaction)
@@ -19,7 +19,7 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = StripeClient.new.issuing.transactions.retrieve("ipi_123")
+        transaction = StripeClient.new.issuing.transaction.retrieve("ipi_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123"
         assert transaction.is_a?(Stripe::Issuing::Transaction)
       end
@@ -28,7 +28,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = StripeClient.new.issuing.transactions.construct_from(id: "ipi_123", object: "issuing.transaction", metadata: {})
+        transaction = StripeClient.new.issuing.transaction.construct_from(id: "ipi_123", object: "issuing.transaction", metadata: {})
         transaction.metadata["key"] = "value"
         transaction.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/transactions/#{transaction.id}"
@@ -39,7 +39,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = StripeClient.new.issuing.transactions.update("ipi_123", metadata: { foo: "bar" })
+        transaction = StripeClient.new.issuing.transaction.update("ipi_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123"
         assert transaction.is_a?(Stripe::Issuing::Transaction)
       end

--- a/test/stripe/issuing/transaction_test.rb
+++ b/test/stripe/issuing/transaction_test.rb
@@ -9,7 +9,7 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/issuing/transactions")
           .to_return(body: JSON.generate(object: "list", data: [{ id: "ipi_123", object: "issuing.transaction" }]))
 
-        transactions = Stripe::Issuing::Transaction.list
+        transactions = StripeClient.new.issuing.transactions.list
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/transactions"
         assert transactions.data.is_a?(Array)
         assert transactions.data[0].is_a?(Stripe::Issuing::Transaction)
@@ -19,7 +19,7 @@ module Stripe
         stub_request(:get, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = Stripe::Issuing::Transaction.retrieve("ipi_123")
+        transaction = StripeClient.new.issuing.transactions.retrieve("ipi_123")
         assert_requested :get, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123"
         assert transaction.is_a?(Stripe::Issuing::Transaction)
       end
@@ -28,7 +28,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = Stripe::Issuing::Transaction.construct_from(id: "ipi_123", object: "issuing.transaction", metadata: {})
+        transaction = StripeClient.new.issuing.transactions.construct_from(id: "ipi_123", object: "issuing.transaction", metadata: {})
         transaction.metadata["key"] = "value"
         transaction.save
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/transactions/#{transaction.id}"
@@ -39,7 +39,7 @@ module Stripe
         stub_request(:post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123")
           .to_return(body: JSON.generate(id: "ipi_123", object: "issuing.transaction"))
 
-        transaction = Stripe::Issuing::Transaction.update("ipi_123", metadata: { foo: "bar" })
+        transaction = StripeClient.new.issuing.transactions.update("ipi_123", metadata: { foo: "bar" })
         assert_requested :post, "#{Stripe.api_base}/v1/issuing/transactions/ipi_123"
         assert transaction.is_a?(Stripe::Issuing::Transaction)
       end

--- a/test/stripe/login_link_test.rb
+++ b/test/stripe/login_link_test.rb
@@ -15,7 +15,7 @@ module Stripe
           "url" => "/v1/accounts/acct_123/login_links",
         },
       }
-      @account = Stripe::Account.construct_from(account_fixture)
+      @account = StripeClient.new.accounts.construct_from(account_fixture)
     end
 
     should "not be retrievable" do

--- a/test/stripe/login_link_test.rb
+++ b/test/stripe/login_link_test.rb
@@ -15,7 +15,7 @@ module Stripe
           "url" => "/v1/accounts/acct_123/login_links",
         },
       }
-      @account = StripeClient.new.accounts.construct_from(account_fixture)
+      @account = StripeClient.new.account.construct_from(account_fixture)
     end
 
     should "not be retrievable" do

--- a/test/stripe/mandate_test.rb
+++ b/test/stripe/mandate_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class MandateTest < Test::Unit::TestCase
     should "be retrievable" do
-      schedule = Stripe::Mandate.retrieve("mandate_123")
+      schedule = StripeClient.new.mandates.retrieve("mandate_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/mandates/mandate_123"
       assert schedule.is_a?(Stripe::Mandate)

--- a/test/stripe/mandate_test.rb
+++ b/test/stripe/mandate_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class MandateTest < Test::Unit::TestCase
     should "be retrievable" do
-      schedule = StripeClient.new.mandates.retrieve("mandate_123")
+      schedule = StripeClient.new.mandate.retrieve("mandate_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/mandates/mandate_123"
       assert schedule.is_a?(Stripe::Mandate)

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -28,7 +28,6 @@ module Stripe
         assert_equal("https", uri.scheme)
         assert_equal("connect.stripe.com", uri.host)
         assert_equal("/oauth/authorize", uri.path)
-
         assert_equal(["ca_test"], params["client_id"])
         assert_equal(["read_write"], params["scope"])
         assert_equal(["test@example.com"], params["stripe_user[email]"])

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class OrderReturnTest < Test::Unit::TestCase
     should "be listable" do
-      order_returns = StripeClient.new.order_returns.list
+      order_returns = StripeClient.new.order_return.list
       assert_requested :get, "#{Stripe.api_base}/v1/order_returns"
       assert order_returns.data.is_a?(Array)
       assert order_returns.data[0].is_a?(Stripe::OrderReturn)
     end
 
     should "be retrievable" do
-      order_return = StripeClient.new.order_returns.retrieve("orret_123")
+      order_return = StripeClient.new.order_return.retrieve("orret_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/order_returns/orret_123"
       assert order_return.is_a?(Stripe::OrderReturn)

--- a/test/stripe/order_return_test.rb
+++ b/test/stripe/order_return_test.rb
@@ -5,14 +5,14 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class OrderReturnTest < Test::Unit::TestCase
     should "be listable" do
-      order_returns = Stripe::OrderReturn.list
+      order_returns = StripeClient.new.order_returns.list
       assert_requested :get, "#{Stripe.api_base}/v1/order_returns"
       assert order_returns.data.is_a?(Array)
       assert order_returns.data[0].is_a?(Stripe::OrderReturn)
     end
 
     should "be retrievable" do
-      order_return = Stripe::OrderReturn.retrieve("orret_123")
+      order_return = StripeClient.new.order_returns.retrieve("orret_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/order_returns/orret_123"
       assert order_return.is_a?(Stripe::OrderReturn)

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class OrderTest < Test::Unit::TestCase
     should "be listable" do
-      orders = Stripe::Order.list
+      orders = StripeClient.new.orders.list
       assert_requested :get, "#{Stripe.api_base}/v1/orders"
       assert orders.data.is_a?(Array)
       assert orders.first.is_a?(Stripe::Order)
     end
 
     should "be retrievable" do
-      order = Stripe::Order.retrieve("or_123")
+      order = StripeClient.new.orders.retrieve("or_123")
       assert_requested :get, "#{Stripe.api_base}/v1/orders/or_123"
       assert order.is_a?(Stripe::Order)
     end
 
     should "be creatable" do
-      order = Stripe::Order.create(
+      order = StripeClient.new.orders.create(
         currency: "USD"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/orders"
@@ -26,28 +26,28 @@ module Stripe
     end
 
     should "be saveable" do
-      order = Stripe::Order.retrieve("or_123")
+      order = StripeClient.new.orders.retrieve("or_123")
       order.metadata["key"] = "value"
       order.save
       assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}"
     end
 
     should "be updateable" do
-      order = Stripe::Order.update("or_123", metadata: { key: "value" })
+      order = StripeClient.new.orders.update("or_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123"
       assert order.is_a?(Stripe::Order)
     end
 
     context "#pay" do
       should "pay an order" do
-        order = Stripe::Order.retrieve("or_123")
+        order = StripeClient.new.orders.retrieve("or_123")
         order = order.pay(source: "tok_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
         assert order.is_a?(Stripe::Order)
       end
 
       should "pay an order without additional arguments" do
-        order = Stripe::Order.retrieve("or_123")
+        order = StripeClient.new.orders.retrieve("or_123")
         order = order.pay
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
         assert order.is_a?(Stripe::Order)
@@ -56,7 +56,7 @@ module Stripe
 
     context ".pay" do
       should "pay an order" do
-        order = Stripe::Order.pay("or_123", source: "tok_123")
+        order = StripeClient.new.orders.pay("or_123", source: "tok_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123/pay"
         assert order.is_a?(Stripe::Order)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context "#return_order" do
       should "return an order" do
-        order = Stripe::Order.retrieve("or_123")
+        order = StripeClient.new.orders.retrieve("or_123")
         order_return = order.return_order({})
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/returns"
         assert order_return.is_a?(Stripe::OrderReturn)
@@ -73,7 +73,7 @@ module Stripe
 
     context ".return_order" do
       should "return an order" do
-        order_return = Stripe::Order.return_order("or_123")
+        order_return = StripeClient.new.orders.return_order("or_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123/returns"
         assert order_return.is_a?(Stripe::OrderReturn)
       end

--- a/test/stripe/order_test.rb
+++ b/test/stripe/order_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class OrderTest < Test::Unit::TestCase
     should "be listable" do
-      orders = StripeClient.new.orders.list
+      orders = StripeClient.new.order.list
       assert_requested :get, "#{Stripe.api_base}/v1/orders"
       assert orders.data.is_a?(Array)
       assert orders.first.is_a?(Stripe::Order)
     end
 
     should "be retrievable" do
-      order = StripeClient.new.orders.retrieve("or_123")
+      order = StripeClient.new.order.retrieve("or_123")
       assert_requested :get, "#{Stripe.api_base}/v1/orders/or_123"
       assert order.is_a?(Stripe::Order)
     end
 
     should "be creatable" do
-      order = StripeClient.new.orders.create(
+      order = StripeClient.new.order.create(
         currency: "USD"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/orders"
@@ -26,28 +26,28 @@ module Stripe
     end
 
     should "be saveable" do
-      order = StripeClient.new.orders.retrieve("or_123")
+      order = StripeClient.new.order.retrieve("or_123")
       order.metadata["key"] = "value"
       order.save
       assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}"
     end
 
     should "be updateable" do
-      order = StripeClient.new.orders.update("or_123", metadata: { key: "value" })
+      order = StripeClient.new.order.update("or_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123"
       assert order.is_a?(Stripe::Order)
     end
 
     context "#pay" do
       should "pay an order" do
-        order = StripeClient.new.orders.retrieve("or_123")
+        order = StripeClient.new.order.retrieve("or_123")
         order = order.pay(source: "tok_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
         assert order.is_a?(Stripe::Order)
       end
 
       should "pay an order without additional arguments" do
-        order = StripeClient.new.orders.retrieve("or_123")
+        order = StripeClient.new.order.retrieve("or_123")
         order = order.pay
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/pay"
         assert order.is_a?(Stripe::Order)
@@ -56,7 +56,7 @@ module Stripe
 
     context ".pay" do
       should "pay an order" do
-        order = StripeClient.new.orders.pay("or_123", source: "tok_123")
+        order = StripeClient.new.order.pay("or_123", source: "tok_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123/pay"
         assert order.is_a?(Stripe::Order)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context "#return_order" do
       should "return an order" do
-        order = StripeClient.new.orders.retrieve("or_123")
+        order = StripeClient.new.order.retrieve("or_123")
         order_return = order.return_order({})
         assert_requested :post, "#{Stripe.api_base}/v1/orders/#{order.id}/returns"
         assert order_return.is_a?(Stripe::OrderReturn)
@@ -73,7 +73,7 @@ module Stripe
 
     context ".return_order" do
       should "return an order" do
-        order_return = StripeClient.new.orders.return_order("or_123")
+        order_return = StripeClient.new.order.return_order("or_123")
         assert_requested :post, "#{Stripe.api_base}/v1/orders/or_123/returns"
         assert order_return.is_a?(Stripe::OrderReturn)
       end

--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -7,20 +7,20 @@ module Stripe
     TEST_RESOURCE_ID = "pi_123"
 
     should "be listable" do
-      payment_intents = StripeClient.new.payment_intents.list
+      payment_intents = StripeClient.new.payment_intent.list
       assert_requested :get, "#{Stripe.api_base}/v1/payment_intents"
       assert payment_intents.data.is_a?(Array)
       assert payment_intents.data[0].is_a?(Stripe::PaymentIntent)
     end
 
     should "be retrievable" do
-      payment_intent = StripeClient.new.payment_intents.retrieve("pi_123")
+      payment_intent = StripeClient.new.payment_intent.retrieve("pi_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payment_intents/pi_123"
       assert payment_intent.is_a?(Stripe::PaymentIntent)
     end
 
     should "be creatable" do
-      payment_intent = StripeClient.new.payment_intents.create(
+      payment_intent = StripeClient.new.payment_intent.create(
         amount: 1234,
         currency: "usd",
         payment_method_types: ["card"]
@@ -30,14 +30,14 @@ module Stripe
     end
 
     should "be saveable" do
-      payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent", metadata: {})
+      payment_intent = StripeClient.new.payment_intent.construct_from(id: "pi_123", object: "payment_intent", metadata: {})
       payment_intent.metadata["key"] = "value"
       payment_intent.save
       assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/#{payment_intent.id}"
     end
 
     should "be updateable" do
-      payment_intent = StripeClient.new.payment_intents.update("pi_123", metadata: { foo: "bar" })
+      payment_intent = StripeClient.new.payment_intent.update("pi_123", metadata: { foo: "bar" })
 
       assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123"
       assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -45,7 +45,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intent.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.cancel
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/cancel"
@@ -55,7 +55,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.cancel("pi_123")
+        payment_intent = StripeClient.new.payment_intent.cancel("pi_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/cancel"
         assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -64,7 +64,7 @@ module Stripe
 
     context "#capture" do
       should "capture a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intent.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.capture(
           amount_to_capture: 1234
         )
@@ -76,7 +76,7 @@ module Stripe
 
     context ".capture" do
       should "capture a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.capture("pi_123", amount_to_capture: 1234)
+        payment_intent = StripeClient.new.payment_intent.capture("pi_123", amount_to_capture: 1234)
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/capture"
         assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -85,7 +85,7 @@ module Stripe
 
     context "#confirm" do
       should "confirm a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intent.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.confirm(
           payment_method: "pm_123"
         )
@@ -97,7 +97,7 @@ module Stripe
 
     context ".confirm" do
       should "confirm a payment_intent" do
-        payment_intent = StripeClient.new.payment_intents.confirm("pi_123", payment_method: "pm_123")
+        payment_intent = StripeClient.new.payment_intent.confirm("pi_123", payment_method: "pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/confirm"
         assert payment_intent.is_a?(Stripe::PaymentIntent)

--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -7,20 +7,20 @@ module Stripe
     TEST_RESOURCE_ID = "pi_123"
 
     should "be listable" do
-      payment_intents = Stripe::PaymentIntent.list
+      payment_intents = StripeClient.new.payment_intents.list
       assert_requested :get, "#{Stripe.api_base}/v1/payment_intents"
       assert payment_intents.data.is_a?(Array)
       assert payment_intents.data[0].is_a?(Stripe::PaymentIntent)
     end
 
     should "be retrievable" do
-      payment_intent = Stripe::PaymentIntent.retrieve("pi_123")
+      payment_intent = StripeClient.new.payment_intents.retrieve("pi_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payment_intents/pi_123"
       assert payment_intent.is_a?(Stripe::PaymentIntent)
     end
 
     should "be creatable" do
-      payment_intent = Stripe::PaymentIntent.create(
+      payment_intent = StripeClient.new.payment_intents.create(
         amount: 1234,
         currency: "usd",
         payment_method_types: ["card"]
@@ -30,14 +30,14 @@ module Stripe
     end
 
     should "be saveable" do
-      payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent", metadata: {})
+      payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent", metadata: {})
       payment_intent.metadata["key"] = "value"
       payment_intent.save
       assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/#{payment_intent.id}"
     end
 
     should "be updateable" do
-      payment_intent = Stripe::PaymentIntent.update("pi_123", metadata: { foo: "bar" })
+      payment_intent = StripeClient.new.payment_intents.update("pi_123", metadata: { foo: "bar" })
 
       assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123"
       assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -45,7 +45,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.cancel
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/cancel"
@@ -55,7 +55,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.cancel("pi_123")
+        payment_intent = StripeClient.new.payment_intents.cancel("pi_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/cancel"
         assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -64,7 +64,7 @@ module Stripe
 
     context "#capture" do
       should "capture a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.capture(
           amount_to_capture: 1234
         )
@@ -76,7 +76,7 @@ module Stripe
 
     context ".capture" do
       should "capture a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.capture("pi_123", amount_to_capture: 1234)
+        payment_intent = StripeClient.new.payment_intents.capture("pi_123", amount_to_capture: 1234)
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/capture"
         assert payment_intent.is_a?(Stripe::PaymentIntent)
@@ -85,7 +85,7 @@ module Stripe
 
     context "#confirm" do
       should "confirm a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent")
+        payment_intent = StripeClient.new.payment_intents.construct_from(id: "pi_123", object: "payment_intent")
         payment_intent = payment_intent.confirm(
           payment_method: "pm_123"
         )
@@ -97,7 +97,7 @@ module Stripe
 
     context ".confirm" do
       should "confirm a payment_intent" do
-        payment_intent = Stripe::PaymentIntent.confirm("pi_123", payment_method: "pm_123")
+        payment_intent = StripeClient.new.payment_intents.confirm("pi_123", payment_method: "pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_intents/pi_123/confirm"
         assert payment_intent.is_a?(Stripe::PaymentIntent)

--- a/test/stripe/payment_method_test.rb
+++ b/test/stripe/payment_method_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PaymentMethodTest < Test::Unit::TestCase
     should "be listable" do
-      payment_methods = StripeClient.new.payment_methods.list(
+      payment_methods = StripeClient.new.payment_method.list(
         customer: "cus_123",
         type: "card"
       )
@@ -15,13 +15,13 @@ module Stripe
     end
 
     should "be retrievable" do
-      payment_method = StripeClient.new.payment_methods.retrieve("pm_123")
+      payment_method = StripeClient.new.payment_method.retrieve("pm_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payment_methods/pm_123"
       assert payment_method.is_a?(Stripe::PaymentMethod)
     end
 
     should "be creatable" do
-      payment_method = StripeClient.new.payment_methods.create(
+      payment_method = StripeClient.new.payment_method.create(
         type: "card"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods"
@@ -29,21 +29,21 @@ module Stripe
     end
 
     should "be saveable" do
-      payment_method = StripeClient.new.payment_methods.retrieve("pm_123")
+      payment_method = StripeClient.new.payment_method.retrieve("pm_123")
       payment_method.metadata["key"] = "value"
       payment_method.save
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/#{payment_method.id}"
     end
 
     should "be updateable" do
-      payment_method = StripeClient.new.payment_methods.update("pm_123", metadata: { key: "value" })
+      payment_method = StripeClient.new.payment_method.update("pm_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123"
       assert payment_method.is_a?(Stripe::PaymentMethod)
     end
 
     context "#attach" do
       should "attach payment_method" do
-        payment_method = StripeClient.new.payment_methods.construct_from(id: "pm_123", object: "payment_method")
+        payment_method = StripeClient.new.payment_method.construct_from(id: "pm_123", object: "payment_method")
         payment_method = payment_method.attach(
           customer: "cus_123"
         )
@@ -55,7 +55,7 @@ module Stripe
 
     context ".attach" do
       should "attach payment_method" do
-        payment_method = StripeClient.new.payment_methods.attach("pm_123", customer: "cus_123")
+        payment_method = StripeClient.new.payment_method.attach("pm_123", customer: "cus_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/attach"
         assert payment_method.is_a?(Stripe::PaymentMethod)
@@ -64,7 +64,7 @@ module Stripe
 
     context "#detach" do
       should "detach payment_method" do
-        payment_method = StripeClient.new.payment_methods.construct_from(id: "pm_123", object: "payment_method")
+        payment_method = StripeClient.new.payment_method.construct_from(id: "pm_123", object: "payment_method")
         payment_method = payment_method.detach
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/detach"
@@ -74,7 +74,7 @@ module Stripe
 
     context ".detach" do
       should "detach payment_method" do
-        payment_method = StripeClient.new.payment_methods.detach("pm_123")
+        payment_method = StripeClient.new.payment_method.detach("pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/detach"
         assert payment_method.is_a?(Stripe::PaymentMethod)

--- a/test/stripe/payment_method_test.rb
+++ b/test/stripe/payment_method_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PaymentMethodTest < Test::Unit::TestCase
     should "be listable" do
-      payment_methods = Stripe::PaymentMethod.list(
+      payment_methods = StripeClient.new.payment_methods.list(
         customer: "cus_123",
         type: "card"
       )
@@ -15,13 +15,13 @@ module Stripe
     end
 
     should "be retrievable" do
-      payment_method = Stripe::PaymentMethod.retrieve("pm_123")
+      payment_method = StripeClient.new.payment_methods.retrieve("pm_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payment_methods/pm_123"
       assert payment_method.is_a?(Stripe::PaymentMethod)
     end
 
     should "be creatable" do
-      payment_method = Stripe::PaymentMethod.create(
+      payment_method = StripeClient.new.payment_methods.create(
         type: "card"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods"
@@ -29,21 +29,21 @@ module Stripe
     end
 
     should "be saveable" do
-      payment_method = Stripe::PaymentMethod.retrieve("pm_123")
+      payment_method = StripeClient.new.payment_methods.retrieve("pm_123")
       payment_method.metadata["key"] = "value"
       payment_method.save
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/#{payment_method.id}"
     end
 
     should "be updateable" do
-      payment_method = Stripe::PaymentMethod.update("pm_123", metadata: { key: "value" })
+      payment_method = StripeClient.new.payment_methods.update("pm_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123"
       assert payment_method.is_a?(Stripe::PaymentMethod)
     end
 
     context "#attach" do
       should "attach payment_method" do
-        payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123", object: "payment_method")
+        payment_method = StripeClient.new.payment_methods.construct_from(id: "pm_123", object: "payment_method")
         payment_method = payment_method.attach(
           customer: "cus_123"
         )
@@ -55,7 +55,7 @@ module Stripe
 
     context ".attach" do
       should "attach payment_method" do
-        payment_method = Stripe::PaymentMethod.attach("pm_123", customer: "cus_123")
+        payment_method = StripeClient.new.payment_methods.attach("pm_123", customer: "cus_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/attach"
         assert payment_method.is_a?(Stripe::PaymentMethod)
@@ -64,7 +64,7 @@ module Stripe
 
     context "#detach" do
       should "detach payment_method" do
-        payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123", object: "payment_method")
+        payment_method = StripeClient.new.payment_methods.construct_from(id: "pm_123", object: "payment_method")
         payment_method = payment_method.detach
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/detach"
@@ -74,7 +74,7 @@ module Stripe
 
     context ".detach" do
       should "detach payment_method" do
-        payment_method = Stripe::PaymentMethod.detach("pm_123")
+        payment_method = StripeClient.new.payment_methods.detach("pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/payment_methods/pm_123/detach"
         assert payment_method.is_a?(Stripe::PaymentMethod)

--- a/test/stripe/payout_test.rb
+++ b/test/stripe/payout_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PayoutTest < Test::Unit::TestCase
     should "be listable" do
-      payouts = Stripe::Payout.list
+      payouts = StripeClient.new.payouts.list
       assert_requested :get, "#{Stripe.api_base}/v1/payouts"
       assert payouts.data.is_a?(Array)
       assert payouts.data[0].is_a?(Stripe::Payout)
     end
 
     should "be retrievable" do
-      payout = Stripe::Payout.retrieve("tr_123")
+      payout = StripeClient.new.payouts.retrieve("tr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payouts/tr_123"
       assert payout.is_a?(Stripe::Payout)
     end
 
     should "be creatable" do
-      payout = Stripe::Payout.create(
+      payout = StripeClient.new.payouts.create(
         amount: 100,
         currency: "USD"
       )
@@ -27,21 +27,21 @@ module Stripe
     end
 
     should "be saveable" do
-      payout = Stripe::Payout.retrieve("tr_123")
+      payout = StripeClient.new.payouts.retrieve("tr_123")
       payout.metadata["key"] = "value"
       payout.save
       assert_requested :post, "#{Stripe.api_base}/v1/payouts/#{payout.id}"
     end
 
     should "be updateable" do
-      payout = Stripe::Payout.update("tr_123", metadata: { foo: "bar" })
+      payout = StripeClient.new.payouts.update("tr_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/payouts/tr_123"
       assert payout.is_a?(Stripe::Payout)
     end
 
     context "#cancel" do
       should "cancel a payout" do
-        payout = Stripe::Payout.retrieve("tr_123")
+        payout = StripeClient.new.payouts.retrieve("tr_123")
         payout = payout.cancel
         assert payout.is_a?(Stripe::Payout)
       end
@@ -49,14 +49,14 @@ module Stripe
 
     context ".cancel" do
       should "cancel a payout" do
-        payout = Stripe::Payout.cancel("pm_123")
+        payout = StripeClient.new.payouts.cancel("pm_123")
         assert payout.is_a?(Stripe::Payout)
       end
     end
 
     context "#reverse" do
       should "reverse a payout" do
-        payout = Stripe::Payout.retrieve("tr_123")
+        payout = StripeClient.new.payouts.retrieve("tr_123")
         payout = payout.reverse
         assert payout.is_a?(Stripe::Payout)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context ".reverse" do
       should "reverse a payout" do
-        payout = Stripe::Payout.reverse("pm_123")
+        payout = StripeClient.new.payouts.reverse("pm_123")
         assert payout.is_a?(Stripe::Payout)
       end
     end

--- a/test/stripe/payout_test.rb
+++ b/test/stripe/payout_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PayoutTest < Test::Unit::TestCase
     should "be listable" do
-      payouts = StripeClient.new.payouts.list
+      payouts = StripeClient.new.payout.list
       assert_requested :get, "#{Stripe.api_base}/v1/payouts"
       assert payouts.data.is_a?(Array)
       assert payouts.data[0].is_a?(Stripe::Payout)
     end
 
     should "be retrievable" do
-      payout = StripeClient.new.payouts.retrieve("tr_123")
+      payout = StripeClient.new.payout.retrieve("tr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/payouts/tr_123"
       assert payout.is_a?(Stripe::Payout)
     end
 
     should "be creatable" do
-      payout = StripeClient.new.payouts.create(
+      payout = StripeClient.new.payout.create(
         amount: 100,
         currency: "USD"
       )
@@ -27,21 +27,21 @@ module Stripe
     end
 
     should "be saveable" do
-      payout = StripeClient.new.payouts.retrieve("tr_123")
+      payout = StripeClient.new.payout.retrieve("tr_123")
       payout.metadata["key"] = "value"
       payout.save
       assert_requested :post, "#{Stripe.api_base}/v1/payouts/#{payout.id}"
     end
 
     should "be updateable" do
-      payout = StripeClient.new.payouts.update("tr_123", metadata: { foo: "bar" })
+      payout = StripeClient.new.payout.update("tr_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/payouts/tr_123"
       assert payout.is_a?(Stripe::Payout)
     end
 
     context "#cancel" do
       should "cancel a payout" do
-        payout = StripeClient.new.payouts.retrieve("tr_123")
+        payout = StripeClient.new.payout.retrieve("tr_123")
         payout = payout.cancel
         assert payout.is_a?(Stripe::Payout)
       end
@@ -49,14 +49,14 @@ module Stripe
 
     context ".cancel" do
       should "cancel a payout" do
-        payout = StripeClient.new.payouts.cancel("pm_123")
+        payout = StripeClient.new.payout.cancel("pm_123")
         assert payout.is_a?(Stripe::Payout)
       end
     end
 
     context "#reverse" do
       should "reverse a payout" do
-        payout = StripeClient.new.payouts.retrieve("tr_123")
+        payout = StripeClient.new.payout.retrieve("tr_123")
         payout = payout.reverse
         assert payout.is_a?(Stripe::Payout)
       end
@@ -64,7 +64,7 @@ module Stripe
 
     context ".reverse" do
       should "reverse a payout" do
-        payout = StripeClient.new.payouts.reverse("pm_123")
+        payout = StripeClient.new.payout.reverse("pm_123")
         assert payout.is_a?(Stripe::Payout)
       end
     end

--- a/test/stripe/person_test.rb
+++ b/test/stripe/person_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class PersonTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        person = Stripe::Person.construct_from(
+        person = StripeClient.new.persons.construct_from(
           id: "person_123",
           account: "acct_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without an account" do
-        person = Stripe::Person.construct_from(id: "person_123")
+        person = StripeClient.new.persons.construct_from(id: "person_123")
         assert_raises NotImplementedError do
           person.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        Stripe::Person.retrieve("person_123")
+        StripeClient.new.persons.retrieve("person_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        Stripe::Person.update("person_123", {})
+        StripeClient.new.persons.update("person_123", {})
       end
     end
 

--- a/test/stripe/person_test.rb
+++ b/test/stripe/person_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class PersonTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        person = StripeClient.new.persons.construct_from(
+        person = StripeClient.new.person.construct_from(
           id: "person_123",
           account: "acct_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without an account" do
-        person = StripeClient.new.persons.construct_from(id: "person_123")
+        person = StripeClient.new.person.construct_from(id: "person_123")
         assert_raises NotImplementedError do
           person.resource_url
         end
@@ -24,13 +24,13 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        StripeClient.new.persons.retrieve("person_123")
+        StripeClient.new.person.retrieve("person_123")
       end
     end
 
     should "raise on #update" do
       assert_raises NotImplementedError do
-        StripeClient.new.persons.update("person_123", {})
+        StripeClient.new.person.update("person_123", {})
       end
     end
 

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PlanTest < Test::Unit::TestCase
     should "be listable" do
-      plans = StripeClient.new.plans.list
+      plans = StripeClient.new.plan.list
       assert_requested :get, "#{Stripe.api_base}/v1/plans"
       assert plans.data.is_a?(Array)
       assert plans.data[0].is_a?(Stripe::Plan)
     end
 
     should "be retrievable" do
-      plan = StripeClient.new.plans.retrieve("pl_123")
+      plan = StripeClient.new.plan.retrieve("pl_123")
       assert_requested :get, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
     should "be creatable" do
-      plan = StripeClient.new.plans.create(
+      plan = StripeClient.new.plan.create(
         amount: 5000,
         interval: "month",
         nickname: "Sapphire elite",
@@ -29,7 +29,7 @@ module Stripe
     end
 
     should "be creatable with metered configuration" do
-      plan = StripeClient.new.plans.create(
+      plan = StripeClient.new.plan.create(
         amount: 5000,
         interval: "month",
         nickname: "Sapphire elite",
@@ -41,7 +41,7 @@ module Stripe
     end
 
     should "be creatable with tiered configuration" do
-      plan = StripeClient.new.plans.create(
+      plan = StripeClient.new.plan.create(
         interval: "month",
         nickname: "Sapphire elite",
         currency: "usd",
@@ -54,7 +54,7 @@ module Stripe
     end
 
     should "be creatable with transform_usage" do
-      plan = StripeClient.new.plans.create(
+      plan = StripeClient.new.plan.create(
         interval: "month",
         nickname: "Sapphire elite",
         currency: "usd",
@@ -66,21 +66,21 @@ module Stripe
     end
 
     should "be saveable" do
-      plan = StripeClient.new.plans.retrieve("pl_123")
+      plan = StripeClient.new.plan.retrieve("pl_123")
       plan.metadata["key"] = "value"
       plan.save
       assert_requested :post, "#{Stripe.api_base}/v1/plans/#{plan.id}"
     end
 
     should "be updateable" do
-      plan = StripeClient.new.plans.update("pl_123", metadata: { foo: "bar" })
+      plan = StripeClient.new.plan.update("pl_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
     context "#delete" do
       should "be deletable" do
-        plan = StripeClient.new.plans.retrieve("pl_123")
+        plan = StripeClient.new.plan.retrieve("pl_123")
         plan = plan.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan.id}"
         assert plan.is_a?(Stripe::Plan)
@@ -89,7 +89,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        plan = StripeClient.new.plans.delete("pl_123")
+        plan = StripeClient.new.plan.delete("pl_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/plans/pl_123"
         assert plan.is_a?(Stripe::Plan)
       end

--- a/test/stripe/plan_test.rb
+++ b/test/stripe/plan_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PlanTest < Test::Unit::TestCase
     should "be listable" do
-      plans = Stripe::Plan.list
+      plans = StripeClient.new.plans.list
       assert_requested :get, "#{Stripe.api_base}/v1/plans"
       assert plans.data.is_a?(Array)
       assert plans.data[0].is_a?(Stripe::Plan)
     end
 
     should "be retrievable" do
-      plan = Stripe::Plan.retrieve("pl_123")
+      plan = StripeClient.new.plans.retrieve("pl_123")
       assert_requested :get, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
     should "be creatable" do
-      plan = Stripe::Plan.create(
+      plan = StripeClient.new.plans.create(
         amount: 5000,
         interval: "month",
         nickname: "Sapphire elite",
@@ -29,7 +29,7 @@ module Stripe
     end
 
     should "be creatable with metered configuration" do
-      plan = Stripe::Plan.create(
+      plan = StripeClient.new.plans.create(
         amount: 5000,
         interval: "month",
         nickname: "Sapphire elite",
@@ -41,7 +41,7 @@ module Stripe
     end
 
     should "be creatable with tiered configuration" do
-      plan = Stripe::Plan.create(
+      plan = StripeClient.new.plans.create(
         interval: "month",
         nickname: "Sapphire elite",
         currency: "usd",
@@ -54,7 +54,7 @@ module Stripe
     end
 
     should "be creatable with transform_usage" do
-      plan = Stripe::Plan.create(
+      plan = StripeClient.new.plans.create(
         interval: "month",
         nickname: "Sapphire elite",
         currency: "usd",
@@ -66,21 +66,21 @@ module Stripe
     end
 
     should "be saveable" do
-      plan = Stripe::Plan.retrieve("pl_123")
+      plan = StripeClient.new.plans.retrieve("pl_123")
       plan.metadata["key"] = "value"
       plan.save
       assert_requested :post, "#{Stripe.api_base}/v1/plans/#{plan.id}"
     end
 
     should "be updateable" do
-      plan = Stripe::Plan.update("pl_123", metadata: { foo: "bar" })
+      plan = StripeClient.new.plans.update("pl_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/plans/pl_123"
       assert plan.is_a?(Stripe::Plan)
     end
 
     context "#delete" do
       should "be deletable" do
-        plan = Stripe::Plan.retrieve("pl_123")
+        plan = StripeClient.new.plans.retrieve("pl_123")
         plan = plan.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/plans/#{plan.id}"
         assert plan.is_a?(Stripe::Plan)
@@ -89,7 +89,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        plan = Stripe::Plan.delete("pl_123")
+        plan = StripeClient.new.plans.delete("pl_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/plans/pl_123"
         assert plan.is_a?(Stripe::Plan)
       end

--- a/test/stripe/price_test.rb
+++ b/test/stripe/price_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PriceTest < Test::Unit::TestCase
     should "be listable" do
-      prices = Stripe::Price.list
+      prices = StripeClient.new.prices.list
       assert_requested :get, "#{Stripe.api_base}/v1/prices"
       assert prices.data.is_a?(Array)
       assert prices.data[0].is_a?(Stripe::Price)
     end
 
     should "be retrievable" do
-      price = Stripe::Price.retrieve("price_123")
+      price = StripeClient.new.prices.retrieve("price_123")
       assert_requested :get, "#{Stripe.api_base}/v1/prices/price_123"
       assert price.is_a?(Stripe::Price)
     end
 
     should "be creatable" do
-      price = Stripe::Price.create(
+      price = StripeClient.new.prices.create(
         unit_amount: 5000,
         currency: "usd",
         recurring: {
@@ -33,14 +33,14 @@ module Stripe
     end
 
     should "be saveable" do
-      price = Stripe::Price.retrieve("price_123")
+      price = StripeClient.new.prices.retrieve("price_123")
       price.metadata["key"] = "value"
       price.save
       assert_requested :post, "#{Stripe.api_base}/v1/prices/#{price.id}"
     end
 
     should "be updateable" do
-      price = Stripe::Price.update("price_123", metadata: { foo: "bar" })
+      price = StripeClient.new.prices.update("price_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/prices/price_123"
       assert price.is_a?(Stripe::Price)
     end

--- a/test/stripe/price_test.rb
+++ b/test/stripe/price_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PriceTest < Test::Unit::TestCase
     should "be listable" do
-      prices = StripeClient.new.prices.list
+      prices = StripeClient.new.price.list
       assert_requested :get, "#{Stripe.api_base}/v1/prices"
       assert prices.data.is_a?(Array)
       assert prices.data[0].is_a?(Stripe::Price)
     end
 
     should "be retrievable" do
-      price = StripeClient.new.prices.retrieve("price_123")
+      price = StripeClient.new.price.retrieve("price_123")
       assert_requested :get, "#{Stripe.api_base}/v1/prices/price_123"
       assert price.is_a?(Stripe::Price)
     end
 
     should "be creatable" do
-      price = StripeClient.new.prices.create(
+      price = StripeClient.new.price.create(
         unit_amount: 5000,
         currency: "usd",
         recurring: {
@@ -33,14 +33,14 @@ module Stripe
     end
 
     should "be saveable" do
-      price = StripeClient.new.prices.retrieve("price_123")
+      price = StripeClient.new.price.retrieve("price_123")
       price.metadata["key"] = "value"
       price.save
       assert_requested :post, "#{Stripe.api_base}/v1/prices/#{price.id}"
     end
 
     should "be updateable" do
-      price = StripeClient.new.prices.update("price_123", metadata: { foo: "bar" })
+      price = StripeClient.new.price.update("price_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/prices/price_123"
       assert price.is_a?(Stripe::Price)
     end

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ProductTest < Test::Unit::TestCase
     should "be listable" do
-      products = StripeClient.new.products.list
+      products = StripeClient.new.product.list
       assert_requested :get, "#{Stripe.api_base}/v1/products"
       assert products.data.is_a?(Array)
       assert products.data[0].is_a?(Stripe::Product)
     end
 
     should "be retrievable" do
-      product = StripeClient.new.products.retrieve("prod_123")
+      product = StripeClient.new.product.retrieve("prod_123")
       assert_requested :get, "#{Stripe.api_base}/v1/products/prod_123"
       assert product.is_a?(Stripe::Product)
     end
 
     should "be creatable" do
-      product = StripeClient.new.products.create(
+      product = StripeClient.new.product.create(
         name: "My Product"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/products"
@@ -26,21 +26,21 @@ module Stripe
     end
 
     should "be saveable" do
-      product = StripeClient.new.products.retrieve("prod_123")
+      product = StripeClient.new.product.retrieve("prod_123")
       product.metadata["key"] = "value"
       product.save
       assert_requested :post, "#{Stripe.api_base}/v1/products/#{product.id}"
     end
 
     should "be updateable" do
-      product = StripeClient.new.products.update("prod_123", metadata: { foo: "bar" })
+      product = StripeClient.new.product.update("prod_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/products/prod_123"
       assert product.is_a?(Stripe::Product)
     end
 
     context "#delete" do
       should "be deletable" do
-        product = StripeClient.new.products.retrieve("prod_123")
+        product = StripeClient.new.product.retrieve("prod_123")
         product = product.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product.id}"
         assert product.is_a?(Stripe::Product)
@@ -49,7 +49,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        product = StripeClient.new.products.delete("prod_123")
+        product = StripeClient.new.product.delete("prod_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/products/prod_123"
         assert product.is_a?(Stripe::Product)
       end

--- a/test/stripe/product_test.rb
+++ b/test/stripe/product_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ProductTest < Test::Unit::TestCase
     should "be listable" do
-      products = Stripe::Product.list
+      products = StripeClient.new.products.list
       assert_requested :get, "#{Stripe.api_base}/v1/products"
       assert products.data.is_a?(Array)
       assert products.data[0].is_a?(Stripe::Product)
     end
 
     should "be retrievable" do
-      product = Stripe::Product.retrieve("prod_123")
+      product = StripeClient.new.products.retrieve("prod_123")
       assert_requested :get, "#{Stripe.api_base}/v1/products/prod_123"
       assert product.is_a?(Stripe::Product)
     end
 
     should "be creatable" do
-      product = Stripe::Product.create(
+      product = StripeClient.new.products.create(
         name: "My Product"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/products"
@@ -26,21 +26,21 @@ module Stripe
     end
 
     should "be saveable" do
-      product = Stripe::Product.retrieve("prod_123")
+      product = StripeClient.new.products.retrieve("prod_123")
       product.metadata["key"] = "value"
       product.save
       assert_requested :post, "#{Stripe.api_base}/v1/products/#{product.id}"
     end
 
     should "be updateable" do
-      product = Stripe::Product.update("prod_123", metadata: { foo: "bar" })
+      product = StripeClient.new.products.update("prod_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/products/prod_123"
       assert product.is_a?(Stripe::Product)
     end
 
     context "#delete" do
       should "be deletable" do
-        product = Stripe::Product.retrieve("prod_123")
+        product = StripeClient.new.products.retrieve("prod_123")
         product = product.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/products/#{product.id}"
         assert product.is_a?(Stripe::Product)
@@ -49,7 +49,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        product = Stripe::Product.delete("prod_123")
+        product = StripeClient.new.products.delete("prod_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/products/prod_123"
         assert product.is_a?(Stripe::Product)
       end

--- a/test/stripe/promotion_code_test.rb
+++ b/test/stripe/promotion_code_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PromotionCodeTest < Test::Unit::TestCase
     should "be listable" do
-      promotion_codes = Stripe::PromotionCode.list
+      promotion_codes = StripeClient.new.promotion_codes.list
       assert_requested :get, "#{Stripe.api_base}/v1/promotion_codes"
       assert promotion_codes.data.is_a?(Array)
       assert promotion_codes.first.is_a?(Stripe::PromotionCode)
     end
 
     should "be retrievable" do
-      coupon = Stripe::PromotionCode.retrieve("PROMO_123")
+      coupon = StripeClient.new.promotion_codes.retrieve("PROMO_123")
       assert_requested :get, "#{Stripe.api_base}/v1/promotion_codes/PROMO_123"
       assert coupon.is_a?(Stripe::PromotionCode)
     end
 
     should "be creatable" do
-      coupon = Stripe::PromotionCode.create(
+      coupon = StripeClient.new.promotion_codes.create(
         coupon: "co_123",
         code: "MYCODE"
       )
@@ -27,14 +27,14 @@ module Stripe
     end
 
     should "be saveable" do
-      coupon = Stripe::PromotionCode.retrieve("PROMO_123")
+      coupon = StripeClient.new.promotion_codes.retrieve("PROMO_123")
       coupon.metadata["key"] = "value"
       coupon.save
       assert_requested :post, "#{Stripe.api_base}/v1/promotion_codes/#{coupon.id}"
     end
 
     should "be updateable" do
-      coupon = Stripe::PromotionCode.update("PROMO_123", metadata: { key: "value" })
+      coupon = StripeClient.new.promotion_codes.update("PROMO_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/promotion_codes/PROMO_123"
       assert coupon.is_a?(Stripe::PromotionCode)
     end

--- a/test/stripe/promotion_code_test.rb
+++ b/test/stripe/promotion_code_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class PromotionCodeTest < Test::Unit::TestCase
     should "be listable" do
-      promotion_codes = StripeClient.new.promotion_codes.list
+      promotion_codes = StripeClient.new.promotion_code.list
       assert_requested :get, "#{Stripe.api_base}/v1/promotion_codes"
       assert promotion_codes.data.is_a?(Array)
       assert promotion_codes.first.is_a?(Stripe::PromotionCode)
     end
 
     should "be retrievable" do
-      coupon = StripeClient.new.promotion_codes.retrieve("PROMO_123")
+      coupon = StripeClient.new.promotion_code.retrieve("PROMO_123")
       assert_requested :get, "#{Stripe.api_base}/v1/promotion_codes/PROMO_123"
       assert coupon.is_a?(Stripe::PromotionCode)
     end
 
     should "be creatable" do
-      coupon = StripeClient.new.promotion_codes.create(
+      coupon = StripeClient.new.promotion_code.create(
         coupon: "co_123",
         code: "MYCODE"
       )
@@ -27,14 +27,14 @@ module Stripe
     end
 
     should "be saveable" do
-      coupon = StripeClient.new.promotion_codes.retrieve("PROMO_123")
+      coupon = StripeClient.new.promotion_code.retrieve("PROMO_123")
       coupon.metadata["key"] = "value"
       coupon.save
       assert_requested :post, "#{Stripe.api_base}/v1/promotion_codes/#{coupon.id}"
     end
 
     should "be updateable" do
-      coupon = StripeClient.new.promotion_codes.update("PROMO_123", metadata: { key: "value" })
+      coupon = StripeClient.new.promotion_code.update("PROMO_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/promotion_codes/PROMO_123"
       assert coupon.is_a?(Stripe::PromotionCode)
     end

--- a/test/stripe/radar/early_fraud_warning_test.rb
+++ b/test/stripe/radar/early_fraud_warning_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Radar
     class EarlyFraudWarningTest < Test::Unit::TestCase
       should "be listable" do
-        warnings = Stripe::Radar::EarlyFraudWarning.list
+        warnings = StripeClient.new.radar.early_fraud_warnings.list
         assert_requested :get, "#{Stripe.api_base}/v1/radar/early_fraud_warnings"
         assert warnings.data.is_a?(Array)
         assert warnings.data[0].is_a?(Stripe::Radar::EarlyFraudWarning)
       end
 
       should "be retrievable" do
-        warning = Stripe::Radar::EarlyFraudWarning.retrieve("issfr_123")
+        warning = StripeClient.new.radar.early_fraud_warnings.retrieve("issfr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/early_fraud_warnings/issfr_123"
         assert warning.is_a?(Stripe::Radar::EarlyFraudWarning)
       end

--- a/test/stripe/radar/early_fraud_warning_test.rb
+++ b/test/stripe/radar/early_fraud_warning_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Radar
     class EarlyFraudWarningTest < Test::Unit::TestCase
       should "be listable" do
-        warnings = StripeClient.new.radar.early_fraud_warnings.list
+        warnings = StripeClient.new.radar.early_fraud_warning.list
         assert_requested :get, "#{Stripe.api_base}/v1/radar/early_fraud_warnings"
         assert warnings.data.is_a?(Array)
         assert warnings.data[0].is_a?(Stripe::Radar::EarlyFraudWarning)
       end
 
       should "be retrievable" do
-        warning = StripeClient.new.radar.early_fraud_warnings.retrieve("issfr_123")
+        warning = StripeClient.new.radar.early_fraud_warning.retrieve("issfr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/early_fraud_warnings/issfr_123"
         assert warning.is_a?(Stripe::Radar::EarlyFraudWarning)
       end

--- a/test/stripe/radar/value_list_item_test.rb
+++ b/test/stripe/radar/value_list_item_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Radar
     class ValueListItemTest < Test::Unit::TestCase
       should "be listable" do
-        items = StripeClient.new.radar.value_list_items.list(value_list: "rsl_123")
+        items = StripeClient.new.radar.value_list_item.list(value_list: "rsl_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_list_items?value_list=rsl_123"
         assert items.data.is_a?(Array)
         assert items.first.is_a?(Stripe::Radar::ValueListItem)
       end
 
       should "be retrievable" do
-        item = StripeClient.new.radar.value_list_items.retrieve("rsli_123")
+        item = StripeClient.new.radar.value_list_item.retrieve("rsli_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
         assert item.is_a?(Stripe::Radar::ValueListItem)
       end
 
       should "be creatable" do
-        item = StripeClient.new.radar.value_list_items.create(
+        item = StripeClient.new.radar.value_list_item.create(
           value_list: "rsl_123",
           value: "value"
         )
@@ -29,7 +29,7 @@ module Stripe
 
       context "#delete" do
         should "be deletable" do
-          list = StripeClient.new.radar.value_list_items.retrieve("rsli_123")
+          list = StripeClient.new.radar.value_list_item.retrieve("rsli_123")
           list = list.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
           assert list.is_a?(Stripe::Radar::ValueListItem)
@@ -38,7 +38,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          list = StripeClient.new.radar.value_list_items.delete("rsli_123")
+          list = StripeClient.new.radar.value_list_item.delete("rsli_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
           assert list.is_a?(Stripe::Radar::ValueListItem)
         end

--- a/test/stripe/radar/value_list_item_test.rb
+++ b/test/stripe/radar/value_list_item_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Radar
     class ValueListItemTest < Test::Unit::TestCase
       should "be listable" do
-        items = Stripe::Radar::ValueListItem.list(value_list: "rsl_123")
+        items = StripeClient.new.radar.value_list_items.list(value_list: "rsl_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_list_items?value_list=rsl_123"
         assert items.data.is_a?(Array)
         assert items.first.is_a?(Stripe::Radar::ValueListItem)
       end
 
       should "be retrievable" do
-        item = Stripe::Radar::ValueListItem.retrieve("rsli_123")
+        item = StripeClient.new.radar.value_list_items.retrieve("rsli_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
         assert item.is_a?(Stripe::Radar::ValueListItem)
       end
 
       should "be creatable" do
-        item = Stripe::Radar::ValueListItem.create(
+        item = StripeClient.new.radar.value_list_items.create(
           value_list: "rsl_123",
           value: "value"
         )
@@ -29,7 +29,7 @@ module Stripe
 
       context "#delete" do
         should "be deletable" do
-          list = Stripe::Radar::ValueListItem.retrieve("rsli_123")
+          list = StripeClient.new.radar.value_list_items.retrieve("rsli_123")
           list = list.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
           assert list.is_a?(Stripe::Radar::ValueListItem)
@@ -38,7 +38,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          list = Stripe::Radar::ValueListItem.delete("rsli_123")
+          list = StripeClient.new.radar.value_list_items.delete("rsli_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_list_items/rsli_123"
           assert list.is_a?(Stripe::Radar::ValueListItem)
         end

--- a/test/stripe/radar/value_list_test.rb
+++ b/test/stripe/radar/value_list_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Radar
     class ValueListTest < Test::Unit::TestCase
       should "be listable" do
-        lists = StripeClient.new.radar.value_lists.list
+        lists = StripeClient.new.radar.value_list.list
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_lists"
         assert lists.data.is_a?(Array)
         assert lists.first.is_a?(Stripe::Radar::ValueList)
       end
 
       should "be retrievable" do
-        list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
+        list = StripeClient.new.radar.value_list.retrieve("rsl_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
         assert list.is_a?(Stripe::Radar::ValueList)
       end
 
       should "be creatable" do
-        list = StripeClient.new.radar.value_lists.create(
+        list = StripeClient.new.radar.value_list.create(
           alias: "list_alias",
           name: "list_name"
         )
@@ -28,21 +28,21 @@ module Stripe
       end
 
       should "be saveable" do
-        list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
+        list = StripeClient.new.radar.value_list.retrieve("rsl_123")
         list.metadata["key"] = "value"
         list.save
         assert_requested :post, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
       end
 
       should "be updateable" do
-        list = StripeClient.new.radar.value_lists.update("rsl_123", metadata: { key: "value" })
+        list = StripeClient.new.radar.value_list.update("rsl_123", metadata: { key: "value" })
         assert_requested :post, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
         assert list.is_a?(Stripe::Radar::ValueList)
       end
 
       context "#delete" do
         should "be deletable" do
-          list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
+          list = StripeClient.new.radar.value_list.retrieve("rsl_123")
           list = list.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
           assert list.is_a?(Stripe::Radar::ValueList)
@@ -51,7 +51,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          list = StripeClient.new.radar.value_lists.delete("rsl_123")
+          list = StripeClient.new.radar.value_list.delete("rsl_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
           assert list.is_a?(Stripe::Radar::ValueList)
         end

--- a/test/stripe/radar/value_list_test.rb
+++ b/test/stripe/radar/value_list_test.rb
@@ -6,20 +6,20 @@ module Stripe
   module Radar
     class ValueListTest < Test::Unit::TestCase
       should "be listable" do
-        lists = Stripe::Radar::ValueList.list
+        lists = StripeClient.new.radar.value_lists.list
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_lists"
         assert lists.data.is_a?(Array)
         assert lists.first.is_a?(Stripe::Radar::ValueList)
       end
 
       should "be retrievable" do
-        list = Stripe::Radar::ValueList.retrieve("rsl_123")
+        list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
         assert_requested :get, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
         assert list.is_a?(Stripe::Radar::ValueList)
       end
 
       should "be creatable" do
-        list = Stripe::Radar::ValueList.create(
+        list = StripeClient.new.radar.value_lists.create(
           alias: "list_alias",
           name: "list_name"
         )
@@ -28,21 +28,21 @@ module Stripe
       end
 
       should "be saveable" do
-        list = Stripe::Radar::ValueList.retrieve("rsl_123")
+        list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
         list.metadata["key"] = "value"
         list.save
         assert_requested :post, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
       end
 
       should "be updateable" do
-        list = Stripe::Radar::ValueList.update("rsl_123", metadata: { key: "value" })
+        list = StripeClient.new.radar.value_lists.update("rsl_123", metadata: { key: "value" })
         assert_requested :post, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
         assert list.is_a?(Stripe::Radar::ValueList)
       end
 
       context "#delete" do
         should "be deletable" do
-          list = Stripe::Radar::ValueList.retrieve("rsl_123")
+          list = StripeClient.new.radar.value_lists.retrieve("rsl_123")
           list = list.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
           assert list.is_a?(Stripe::Radar::ValueList)
@@ -51,7 +51,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          list = Stripe::Radar::ValueList.delete("rsl_123")
+          list = StripeClient.new.radar.value_lists.delete("rsl_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/radar/value_lists/rsl_123"
           assert list.is_a?(Stripe::Radar::ValueList)
         end

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class RecipientTest < Test::Unit::TestCase
     should "be listable" do
-      recipients = Stripe::Recipient.list
+      recipients = StripeClient.new.recipients.list
       assert_requested :get, "#{Stripe.api_base}/v1/recipients"
       assert recipients.data.is_a?(Array)
       assert recipients.data[0].is_a?(Stripe::Recipient)
     end
 
     should "be retrievable" do
-      recipient = Stripe::Recipient.retrieve("rp_123")
+      recipient = StripeClient.new.recipients.retrieve("rp_123")
       assert_requested :get, "#{Stripe.api_base}/v1/recipients/rp_123"
       assert recipient.is_a?(Stripe::Recipient)
     end
 
     should "be creatable" do
-      recipient = Stripe::Recipient.create(
+      recipient = StripeClient.new.recipients.create(
         name: "Noah Jackson",
         type: "individual"
       )
@@ -27,14 +27,14 @@ module Stripe
     end
 
     should "be saveable" do
-      recipient = Stripe::Recipient.retrieve("rp_123")
+      recipient = StripeClient.new.recipients.retrieve("rp_123")
       recipient.metadata["key"] = "value"
       recipient.save
       assert_requested :post, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
     end
 
     should "be updateable" do
-      recipient = Stripe::Recipient.update("rp_123", metadata: { foo: "bar" })
+      recipient = StripeClient.new.recipients.update("rp_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/recipients/rp_123"
       assert recipient.is_a?(Stripe::Recipient)
     end
@@ -44,7 +44,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        recipient = Stripe::Recipient.retrieve("rp_123")
+        recipient = StripeClient.new.recipients.retrieve("rp_123")
         recipient = recipient.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
         assert recipient.is_a?(Stripe::Recipient)
@@ -53,7 +53,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        recipient = Stripe::Recipient.delete("rp_123")
+        recipient = StripeClient.new.recipients.delete("rp_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/recipients/rp_123"
         assert recipient.is_a?(Stripe::Recipient)
       end

--- a/test/stripe/recipient_test.rb
+++ b/test/stripe/recipient_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class RecipientTest < Test::Unit::TestCase
     should "be listable" do
-      recipients = StripeClient.new.recipients.list
+      recipients = StripeClient.new.recipient.list
       assert_requested :get, "#{Stripe.api_base}/v1/recipients"
       assert recipients.data.is_a?(Array)
       assert recipients.data[0].is_a?(Stripe::Recipient)
     end
 
     should "be retrievable" do
-      recipient = StripeClient.new.recipients.retrieve("rp_123")
+      recipient = StripeClient.new.recipient.retrieve("rp_123")
       assert_requested :get, "#{Stripe.api_base}/v1/recipients/rp_123"
       assert recipient.is_a?(Stripe::Recipient)
     end
 
     should "be creatable" do
-      recipient = StripeClient.new.recipients.create(
+      recipient = StripeClient.new.recipient.create(
         name: "Noah Jackson",
         type: "individual"
       )
@@ -27,14 +27,14 @@ module Stripe
     end
 
     should "be saveable" do
-      recipient = StripeClient.new.recipients.retrieve("rp_123")
+      recipient = StripeClient.new.recipient.retrieve("rp_123")
       recipient.metadata["key"] = "value"
       recipient.save
       assert_requested :post, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
     end
 
     should "be updateable" do
-      recipient = StripeClient.new.recipients.update("rp_123", metadata: { foo: "bar" })
+      recipient = StripeClient.new.recipient.update("rp_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/recipients/rp_123"
       assert recipient.is_a?(Stripe::Recipient)
     end
@@ -44,7 +44,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        recipient = StripeClient.new.recipients.retrieve("rp_123")
+        recipient = StripeClient.new.recipient.retrieve("rp_123")
         recipient = recipient.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/recipients/#{recipient.id}"
         assert recipient.is_a?(Stripe::Recipient)
@@ -53,7 +53,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        recipient = StripeClient.new.recipients.delete("rp_123")
+        recipient = StripeClient.new.recipient.delete("rp_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/recipients/rp_123"
         assert recipient.is_a?(Stripe::Recipient)
       end

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -5,33 +5,33 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class RefundTest < Test::Unit::TestCase
     should "be listable" do
-      refunds = StripeClient.new.refunds.list
+      refunds = StripeClient.new.refund.list
       assert_requested :get, "#{Stripe.api_base}/v1/refunds"
       assert refunds.data.is_a?(Array)
       assert refunds.first.is_a?(Stripe::Refund)
     end
 
     should "be retrievable" do
-      refund = StripeClient.new.refunds.retrieve("re_123")
+      refund = StripeClient.new.refund.retrieve("re_123")
       assert_requested :get, "#{Stripe.api_base}/v1/refunds/re_123"
       assert refund.is_a?(Stripe::Refund)
     end
 
     should "be creatable" do
-      refund = StripeClient.new.refunds.create(charge: "ch_123")
+      refund = StripeClient.new.refund.create(charge: "ch_123")
       assert_requested :post, "#{Stripe.api_base}/v1/refunds"
       assert refund.is_a?(Stripe::Refund)
     end
 
     should "be saveable" do
-      refund = StripeClient.new.refunds.retrieve("re_123")
+      refund = StripeClient.new.refund.retrieve("re_123")
       refund.metadata["key"] = "value"
       refund.save
       assert_requested :post, "#{Stripe.api_base}/v1/refunds/#{refund.id}"
     end
 
     should "be updateable" do
-      refund = StripeClient.new.refunds.update("re_123", metadata: { key: "value" })
+      refund = StripeClient.new.refund.update("re_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/refunds/re_123"
       assert refund.is_a?(Stripe::Refund)
     end

--- a/test/stripe/refund_test.rb
+++ b/test/stripe/refund_test.rb
@@ -5,33 +5,33 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class RefundTest < Test::Unit::TestCase
     should "be listable" do
-      refunds = Stripe::Refund.list
+      refunds = StripeClient.new.refunds.list
       assert_requested :get, "#{Stripe.api_base}/v1/refunds"
       assert refunds.data.is_a?(Array)
       assert refunds.first.is_a?(Stripe::Refund)
     end
 
     should "be retrievable" do
-      refund = Stripe::Refund.retrieve("re_123")
+      refund = StripeClient.new.refunds.retrieve("re_123")
       assert_requested :get, "#{Stripe.api_base}/v1/refunds/re_123"
       assert refund.is_a?(Stripe::Refund)
     end
 
     should "be creatable" do
-      refund = Stripe::Refund.create(charge: "ch_123")
+      refund = StripeClient.new.refunds.create(charge: "ch_123")
       assert_requested :post, "#{Stripe.api_base}/v1/refunds"
       assert refund.is_a?(Stripe::Refund)
     end
 
     should "be saveable" do
-      refund = Stripe::Refund.retrieve("re_123")
+      refund = StripeClient.new.refunds.retrieve("re_123")
       refund.metadata["key"] = "value"
       refund.save
       assert_requested :post, "#{Stripe.api_base}/v1/refunds/#{refund.id}"
     end
 
     should "be updateable" do
-      refund = Stripe::Refund.update("re_123", metadata: { key: "value" })
+      refund = StripeClient.new.refunds.update("re_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/refunds/re_123"
       assert refund.is_a?(Stripe::Refund)
     end

--- a/test/stripe/reporting/report_run_test.rb
+++ b/test/stripe/reporting/report_run_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Reporting
     class ReportRunTest < Test::Unit::TestCase
       should "be creatable" do
-        report_run = StripeClient.new.reporting.report_runs.create(
+        report_run = StripeClient.new.reporting.report_run.create(
           parameters: {
             connected_account: "acct_123",
           },
@@ -17,14 +17,14 @@ module Stripe
       end
 
       should "be listable" do
-        report_runs = StripeClient.new.reporting.report_runs.list
+        report_runs = StripeClient.new.reporting.report_run.list
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_runs"
         assert report_runs.data.is_a?(Array)
         assert report_runs.data[0].is_a?(Stripe::Reporting::ReportRun)
       end
 
       should "be retrievable" do
-        report_run = StripeClient.new.reporting.report_runs.retrieve("frr_123")
+        report_run = StripeClient.new.reporting.report_run.retrieve("frr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_runs/frr_123"
         assert report_run.is_a?(Stripe::Reporting::ReportRun)
       end

--- a/test/stripe/reporting/report_run_test.rb
+++ b/test/stripe/reporting/report_run_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Reporting
     class ReportRunTest < Test::Unit::TestCase
       should "be creatable" do
-        report_run = Stripe::Reporting::ReportRun.create(
+        report_run = StripeClient.new.reporting.report_runs.create(
           parameters: {
             connected_account: "acct_123",
           },
@@ -17,14 +17,14 @@ module Stripe
       end
 
       should "be listable" do
-        report_runs = Stripe::Reporting::ReportRun.list
+        report_runs = StripeClient.new.reporting.report_runs.list
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_runs"
         assert report_runs.data.is_a?(Array)
         assert report_runs.data[0].is_a?(Stripe::Reporting::ReportRun)
       end
 
       should "be retrievable" do
-        report_run = Stripe::Reporting::ReportRun.retrieve("frr_123")
+        report_run = StripeClient.new.reporting.report_runs.retrieve("frr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_runs/frr_123"
         assert report_run.is_a?(Stripe::Reporting::ReportRun)
       end

--- a/test/stripe/reporting/report_type_test.rb
+++ b/test/stripe/reporting/report_type_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Reporting
     class ReportTypeTest < Test::Unit::TestCase
       should "be listable" do
-        report_types = Stripe::Reporting::ReportType.list
+        report_types = StripeClient.new.reporting.report_types.list
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_types"
         assert report_types.data.is_a?(Array)
         assert report_types.data[0].is_a?(Stripe::Reporting::ReportType)
       end
 
       should "be retrievable" do
-        report_type = Stripe::Reporting::ReportType.retrieve("activity.summary.1")
+        report_type = StripeClient.new.reporting.report_types.retrieve("activity.summary.1")
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_types/activity.summary.1"
         assert report_type.is_a?(Stripe::Reporting::ReportType)
       end

--- a/test/stripe/reporting/report_type_test.rb
+++ b/test/stripe/reporting/report_type_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Reporting
     class ReportTypeTest < Test::Unit::TestCase
       should "be listable" do
-        report_types = StripeClient.new.reporting.report_types.list
+        report_types = StripeClient.new.reporting.report_type.list
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_types"
         assert report_types.data.is_a?(Array)
         assert report_types.data[0].is_a?(Stripe::Reporting::ReportType)
       end
 
       should "be retrievable" do
-        report_type = StripeClient.new.reporting.report_types.retrieve("activity.summary.1")
+        report_type = StripeClient.new.reporting.report_type.retrieve("activity.summary.1")
         assert_requested :get, "#{Stripe.api_base}/v1/reporting/report_types/activity.summary.1"
         assert report_type.is_a?(Stripe::Reporting::ReportType)
       end

--- a/test/stripe/reversal_test.rb
+++ b/test/stripe/reversal_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ReversalTest < Test::Unit::TestCase
     setup do
-      @transfer = Stripe::Transfer.retrieve("tr_123")
+      @transfer = StripeClient.new.transfers.retrieve("tr_123")
     end
 
     should "be listable" do

--- a/test/stripe/reversal_test.rb
+++ b/test/stripe/reversal_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ReversalTest < Test::Unit::TestCase
     setup do
-      @transfer = StripeClient.new.transfers.retrieve("tr_123")
+      @transfer = StripeClient.new.transfer.retrieve("tr_123")
     end
 
     should "be listable" do

--- a/test/stripe/review_test.rb
+++ b/test/stripe/review_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ReviewTest < Test::Unit::TestCase
     should "be listable" do
-      reviews = StripeClient.new.reviews.list
+      reviews = StripeClient.new.review.list
       assert_requested :get, "#{Stripe.api_base}/v1/reviews"
       assert reviews.data.is_a?(Array)
       assert reviews.first.is_a?(Stripe::Review)
     end
 
     should "be retrievable" do
-      review = StripeClient.new.reviews.retrieve("prv_123")
+      review = StripeClient.new.review.retrieve("prv_123")
       assert_requested :get, "#{Stripe.api_base}/v1/reviews/prv_123"
       assert review.is_a?(Stripe::Review)
     end
 
     should "be approvable" do
-      review = StripeClient.new.reviews.retrieve("prv_123")
+      review = StripeClient.new.review.retrieve("prv_123")
       review.approve
       assert_requested :post, "#{Stripe.api_base}/v1/reviews/prv_123/approve"
       assert review.is_a?(Stripe::Review)

--- a/test/stripe/review_test.rb
+++ b/test/stripe/review_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ReviewTest < Test::Unit::TestCase
     should "be listable" do
-      reviews = Stripe::Review.list
+      reviews = StripeClient.new.reviews.list
       assert_requested :get, "#{Stripe.api_base}/v1/reviews"
       assert reviews.data.is_a?(Array)
       assert reviews.first.is_a?(Stripe::Review)
     end
 
     should "be retrievable" do
-      review = Stripe::Review.retrieve("prv_123")
+      review = StripeClient.new.reviews.retrieve("prv_123")
       assert_requested :get, "#{Stripe.api_base}/v1/reviews/prv_123"
       assert review.is_a?(Stripe::Review)
     end
 
     should "be approvable" do
-      review = Stripe::Review.retrieve("prv_123")
+      review = StripeClient.new.reviews.retrieve("prv_123")
       review.approve
       assert_requested :post, "#{Stripe.api_base}/v1/reviews/prv_123/approve"
       assert review.is_a?(Stripe::Review)

--- a/test/stripe/setup_attempt_test.rb
+++ b/test/stripe/setup_attempt_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SetupAttemptTest < Test::Unit::TestCase
     should "be listable" do
-      setup_attempts = StripeClient.new.setup_attempts.list({
+      setup_attempts = StripeClient.new.setup_attempt.list({
         setup_intent: "seti_123",
       })
       assert_requested :get, "#{Stripe.api_base}/v1/setup_attempts?setup_intent=seti_123"

--- a/test/stripe/setup_attempt_test.rb
+++ b/test/stripe/setup_attempt_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SetupAttemptTest < Test::Unit::TestCase
     should "be listable" do
-      setup_attempts = Stripe::SetupAttempt.list({
+      setup_attempts = StripeClient.new.setup_attempts.list({
         setup_intent: "seti_123",
       })
       assert_requested :get, "#{Stripe.api_base}/v1/setup_attempts?setup_intent=seti_123"

--- a/test/stripe/setup_intent_test.rb
+++ b/test/stripe/setup_intent_test.rb
@@ -7,20 +7,20 @@ module Stripe
     TEST_RESOURCE_ID = "seti_123"
 
     should "be listable" do
-      setup_intents = Stripe::SetupIntent.list
+      setup_intents = StripeClient.new.setup_intents.list
       assert_requested :get, "#{Stripe.api_base}/v1/setup_intents"
       assert setup_intents.data.is_a?(Array)
       assert setup_intents.data[0].is_a?(Stripe::SetupIntent)
     end
 
     should "be retrievable" do
-      setup_intent = Stripe::SetupIntent.retrieve("seti_123")
+      setup_intent = StripeClient.new.setup_intents.retrieve("seti_123")
       assert_requested :get, "#{Stripe.api_base}/v1/setup_intents/seti_123"
       assert setup_intent.is_a?(Stripe::SetupIntent)
     end
 
     should "be creatable" do
-      setup_intent = Stripe::SetupIntent.create(
+      setup_intent = StripeClient.new.setup_intents.create(
         payment_method_types: ["card"]
       )
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents"
@@ -28,14 +28,14 @@ module Stripe
     end
 
     should "be saveable" do
-      setup_intent = Stripe::SetupIntent.construct_from(id: "seti_123", object: "setup_intent", metadata: {})
+      setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent", metadata: {})
       setup_intent.metadata["key"] = "value"
       setup_intent.save
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/#{setup_intent.id}"
     end
 
     should "be updateable" do
-      setup_intent = Stripe::SetupIntent.update("seti_123", metadata: { foo: "bar" })
+      setup_intent = StripeClient.new.setup_intents.update("seti_123", metadata: { foo: "bar" })
 
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123"
       assert setup_intent.is_a?(Stripe::SetupIntent)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a setup_intent" do
-        setup_intent = Stripe::SetupIntent.construct_from(id: "seti_123", object: "setup_intent")
+        setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent")
         setup_intent = setup_intent.cancel
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/cancel"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a setup_intent" do
-        setup_intent = Stripe::SetupIntent.cancel("seti_123")
+        setup_intent = StripeClient.new.setup_intents.cancel("seti_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/cancel"
         assert setup_intent.is_a?(Stripe::SetupIntent)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#confirm" do
       should "confirm a setup_intent" do
-        setup_intent = Stripe::SetupIntent.construct_from(id: "seti_123", object: "setup_intent")
+        setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent")
         setup_intent = setup_intent.confirm(
           payment_method: "pm_123"
         )
@@ -74,7 +74,7 @@ module Stripe
 
     context ".confirm" do
       should "confirm a setup_intent" do
-        setup_intent = Stripe::SetupIntent.confirm("seti_123", payment_method: "pm_123")
+        setup_intent = StripeClient.new.setup_intents.confirm("seti_123", payment_method: "pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/confirm"
         assert setup_intent.is_a?(Stripe::SetupIntent)

--- a/test/stripe/setup_intent_test.rb
+++ b/test/stripe/setup_intent_test.rb
@@ -7,20 +7,20 @@ module Stripe
     TEST_RESOURCE_ID = "seti_123"
 
     should "be listable" do
-      setup_intents = StripeClient.new.setup_intents.list
+      setup_intents = StripeClient.new.setup_intent.list
       assert_requested :get, "#{Stripe.api_base}/v1/setup_intents"
       assert setup_intents.data.is_a?(Array)
       assert setup_intents.data[0].is_a?(Stripe::SetupIntent)
     end
 
     should "be retrievable" do
-      setup_intent = StripeClient.new.setup_intents.retrieve("seti_123")
+      setup_intent = StripeClient.new.setup_intent.retrieve("seti_123")
       assert_requested :get, "#{Stripe.api_base}/v1/setup_intents/seti_123"
       assert setup_intent.is_a?(Stripe::SetupIntent)
     end
 
     should "be creatable" do
-      setup_intent = StripeClient.new.setup_intents.create(
+      setup_intent = StripeClient.new.setup_intent.create(
         payment_method_types: ["card"]
       )
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents"
@@ -28,14 +28,14 @@ module Stripe
     end
 
     should "be saveable" do
-      setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent", metadata: {})
+      setup_intent = StripeClient.new.setup_intent.construct_from(id: "seti_123", object: "setup_intent", metadata: {})
       setup_intent.metadata["key"] = "value"
       setup_intent.save
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/#{setup_intent.id}"
     end
 
     should "be updateable" do
-      setup_intent = StripeClient.new.setup_intents.update("seti_123", metadata: { foo: "bar" })
+      setup_intent = StripeClient.new.setup_intent.update("seti_123", metadata: { foo: "bar" })
 
       assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123"
       assert setup_intent.is_a?(Stripe::SetupIntent)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a setup_intent" do
-        setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent")
+        setup_intent = StripeClient.new.setup_intent.construct_from(id: "seti_123", object: "setup_intent")
         setup_intent = setup_intent.cancel
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/cancel"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a setup_intent" do
-        setup_intent = StripeClient.new.setup_intents.cancel("seti_123")
+        setup_intent = StripeClient.new.setup_intent.cancel("seti_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/cancel"
         assert setup_intent.is_a?(Stripe::SetupIntent)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#confirm" do
       should "confirm a setup_intent" do
-        setup_intent = StripeClient.new.setup_intents.construct_from(id: "seti_123", object: "setup_intent")
+        setup_intent = StripeClient.new.setup_intent.construct_from(id: "seti_123", object: "setup_intent")
         setup_intent = setup_intent.confirm(
           payment_method: "pm_123"
         )
@@ -74,7 +74,7 @@ module Stripe
 
     context ".confirm" do
       should "confirm a setup_intent" do
-        setup_intent = StripeClient.new.setup_intents.confirm("seti_123", payment_method: "pm_123")
+        setup_intent = StripeClient.new.setup_intent.confirm("seti_123", payment_method: "pm_123")
 
         assert_requested :post, "#{Stripe.api_base}/v1/setup_intents/seti_123/confirm"
         assert setup_intent.is_a?(Stripe::SetupIntent)

--- a/test/stripe/sigma/scheduled_query_run_test.rb
+++ b/test/stripe/sigma/scheduled_query_run_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Issuing
     class ScheduledQueryRunTest < Test::Unit::TestCase
       should "be listable" do
-        runs = StripeClient.new.sigma.scheduled_query_runs.list
+        runs = StripeClient.new.sigma.scheduled_query_run.list
         assert_requested :get, "#{Stripe.api_base}/v1/sigma/scheduled_query_runs"
         assert runs.data.is_a?(Array)
         assert runs.data[0].is_a?(Stripe::Sigma::ScheduledQueryRun)
       end
 
       should "be retrievable" do
-        run = StripeClient.new.sigma.scheduled_query_runs.retrieve("sqr_123")
+        run = StripeClient.new.sigma.scheduled_query_run.retrieve("sqr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/sigma/scheduled_query_runs/sqr_123"
         assert run.is_a?(Stripe::Sigma::ScheduledQueryRun)
       end

--- a/test/stripe/sigma/scheduled_query_run_test.rb
+++ b/test/stripe/sigma/scheduled_query_run_test.rb
@@ -6,14 +6,14 @@ module Stripe
   module Issuing
     class ScheduledQueryRunTest < Test::Unit::TestCase
       should "be listable" do
-        runs = Stripe::Sigma::ScheduledQueryRun.list
+        runs = StripeClient.new.sigma.scheduled_query_runs.list
         assert_requested :get, "#{Stripe.api_base}/v1/sigma/scheduled_query_runs"
         assert runs.data.is_a?(Array)
         assert runs.data[0].is_a?(Stripe::Sigma::ScheduledQueryRun)
       end
 
       should "be retrievable" do
-        run = Stripe::Sigma::ScheduledQueryRun.retrieve("sqr_123")
+        run = StripeClient.new.sigma.scheduled_query_runs.retrieve("sqr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/sigma/scheduled_query_runs/sqr_123"
         assert run.is_a?(Stripe::Sigma::ScheduledQueryRun)
       end

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SKUTest < Test::Unit::TestCase
     should "be listable" do
-      skus = StripeClient.new.skus.list
+      skus = StripeClient.new.sku.list
       assert_requested :get, "#{Stripe.api_base}/v1/skus"
       assert skus.data.is_a?(Array)
       assert skus.data[0].is_a?(Stripe::SKU)
     end
 
     should "be retrievable" do
-      sku = StripeClient.new.skus.retrieve("sku_123")
+      sku = StripeClient.new.sku.retrieve("sku_123")
       assert_requested :get, "#{Stripe.api_base}/v1/skus/sku_123"
       assert sku.is_a?(Stripe::SKU)
     end
 
     should "be creatable" do
-      _ = StripeClient.new.skus.create(
+      _ = StripeClient.new.sku.create(
         currency: "USD",
         inventory: { type: "finite", quantity: 500 },
         price: 100,
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      sku = StripeClient.new.skus.retrieve("sku_123")
+      sku = StripeClient.new.sku.retrieve("sku_123")
       sku.metadata["key"] = "value"
       sku.save
       assert_requested :post, "#{Stripe.api_base}/v1/skus/#{sku.id}"
     end
 
     should "be updateable" do
-      sku = StripeClient.new.skus.update("sku_123", metadata: { foo: "bar" })
+      sku = StripeClient.new.sku.update("sku_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/skus/sku_123"
       assert sku.is_a?(Stripe::SKU)
     end
 
     context "#delete" do
       should "be deletable" do
-        sku = StripeClient.new.skus.retrieve("sku_123")
+        sku = StripeClient.new.sku.retrieve("sku_123")
         sku = sku.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku.id}"
         assert sku.is_a?(Stripe::SKU)
@@ -51,7 +51,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        sku = StripeClient.new.skus.delete("sku_123")
+        sku = StripeClient.new.sku.delete("sku_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/skus/sku_123"
         assert sku.is_a?(Stripe::SKU)
       end

--- a/test/stripe/sku_test.rb
+++ b/test/stripe/sku_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SKUTest < Test::Unit::TestCase
     should "be listable" do
-      skus = Stripe::SKU.list
+      skus = StripeClient.new.skus.list
       assert_requested :get, "#{Stripe.api_base}/v1/skus"
       assert skus.data.is_a?(Array)
       assert skus.data[0].is_a?(Stripe::SKU)
     end
 
     should "be retrievable" do
-      sku = Stripe::SKU.retrieve("sku_123")
+      sku = StripeClient.new.skus.retrieve("sku_123")
       assert_requested :get, "#{Stripe.api_base}/v1/skus/sku_123"
       assert sku.is_a?(Stripe::SKU)
     end
 
     should "be creatable" do
-      _ = Stripe::SKU.create(
+      _ = StripeClient.new.skus.create(
         currency: "USD",
         inventory: { type: "finite", quantity: 500 },
         price: 100,
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      sku = Stripe::SKU.retrieve("sku_123")
+      sku = StripeClient.new.skus.retrieve("sku_123")
       sku.metadata["key"] = "value"
       sku.save
       assert_requested :post, "#{Stripe.api_base}/v1/skus/#{sku.id}"
     end
 
     should "be updateable" do
-      sku = Stripe::SKU.update("sku_123", metadata: { foo: "bar" })
+      sku = StripeClient.new.skus.update("sku_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/skus/sku_123"
       assert sku.is_a?(Stripe::SKU)
     end
 
     context "#delete" do
       should "be deletable" do
-        sku = Stripe::SKU.retrieve("sku_123")
+        sku = StripeClient.new.skus.retrieve("sku_123")
         sku = sku.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/skus/#{sku.id}"
         assert sku.is_a?(Stripe::SKU)
@@ -51,7 +51,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        sku = Stripe::SKU.delete("sku_123")
+        sku = StripeClient.new.skus.delete("sku_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/skus/sku_123"
         assert sku.is_a?(Stripe::SKU)
       end

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -5,13 +5,13 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SourceTest < Test::Unit::TestCase
     should "be retrievable" do
-      source = Stripe::Source.retrieve("src_123")
+      source = StripeClient.new.sources.retrieve("src_123")
       assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123"
       assert source.is_a?(Stripe::Source)
     end
 
     should "be creatable" do
-      source = Stripe::Source.create(
+      source = StripeClient.new.sources.create(
         type: "card",
         token: "tok_123"
       )
@@ -20,21 +20,21 @@ module Stripe
     end
 
     should "be saveable" do
-      source = Stripe::Source.retrieve("src_123")
+      source = StripeClient.new.sources.retrieve("src_123")
       source.metadata["key"] = "value"
       source.save
       assert_requested :post, "#{Stripe.api_base}/v1/sources/#{source.id}"
     end
 
     should "be updateable" do
-      source = Stripe::Source.update("src_123", metadata: { foo: "bar" })
+      source = StripeClient.new.sources.update("src_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/sources/src_123"
       assert source.is_a?(Stripe::Source)
     end
 
     context "#detach" do
       should "not be deletable when unattached" do
-        source = Stripe::Source.retrieve("src_123")
+        source = StripeClient.new.sources.retrieve("src_123")
 
         assert_raises NotImplementedError do
           source.detach
@@ -42,9 +42,9 @@ module Stripe
       end
 
       should "be deletable when attached to a customer" do
-        source = Stripe::Source.construct_from(customer: "cus_123",
-                                               id: "src_123",
-                                               object: "source")
+        source = StripeClient.new.sources.construct_from(customer: "cus_123",
+                                                         id: "src_123",
+                                                         object: "source")
         source = source.detach
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/sources/src_123"
         assert source.is_a?(Stripe::Source)
@@ -53,13 +53,13 @@ module Stripe
 
     should "not be listable" do
       assert_raises NoMethodError do
-        Stripe::Source.list
+        StripeClient.new.sources.list
       end
     end
 
     context "#verify" do
       should "verify the source" do
-        source = Stripe::Source.retrieve("src_123")
+        source = StripeClient.new.sources.retrieve("src_123")
         source = source.verify(values: [1, 2])
         assert_requested :post,
                          "#{Stripe.api_base}/v1/sources/#{source.id}/verify",
@@ -70,7 +70,7 @@ module Stripe
 
     context ".verify" do
       should "verify the source" do
-        source = Stripe::Source.verify("src_123", values: [1, 2])
+        source = StripeClient.new.sources.verify("src_123", values: [1, 2])
         assert_requested :post,
                          "#{Stripe.api_base}/v1/sources/src_123/verify",
                          body: { values: [1, 2] }
@@ -80,7 +80,7 @@ module Stripe
 
     context ".retrieve_source_transaction" do
       should "retrieve a source transaction" do
-        Stripe::Source.retrieve_source_transaction(
+        StripeClient.new.sources.retrieve_source_transaction(
           "src_123",
           "srctxn_123"
         )
@@ -90,7 +90,7 @@ module Stripe
 
     context ".list_source_transactions" do
       should "list source transactions" do
-        Stripe::Source.list_source_transactions(
+        StripeClient.new.sources.list_source_transactions(
           "src_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
@@ -103,8 +103,8 @@ module Stripe
         $stderr = StringIO.new
 
         begin
-          source = Stripe::Source.construct_from(id: "src_123",
-                                                 object: "source")
+          source = StripeClient.new.sources.construct_from(id: "src_123",
+                                                           object: "source")
           source.source_transactions
           assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
 

--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -5,13 +5,13 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SourceTest < Test::Unit::TestCase
     should "be retrievable" do
-      source = StripeClient.new.sources.retrieve("src_123")
+      source = StripeClient.new.source.retrieve("src_123")
       assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123"
       assert source.is_a?(Stripe::Source)
     end
 
     should "be creatable" do
-      source = StripeClient.new.sources.create(
+      source = StripeClient.new.source.create(
         type: "card",
         token: "tok_123"
       )
@@ -20,21 +20,21 @@ module Stripe
     end
 
     should "be saveable" do
-      source = StripeClient.new.sources.retrieve("src_123")
+      source = StripeClient.new.source.retrieve("src_123")
       source.metadata["key"] = "value"
       source.save
       assert_requested :post, "#{Stripe.api_base}/v1/sources/#{source.id}"
     end
 
     should "be updateable" do
-      source = StripeClient.new.sources.update("src_123", metadata: { foo: "bar" })
+      source = StripeClient.new.source.update("src_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/sources/src_123"
       assert source.is_a?(Stripe::Source)
     end
 
     context "#detach" do
       should "not be deletable when unattached" do
-        source = StripeClient.new.sources.retrieve("src_123")
+        source = StripeClient.new.source.retrieve("src_123")
 
         assert_raises NotImplementedError do
           source.detach
@@ -42,9 +42,9 @@ module Stripe
       end
 
       should "be deletable when attached to a customer" do
-        source = StripeClient.new.sources.construct_from(customer: "cus_123",
-                                                         id: "src_123",
-                                                         object: "source")
+        source = StripeClient.new.source.construct_from(customer: "cus_123",
+                                                        id: "src_123",
+                                                        object: "source")
         source = source.detach
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/sources/src_123"
         assert source.is_a?(Stripe::Source)
@@ -53,13 +53,13 @@ module Stripe
 
     should "not be listable" do
       assert_raises NoMethodError do
-        StripeClient.new.sources.list
+        StripeClient.new.source.list
       end
     end
 
     context "#verify" do
       should "verify the source" do
-        source = StripeClient.new.sources.retrieve("src_123")
+        source = StripeClient.new.source.retrieve("src_123")
         source = source.verify(values: [1, 2])
         assert_requested :post,
                          "#{Stripe.api_base}/v1/sources/#{source.id}/verify",
@@ -70,7 +70,7 @@ module Stripe
 
     context ".verify" do
       should "verify the source" do
-        source = StripeClient.new.sources.verify("src_123", values: [1, 2])
+        source = StripeClient.new.source.verify("src_123", values: [1, 2])
         assert_requested :post,
                          "#{Stripe.api_base}/v1/sources/src_123/verify",
                          body: { values: [1, 2] }
@@ -80,7 +80,7 @@ module Stripe
 
     context ".retrieve_source_transaction" do
       should "retrieve a source transaction" do
-        StripeClient.new.sources.retrieve_source_transaction(
+        StripeClient.new.source.retrieve_source_transaction(
           "src_123",
           "srctxn_123"
         )
@@ -90,7 +90,7 @@ module Stripe
 
     context ".list_source_transactions" do
       should "list source transactions" do
-        StripeClient.new.sources.list_source_transactions(
+        StripeClient.new.source.list_source_transactions(
           "src_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
@@ -103,8 +103,8 @@ module Stripe
         $stderr = StringIO.new
 
         begin
-          source = StripeClient.new.sources.construct_from(id: "src_123",
-                                                           object: "source")
+          source = StripeClient.new.source.construct_from(id: "src_123",
+                                                          object: "source")
           source.source_transactions
           assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions"
 

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionItemTest < Test::Unit::TestCase
     should "be listable" do
-      items = Stripe::SubscriptionItem.list(
+      items = StripeClient.new.subscription_items.list(
         subscription: "sub_123"
       )
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_items",
@@ -15,13 +15,13 @@ module Stripe
     end
 
     should "be retrievable" do
-      item = Stripe::SubscriptionItem.retrieve("si_123")
+      item = StripeClient.new.subscription_items.retrieve("si_123")
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123"
       assert item.is_a?(Stripe::SubscriptionItem)
     end
 
     should "be creatable" do
-      item = Stripe::SubscriptionItem.create(
+      item = StripeClient.new.subscription_items.create(
         price: "sapphire-elite",
         quantity: 3,
         subscription: "sub_123"
@@ -31,21 +31,21 @@ module Stripe
     end
 
     should "be saveable" do
-      item = Stripe::SubscriptionItem.retrieve("si_123")
+      item = StripeClient.new.subscription_items.retrieve("si_123")
       item.quantity = 4
       item.save
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
     end
 
     should "be updateable" do
-      item = Stripe::SubscriptionItem.update("si_123", metadata: { foo: "bar" })
+      item = StripeClient.new.subscription_items.update("si_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_items/si_123"
       assert item.is_a?(Stripe::SubscriptionItem)
     end
 
     context "#delete" do
       should "be deletable" do
-        item = Stripe::SubscriptionItem.retrieve("si_123")
+        item = StripeClient.new.subscription_items.retrieve("si_123")
         item = item.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
         assert item.is_a?(Stripe::SubscriptionItem)
@@ -54,7 +54,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        item = Stripe::SubscriptionItem.delete("si_123")
+        item = StripeClient.new.subscription_items.delete("si_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/si_123"
         assert item.is_a?(Stripe::SubscriptionItem)
       end
@@ -62,7 +62,7 @@ module Stripe
 
     context "#create_usage_record" do
       should "create a usage record" do
-        Stripe::SubscriptionItem.create_usage_record(
+        StripeClient.new.subscription_items.create_usage_record(
           "si_123",
           quantity: 5000,
           timestamp: Time.now.to_i,
@@ -74,7 +74,7 @@ module Stripe
 
     context "#list_usage_record_summaries" do
       should "list usage record summaries" do
-        Stripe::SubscriptionItem.list_usage_record_summaries(
+        StripeClient.new.subscription_items.list_usage_record_summaries(
           "si_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123/usage_record_summaries"

--- a/test/stripe/subscription_item_test.rb
+++ b/test/stripe/subscription_item_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionItemTest < Test::Unit::TestCase
     should "be listable" do
-      items = StripeClient.new.subscription_items.list(
+      items = StripeClient.new.subscription_item.list(
         subscription: "sub_123"
       )
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_items",
@@ -15,13 +15,13 @@ module Stripe
     end
 
     should "be retrievable" do
-      item = StripeClient.new.subscription_items.retrieve("si_123")
+      item = StripeClient.new.subscription_item.retrieve("si_123")
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123"
       assert item.is_a?(Stripe::SubscriptionItem)
     end
 
     should "be creatable" do
-      item = StripeClient.new.subscription_items.create(
+      item = StripeClient.new.subscription_item.create(
         price: "sapphire-elite",
         quantity: 3,
         subscription: "sub_123"
@@ -31,21 +31,21 @@ module Stripe
     end
 
     should "be saveable" do
-      item = StripeClient.new.subscription_items.retrieve("si_123")
+      item = StripeClient.new.subscription_item.retrieve("si_123")
       item.quantity = 4
       item.save
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
     end
 
     should "be updateable" do
-      item = StripeClient.new.subscription_items.update("si_123", metadata: { foo: "bar" })
+      item = StripeClient.new.subscription_item.update("si_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_items/si_123"
       assert item.is_a?(Stripe::SubscriptionItem)
     end
 
     context "#delete" do
       should "be deletable" do
-        item = StripeClient.new.subscription_items.retrieve("si_123")
+        item = StripeClient.new.subscription_item.retrieve("si_123")
         item = item.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/#{item.id}"
         assert item.is_a?(Stripe::SubscriptionItem)
@@ -54,7 +54,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        item = StripeClient.new.subscription_items.delete("si_123")
+        item = StripeClient.new.subscription_item.delete("si_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/subscription_items/si_123"
         assert item.is_a?(Stripe::SubscriptionItem)
       end
@@ -62,7 +62,7 @@ module Stripe
 
     context "#create_usage_record" do
       should "create a usage record" do
-        StripeClient.new.subscription_items.create_usage_record(
+        StripeClient.new.subscription_item.create_usage_record(
           "si_123",
           quantity: 5000,
           timestamp: Time.now.to_i,
@@ -74,7 +74,7 @@ module Stripe
 
     context "#list_usage_record_summaries" do
       should "list usage record summaries" do
-        StripeClient.new.subscription_items.list_usage_record_summaries(
+        StripeClient.new.subscription_item.list_usage_record_summaries(
           "si_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/subscription_items/si_123/usage_record_summaries"

--- a/test/stripe/subscription_schedule_test.rb
+++ b/test/stripe/subscription_schedule_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionScheduleTest < Test::Unit::TestCase
     should "be listable" do
-      subscriptions = Stripe::SubscriptionSchedule.list
+      subscriptions = StripeClient.new.subscription_schedules.list
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_schedules"
       assert subscriptions.data.is_a?(Array)
       assert subscriptions.data[0].is_a?(Stripe::SubscriptionSchedule)
     end
 
     should "be retrievable" do
-      schedule = Stripe::SubscriptionSchedule.retrieve("sub_sched_123")
+      schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123"
       assert schedule.is_a?(Stripe::SubscriptionSchedule)
     end
 
     should "be creatable" do
-      schedule = Stripe::SubscriptionSchedule.create(
+      schedule = StripeClient.new.subscription_schedules.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_schedules"
@@ -27,7 +27,7 @@ module Stripe
     end
 
     should "be saveable" do
-      schedule = Stripe::SubscriptionSchedule.retrieve("sub_sched_123")
+      schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
       schedule.metadata["key"] = "value"
       schedule.save
       assert_requested :post,
@@ -35,7 +35,7 @@ module Stripe
     end
 
     should "be updateable" do
-      schedule = Stripe::SubscriptionSchedule.update("sub_sched_123", metadata: { foo: "bar" })
+      schedule = StripeClient.new.subscription_schedules.update("sub_sched_123", metadata: { foo: "bar" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123"
       assert schedule.is_a?(Stripe::SubscriptionSchedule)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a subscription schedule" do
-        schedule = Stripe::SubscriptionSchedule.retrieve("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
         schedule = schedule.cancel
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/#{schedule.id}/cancel"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a subscription schedule" do
-        schedule = Stripe::SubscriptionSchedule.cancel("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedules.cancel("sub_sched_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123/cancel"
         assert schedule.is_a?(Stripe::SubscriptionSchedule)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#release" do
       should "release a subscription schedule" do
-        schedule = Stripe::SubscriptionSchedule.retrieve("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
         schedule = schedule.release
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/#{schedule.id}/release"
@@ -72,7 +72,7 @@ module Stripe
 
     context ".release" do
       should "release a subscription schedule" do
-        schedule = Stripe::SubscriptionSchedule.release("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedules.release("sub_sched_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123/release"
         assert schedule.is_a?(Stripe::SubscriptionSchedule)

--- a/test/stripe/subscription_schedule_test.rb
+++ b/test/stripe/subscription_schedule_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionScheduleTest < Test::Unit::TestCase
     should "be listable" do
-      subscriptions = StripeClient.new.subscription_schedules.list
+      subscriptions = StripeClient.new.subscription_schedule.list
       assert_requested :get, "#{Stripe.api_base}/v1/subscription_schedules"
       assert subscriptions.data.is_a?(Array)
       assert subscriptions.data[0].is_a?(Stripe::SubscriptionSchedule)
     end
 
     should "be retrievable" do
-      schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
+      schedule = StripeClient.new.subscription_schedule.retrieve("sub_sched_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123"
       assert schedule.is_a?(Stripe::SubscriptionSchedule)
     end
 
     should "be creatable" do
-      schedule = StripeClient.new.subscription_schedules.create(
+      schedule = StripeClient.new.subscription_schedule.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/subscription_schedules"
@@ -27,7 +27,7 @@ module Stripe
     end
 
     should "be saveable" do
-      schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
+      schedule = StripeClient.new.subscription_schedule.retrieve("sub_sched_123")
       schedule.metadata["key"] = "value"
       schedule.save
       assert_requested :post,
@@ -35,7 +35,7 @@ module Stripe
     end
 
     should "be updateable" do
-      schedule = StripeClient.new.subscription_schedules.update("sub_sched_123", metadata: { foo: "bar" })
+      schedule = StripeClient.new.subscription_schedule.update("sub_sched_123", metadata: { foo: "bar" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123"
       assert schedule.is_a?(Stripe::SubscriptionSchedule)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#cancel" do
       should "cancel a subscription schedule" do
-        schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedule.retrieve("sub_sched_123")
         schedule = schedule.cancel
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/#{schedule.id}/cancel"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel a subscription schedule" do
-        schedule = StripeClient.new.subscription_schedules.cancel("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedule.cancel("sub_sched_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123/cancel"
         assert schedule.is_a?(Stripe::SubscriptionSchedule)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#release" do
       should "release a subscription schedule" do
-        schedule = StripeClient.new.subscription_schedules.retrieve("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedule.retrieve("sub_sched_123")
         schedule = schedule.release
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/#{schedule.id}/release"
@@ -72,7 +72,7 @@ module Stripe
 
     context ".release" do
       should "release a subscription schedule" do
-        schedule = StripeClient.new.subscription_schedules.release("sub_sched_123")
+        schedule = StripeClient.new.subscription_schedule.release("sub_sched_123")
         assert_requested :post,
                          "#{Stripe.api_base}/v1/subscription_schedules/sub_sched_123/release"
         assert schedule.is_a?(Stripe::SubscriptionSchedule)

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionTest < Test::Unit::TestCase
     should "be listable" do
-      subscriptions = StripeClient.new.subscriptions.list
+      subscriptions = StripeClient.new.subscription.list
       assert_requested :get, "#{Stripe.api_base}/v1/subscriptions"
       assert subscriptions.data.is_a?(Array)
       assert subscriptions.data[0].is_a?(Stripe::Subscription)
     end
 
     should "be retrievable" do
-      subscription = StripeClient.new.subscriptions.retrieve("sub_123")
+      subscription = StripeClient.new.subscription.retrieve("sub_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/subscriptions/sub_123"
       assert subscription.is_a?(Stripe::Subscription)
     end
 
     should "be creatable" do
-      subscription = StripeClient.new.subscriptions.create(
+      subscription = StripeClient.new.subscription.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/subscriptions"
@@ -27,7 +27,7 @@ module Stripe
     end
 
     should "be saveable" do
-      subscription = StripeClient.new.subscriptions.retrieve("sub_123")
+      subscription = StripeClient.new.subscription.retrieve("sub_123")
       subscription.metadata["key"] = "value"
       subscription.save
       assert_requested :post,
@@ -35,7 +35,7 @@ module Stripe
     end
 
     should "be updateable" do
-      subscription = StripeClient.new.subscriptions.update("sub_123", metadata: { foo: "bar" })
+      subscription = StripeClient.new.subscription.update("sub_123", metadata: { foo: "bar" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/subscriptions/sub_123"
       assert subscription.is_a?(Stripe::Subscription)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        subscription = StripeClient.new.subscriptions.retrieve("sub_123")
+        subscription = StripeClient.new.subscription.retrieve("sub_123")
         subscription = subscription.delete
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/subscriptions/#{subscription.id}"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        subscription = StripeClient.new.subscriptions.delete("sub_123")
+        subscription = StripeClient.new.subscription.delete("sub_123")
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/subscriptions/sub_123"
         assert subscription.is_a?(Stripe::Subscription)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#delete_discount" do
       should "be able to delete a subscriptions's discount" do
-        subscription = StripeClient.new.subscriptions.retrieve("sub_123")
+        subscription = StripeClient.new.subscription.retrieve("sub_123")
         discount = subscription.delete_discount
         assert_requested :delete, "#{Stripe.api_base}/v1/subscriptions/sub_123/discount"
         assert discount.is_a?(Stripe::Discount)
@@ -71,7 +71,7 @@ module Stripe
 
     context ".delete_discount" do
       should "be able to delete a subscriptions's discount" do
-        discount = StripeClient.new.subscriptions.delete_discount("sub_123")
+        discount = StripeClient.new.subscription.delete_discount("sub_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/subscriptions/sub_123/discount"
         assert discount.is_a?(Stripe::Discount)
       end

--- a/test/stripe/subscription_test.rb
+++ b/test/stripe/subscription_test.rb
@@ -5,21 +5,21 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class SubscriptionTest < Test::Unit::TestCase
     should "be listable" do
-      subscriptions = Stripe::Subscription.list
+      subscriptions = StripeClient.new.subscriptions.list
       assert_requested :get, "#{Stripe.api_base}/v1/subscriptions"
       assert subscriptions.data.is_a?(Array)
       assert subscriptions.data[0].is_a?(Stripe::Subscription)
     end
 
     should "be retrievable" do
-      subscription = Stripe::Subscription.retrieve("sub_123")
+      subscription = StripeClient.new.subscriptions.retrieve("sub_123")
       assert_requested :get,
                        "#{Stripe.api_base}/v1/subscriptions/sub_123"
       assert subscription.is_a?(Stripe::Subscription)
     end
 
     should "be creatable" do
-      subscription = Stripe::Subscription.create(
+      subscription = StripeClient.new.subscriptions.create(
         customer: "cus_123"
       )
       assert_requested :post, "#{Stripe.api_base}/v1/subscriptions"
@@ -27,7 +27,7 @@ module Stripe
     end
 
     should "be saveable" do
-      subscription = Stripe::Subscription.retrieve("sub_123")
+      subscription = StripeClient.new.subscriptions.retrieve("sub_123")
       subscription.metadata["key"] = "value"
       subscription.save
       assert_requested :post,
@@ -35,7 +35,7 @@ module Stripe
     end
 
     should "be updateable" do
-      subscription = Stripe::Subscription.update("sub_123", metadata: { foo: "bar" })
+      subscription = StripeClient.new.subscriptions.update("sub_123", metadata: { foo: "bar" })
       assert_requested :post,
                        "#{Stripe.api_base}/v1/subscriptions/sub_123"
       assert subscription.is_a?(Stripe::Subscription)
@@ -43,7 +43,7 @@ module Stripe
 
     context "#delete" do
       should "be deletable" do
-        subscription = Stripe::Subscription.retrieve("sub_123")
+        subscription = StripeClient.new.subscriptions.retrieve("sub_123")
         subscription = subscription.delete
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/subscriptions/#{subscription.id}"
@@ -53,7 +53,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        subscription = Stripe::Subscription.delete("sub_123")
+        subscription = StripeClient.new.subscriptions.delete("sub_123")
         assert_requested :delete,
                          "#{Stripe.api_base}/v1/subscriptions/sub_123"
         assert subscription.is_a?(Stripe::Subscription)
@@ -62,7 +62,7 @@ module Stripe
 
     context "#delete_discount" do
       should "be able to delete a subscriptions's discount" do
-        subscription = Stripe::Subscription.retrieve("sub_123")
+        subscription = StripeClient.new.subscriptions.retrieve("sub_123")
         discount = subscription.delete_discount
         assert_requested :delete, "#{Stripe.api_base}/v1/subscriptions/sub_123/discount"
         assert discount.is_a?(Stripe::Discount)
@@ -71,7 +71,7 @@ module Stripe
 
     context ".delete_discount" do
       should "be able to delete a subscriptions's discount" do
-        discount = Stripe::Subscription.delete_discount("sub_123")
+        discount = StripeClient.new.subscriptions.delete_discount("sub_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/subscriptions/sub_123/discount"
         assert discount.is_a?(Stripe::Discount)
       end

--- a/test/stripe/tax_id_test.rb
+++ b/test/stripe/tax_id_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class TaxIdTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        tax_id = Stripe::TaxId.construct_from(
+        tax_id = StripeClient.new.tax_ids.construct_from(
           id: "txi_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        tax_id = Stripe::TaxId.construct_from(id: "txi_123")
+        tax_id = StripeClient.new.tax_ids.construct_from(id: "txi_123")
         assert_raises NotImplementedError do
           tax_id.resource_url
         end
@@ -24,7 +24,7 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        Stripe::TaxId.retrieve("txi_123")
+        StripeClient.new.tax_ids.retrieve("txi_123")
       end
     end
   end

--- a/test/stripe/tax_id_test.rb
+++ b/test/stripe/tax_id_test.rb
@@ -6,7 +6,7 @@ module Stripe
   class TaxIdTest < Test::Unit::TestCase
     context "#resource_url" do
       should "return a resource URL" do
-        tax_id = StripeClient.new.tax_ids.construct_from(
+        tax_id = StripeClient.new.tax_id.construct_from(
           id: "txi_123",
           customer: "cus_123"
         )
@@ -15,7 +15,7 @@ module Stripe
       end
 
       should "raise without a customer" do
-        tax_id = StripeClient.new.tax_ids.construct_from(id: "txi_123")
+        tax_id = StripeClient.new.tax_id.construct_from(id: "txi_123")
         assert_raises NotImplementedError do
           tax_id.resource_url
         end
@@ -24,7 +24,7 @@ module Stripe
 
     should "raise on #retrieve" do
       assert_raises NotImplementedError do
-        StripeClient.new.tax_ids.retrieve("txi_123")
+        StripeClient.new.tax_id.retrieve("txi_123")
       end
     end
   end

--- a/test/stripe/tax_rate_test.rb
+++ b/test/stripe/tax_rate_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TaxRateTest < Test::Unit::TestCase
     should "be listable" do
-      tax_rates = StripeClient.new.tax_rates.list
+      tax_rates = StripeClient.new.tax_rate.list
       assert_requested :get, "#{Stripe.api_base}/v1/tax_rates"
       assert tax_rates.data.is_a?(Array)
       assert tax_rates.first.is_a?(Stripe::TaxRate)
     end
 
     should "be retrievable" do
-      tax_rate = StripeClient.new.tax_rates.retrieve("txr_123")
+      tax_rate = StripeClient.new.tax_rate.retrieve("txr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/tax_rates/txr_123"
       assert tax_rate.is_a?(Stripe::TaxRate)
     end
 
     should "be creatable" do
-      tax_rate = StripeClient.new.tax_rates.create(
+      tax_rate = StripeClient.new.tax_rate.create(
         display_name: "name",
         inclusive: false,
         percentage: 10.15
@@ -28,14 +28,14 @@ module Stripe
     end
 
     should "be saveable" do
-      tax_rate = StripeClient.new.tax_rates.retrieve("txr_123")
+      tax_rate = StripeClient.new.tax_rate.retrieve("txr_123")
       tax_rate.metadata["key"] = "value"
       tax_rate.save
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/#{tax_rate.id}"
     end
 
     should "be updateable" do
-      tax_rate = StripeClient.new.tax_rates.update("txr_123", metadata: { key: "value" })
+      tax_rate = StripeClient.new.tax_rate.update("txr_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/txr_123"
       assert tax_rate.is_a?(Stripe::TaxRate)
     end

--- a/test/stripe/tax_rate_test.rb
+++ b/test/stripe/tax_rate_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TaxRateTest < Test::Unit::TestCase
     should "be listable" do
-      tax_rates = Stripe::TaxRate.list
+      tax_rates = StripeClient.new.tax_rates.list
       assert_requested :get, "#{Stripe.api_base}/v1/tax_rates"
       assert tax_rates.data.is_a?(Array)
       assert tax_rates.first.is_a?(Stripe::TaxRate)
     end
 
     should "be retrievable" do
-      tax_rate = Stripe::TaxRate.retrieve("txr_123")
+      tax_rate = StripeClient.new.tax_rates.retrieve("txr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/tax_rates/txr_123"
       assert tax_rate.is_a?(Stripe::TaxRate)
     end
 
     should "be creatable" do
-      tax_rate = Stripe::TaxRate.create(
+      tax_rate = StripeClient.new.tax_rates.create(
         display_name: "name",
         inclusive: false,
         percentage: 10.15
@@ -28,14 +28,14 @@ module Stripe
     end
 
     should "be saveable" do
-      tax_rate = Stripe::TaxRate.retrieve("txr_123")
+      tax_rate = StripeClient.new.tax_rates.retrieve("txr_123")
       tax_rate.metadata["key"] = "value"
       tax_rate.save
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/#{tax_rate.id}"
     end
 
     should "be updateable" do
-      tax_rate = Stripe::TaxRate.update("txr_123", metadata: { key: "value" })
+      tax_rate = StripeClient.new.tax_rates.update("txr_123", metadata: { key: "value" })
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/txr_123"
       assert tax_rate.is_a?(Stripe::TaxRate)
     end

--- a/test/stripe/terminal/connection_token_test.rb
+++ b/test/stripe/terminal/connection_token_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class ConnectionTokenTest < Test::Unit::TestCase
       should "be creatable" do
-        connection_token = Stripe::Terminal::ConnectionToken.create
+        connection_token = StripeClient.new.terminal.connection_tokens.create
 
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/connection_tokens"
         assert connection_token.is_a?(Stripe::Terminal::ConnectionToken)

--- a/test/stripe/terminal/connection_token_test.rb
+++ b/test/stripe/terminal/connection_token_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class ConnectionTokenTest < Test::Unit::TestCase
       should "be creatable" do
-        connection_token = StripeClient.new.terminal.connection_tokens.create
+        connection_token = StripeClient.new.terminal.connection_token.create
 
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/connection_tokens"
         assert connection_token.is_a?(Stripe::Terminal::ConnectionToken)

--- a/test/stripe/terminal/location_test.rb
+++ b/test/stripe/terminal/location_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class LocationTest < Test::Unit::TestCase
       should "be creatable" do
-        location = Stripe::Terminal::Location.create(
+        location = StripeClient.new.terminal.locations.create(
           address: {
             line1: "line1",
             country: "US",
@@ -21,20 +21,20 @@ module Stripe
       end
 
       should "be listable" do
-        locations = Stripe::Terminal::Location.list
+        locations = StripeClient.new.terminal.locations.list
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/locations"
         assert locations.data.is_a?(Array)
         assert locations.data[0].is_a?(Stripe::Terminal::Location)
       end
 
       should "be retrievable" do
-        location = Stripe::Terminal::Location.retrieve("loc_123")
+        location = StripeClient.new.terminal.locations.retrieve("loc_123")
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
         assert location.is_a?(Stripe::Terminal::Location)
       end
 
       should "be saveable" do
-        location = Stripe::Terminal::Location.retrieve("loc_123")
+        location = StripeClient.new.terminal.locations.retrieve("loc_123")
         location["display_name"] = "new name"
         location.save
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
@@ -42,14 +42,14 @@ module Stripe
       end
 
       should "be updateable" do
-        location = Stripe::Terminal::Location.update("loc_123", display_name: "new name")
+        location = StripeClient.new.terminal.locations.update("loc_123", display_name: "new name")
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
         assert location.is_a?(Stripe::Terminal::Location)
       end
 
       context "#delete" do
         should "be deletable" do
-          location = Stripe::Terminal::Location.retrieve("loc_123")
+          location = StripeClient.new.terminal.locations.retrieve("loc_123")
           location = location.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/#{location.id}"
           assert location.is_a?(Stripe::Terminal::Location)
@@ -58,7 +58,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          location = Stripe::Terminal::Location.delete("loc_123")
+          location = StripeClient.new.terminal.locations.delete("loc_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
           assert location.is_a?(Stripe::Terminal::Location)
         end

--- a/test/stripe/terminal/location_test.rb
+++ b/test/stripe/terminal/location_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class LocationTest < Test::Unit::TestCase
       should "be creatable" do
-        location = StripeClient.new.terminal.locations.create(
+        location = StripeClient.new.terminal.location.create(
           address: {
             line1: "line1",
             country: "US",
@@ -21,20 +21,20 @@ module Stripe
       end
 
       should "be listable" do
-        locations = StripeClient.new.terminal.locations.list
+        locations = StripeClient.new.terminal.location.list
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/locations"
         assert locations.data.is_a?(Array)
         assert locations.data[0].is_a?(Stripe::Terminal::Location)
       end
 
       should "be retrievable" do
-        location = StripeClient.new.terminal.locations.retrieve("loc_123")
+        location = StripeClient.new.terminal.location.retrieve("loc_123")
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
         assert location.is_a?(Stripe::Terminal::Location)
       end
 
       should "be saveable" do
-        location = StripeClient.new.terminal.locations.retrieve("loc_123")
+        location = StripeClient.new.terminal.location.retrieve("loc_123")
         location["display_name"] = "new name"
         location.save
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
@@ -42,14 +42,14 @@ module Stripe
       end
 
       should "be updateable" do
-        location = StripeClient.new.terminal.locations.update("loc_123", display_name: "new name")
+        location = StripeClient.new.terminal.location.update("loc_123", display_name: "new name")
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
         assert location.is_a?(Stripe::Terminal::Location)
       end
 
       context "#delete" do
         should "be deletable" do
-          location = StripeClient.new.terminal.locations.retrieve("loc_123")
+          location = StripeClient.new.terminal.location.retrieve("loc_123")
           location = location.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/#{location.id}"
           assert location.is_a?(Stripe::Terminal::Location)
@@ -58,7 +58,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          location = StripeClient.new.terminal.locations.delete("loc_123")
+          location = StripeClient.new.terminal.location.delete("loc_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/locations/loc_123"
           assert location.is_a?(Stripe::Terminal::Location)
         end

--- a/test/stripe/terminal/reader_test.rb
+++ b/test/stripe/terminal/reader_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class ReaderTest < Test::Unit::TestCase
       should "be creatable" do
-        reader = StripeClient.new.terminal.readers.create(
+        reader = StripeClient.new.terminal.reader.create(
           registration_code: "elegant-orange-aqua",
           label: "label"
         )
@@ -15,20 +15,20 @@ module Stripe
       end
 
       should "be listable" do
-        readers = StripeClient.new.terminal.readers.list
+        readers = StripeClient.new.terminal.reader.list
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/readers"
         assert readers.data.is_a?(Array)
         assert readers.data[0].is_a?(Stripe::Terminal::Reader)
       end
 
       should "be retrievable" do
-        reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
+        reader = StripeClient.new.terminal.reader.retrieve("rdr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
         assert reader.is_a?(Stripe::Terminal::Reader)
       end
 
       should "be saveable" do
-        reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
+        reader = StripeClient.new.terminal.reader.retrieve("rdr_123")
         reader["label"] = "new label"
         reader.save
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
@@ -36,14 +36,14 @@ module Stripe
       end
 
       should "be updateable" do
-        reader = StripeClient.new.terminal.readers.update("rdr_123", label: "new label")
+        reader = StripeClient.new.terminal.reader.update("rdr_123", label: "new label")
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
         assert reader.is_a?(Stripe::Terminal::Reader)
       end
 
       context "#delete" do
         should "be deletable" do
-          reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
+          reader = StripeClient.new.terminal.reader.retrieve("rdr_123")
           reader = reader.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/#{reader.id}"
           assert reader.is_a?(Stripe::Terminal::Reader)
@@ -52,7 +52,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          reader = StripeClient.new.terminal.readers.delete("rdr_123")
+          reader = StripeClient.new.terminal.reader.delete("rdr_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
           assert reader.is_a?(Stripe::Terminal::Reader)
         end

--- a/test/stripe/terminal/reader_test.rb
+++ b/test/stripe/terminal/reader_test.rb
@@ -6,7 +6,7 @@ module Stripe
   module Terminal
     class ReaderTest < Test::Unit::TestCase
       should "be creatable" do
-        reader = Stripe::Terminal::Reader.create(
+        reader = StripeClient.new.terminal.readers.create(
           registration_code: "elegant-orange-aqua",
           label: "label"
         )
@@ -15,20 +15,20 @@ module Stripe
       end
 
       should "be listable" do
-        readers = Stripe::Terminal::Reader.list
+        readers = StripeClient.new.terminal.readers.list
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/readers"
         assert readers.data.is_a?(Array)
         assert readers.data[0].is_a?(Stripe::Terminal::Reader)
       end
 
       should "be retrievable" do
-        reader = Stripe::Terminal::Reader.retrieve("rdr_123")
+        reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
         assert_requested :get, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
         assert reader.is_a?(Stripe::Terminal::Reader)
       end
 
       should "be saveable" do
-        reader = Stripe::Terminal::Reader.retrieve("rdr_123")
+        reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
         reader["label"] = "new label"
         reader.save
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
@@ -36,14 +36,14 @@ module Stripe
       end
 
       should "be updateable" do
-        reader = Stripe::Terminal::Reader.update("rdr_123", label: "new label")
+        reader = StripeClient.new.terminal.readers.update("rdr_123", label: "new label")
         assert_requested :post, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
         assert reader.is_a?(Stripe::Terminal::Reader)
       end
 
       context "#delete" do
         should "be deletable" do
-          reader = Stripe::Terminal::Reader.retrieve("rdr_123")
+          reader = StripeClient.new.terminal.readers.retrieve("rdr_123")
           reader = reader.delete
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/#{reader.id}"
           assert reader.is_a?(Stripe::Terminal::Reader)
@@ -52,7 +52,7 @@ module Stripe
 
       context ".delete" do
         should "be deletable" do
-          reader = Stripe::Terminal::Reader.delete("rdr_123")
+          reader = StripeClient.new.terminal.readers.delete("rdr_123")
           assert_requested :delete, "#{Stripe.api_base}/v1/terminal/readers/rdr_123"
           assert reader.is_a?(Stripe::Terminal::Reader)
         end

--- a/test/stripe/three_d_secure_test.rb
+++ b/test/stripe/three_d_secure_test.rb
@@ -5,13 +5,13 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ThreeDSecureTest < Test::Unit::TestCase
     should "be retrievable" do
-      secure = Stripe::ThreeDSecure.retrieve("tdsrc_123")
+      secure = StripeClient.new.three_d_secures.retrieve("tdsrc_123")
       assert_requested :get, "#{Stripe.api_base}/v1/3d_secure/tdsrc_123"
       assert secure.is_a?(Stripe::ThreeDSecure)
     end
 
     should "be creatable" do
-      _ = Stripe::ThreeDSecure.create(
+      _ = StripeClient.new.three_d_secures.create(
         card: "tok_123",
         amount: 1500,
         currency: "usd",

--- a/test/stripe/three_d_secure_test.rb
+++ b/test/stripe/three_d_secure_test.rb
@@ -5,13 +5,13 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class ThreeDSecureTest < Test::Unit::TestCase
     should "be retrievable" do
-      secure = StripeClient.new.three_d_secures.retrieve("tdsrc_123")
+      secure = StripeClient.new.three_d_secure.retrieve("tdsrc_123")
       assert_requested :get, "#{Stripe.api_base}/v1/3d_secure/tdsrc_123"
       assert secure.is_a?(Stripe::ThreeDSecure)
     end
 
     should "be creatable" do
-      _ = StripeClient.new.three_d_secures.create(
+      _ = StripeClient.new.three_d_secure.create(
         card: "tok_123",
         amount: 1500,
         currency: "usd",

--- a/test/stripe/topup_test.rb
+++ b/test/stripe/topup_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TopupTest < Test::Unit::TestCase
     should "be listable" do
-      topups = StripeClient.new.topups.list
+      topups = StripeClient.new.topup.list
       assert_requested :get, "#{Stripe.api_base}/v1/topups"
       assert topups.data.is_a?(Array)
       assert topups.data[0].is_a?(Stripe::Topup)
     end
 
     should "be retrievable" do
-      topup = StripeClient.new.topups.retrieve("tu_123")
+      topup = StripeClient.new.topup.retrieve("tu_123")
       assert_requested :get, "#{Stripe.api_base}/v1/topups/tu_123"
       assert topup.is_a?(Stripe::Topup)
     end
 
     should "be creatable" do
-      topup = StripeClient.new.topups.create(
+      topup = StripeClient.new.topup.create(
         amount: 100,
         currency: "USD",
         source: "src_123",
@@ -30,21 +30,21 @@ module Stripe
     end
 
     should "be saveable" do
-      topup = StripeClient.new.topups.retrieve("tu_123")
+      topup = StripeClient.new.topup.retrieve("tu_123")
       topup.metadata["key"] = "value"
       topup.save
       assert_requested :post, "#{Stripe.api_base}/v1/topups/#{topup.id}"
     end
 
     should "be updateable" do
-      topup = StripeClient.new.topups.update("tu_123", metadata: { foo: "bar" })
+      topup = StripeClient.new.topup.update("tu_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/topups/tu_123"
       assert topup.is_a?(Stripe::Topup)
     end
 
     context "#cancel" do
       should "cancel the topup" do
-        topup = StripeClient.new.topups.retrieve("tu_123")
+        topup = StripeClient.new.topup.retrieve("tu_123")
         topup = topup.cancel
         assert_requested :post, "#{Stripe.api_base}/v1/topups/#{topup.id}/cancel"
         assert topup.is_a?(Stripe::Topup)
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel the topup" do
-        topup = StripeClient.new.topups.cancel("tu_123")
+        topup = StripeClient.new.topup.cancel("tu_123")
         assert_requested :post, "#{Stripe.api_base}/v1/topups/tu_123/cancel"
         assert topup.is_a?(Stripe::Topup)
       end

--- a/test/stripe/topup_test.rb
+++ b/test/stripe/topup_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TopupTest < Test::Unit::TestCase
     should "be listable" do
-      topups = Stripe::Topup.list
+      topups = StripeClient.new.topups.list
       assert_requested :get, "#{Stripe.api_base}/v1/topups"
       assert topups.data.is_a?(Array)
       assert topups.data[0].is_a?(Stripe::Topup)
     end
 
     should "be retrievable" do
-      topup = Stripe::Topup.retrieve("tu_123")
+      topup = StripeClient.new.topups.retrieve("tu_123")
       assert_requested :get, "#{Stripe.api_base}/v1/topups/tu_123"
       assert topup.is_a?(Stripe::Topup)
     end
 
     should "be creatable" do
-      topup = Stripe::Topup.create(
+      topup = StripeClient.new.topups.create(
         amount: 100,
         currency: "USD",
         source: "src_123",
@@ -30,21 +30,21 @@ module Stripe
     end
 
     should "be saveable" do
-      topup = Stripe::Topup.retrieve("tu_123")
+      topup = StripeClient.new.topups.retrieve("tu_123")
       topup.metadata["key"] = "value"
       topup.save
       assert_requested :post, "#{Stripe.api_base}/v1/topups/#{topup.id}"
     end
 
     should "be updateable" do
-      topup = Stripe::Topup.update("tu_123", metadata: { foo: "bar" })
+      topup = StripeClient.new.topups.update("tu_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/topups/tu_123"
       assert topup.is_a?(Stripe::Topup)
     end
 
     context "#cancel" do
       should "cancel the topup" do
-        topup = Stripe::Topup.retrieve("tu_123")
+        topup = StripeClient.new.topups.retrieve("tu_123")
         topup = topup.cancel
         assert_requested :post, "#{Stripe.api_base}/v1/topups/#{topup.id}/cancel"
         assert topup.is_a?(Stripe::Topup)
@@ -53,7 +53,7 @@ module Stripe
 
     context ".cancel" do
       should "cancel the topup" do
-        topup = Stripe::Topup.cancel("tu_123")
+        topup = StripeClient.new.topups.cancel("tu_123")
         assert_requested :post, "#{Stripe.api_base}/v1/topups/tu_123/cancel"
         assert topup.is_a?(Stripe::Topup)
       end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TransferTest < Test::Unit::TestCase
     should "be listable" do
-      transfers = StripeClient.new.transfers.list
+      transfers = StripeClient.new.transfer.list
       assert_requested :get, "#{Stripe.api_base}/v1/transfers"
       assert transfers.data.is_a?(Array)
       assert transfers.data[0].is_a?(Stripe::Transfer)
     end
 
     should "be retrievable" do
-      transfer = StripeClient.new.transfers.retrieve("tr_123")
+      transfer = StripeClient.new.transfer.retrieve("tr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123"
       assert transfer.is_a?(Stripe::Transfer)
     end
 
     should "be creatable" do
-      transfer = StripeClient.new.transfers.create(
+      transfer = StripeClient.new.transfer.create(
         amount: 100,
         currency: "USD",
         destination: "acct_123"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      transfer = StripeClient.new.transfers.retrieve("tr_123")
+      transfer = StripeClient.new.transfer.retrieve("tr_123")
       transfer.metadata["key"] = "value"
       transfer.save
       assert_requested :post, "#{Stripe.api_base}/v1/transfers/#{transfer.id}"
     end
 
     should "be updateable" do
-      transfer = StripeClient.new.transfers.update("tr_123", metadata: { foo: "bar" })
+      transfer = StripeClient.new.transfer.update("tr_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/transfers/tr_123"
       assert transfer.is_a?(Stripe::Transfer)
     end
 
     context "#create_reversal" do
       should "create a reversal" do
-        reversal = StripeClient.new.transfers.create_reversal(
+        reversal = StripeClient.new.transfer.create_reversal(
           "tr_123",
           amount: 100
         )
@@ -53,7 +53,7 @@ module Stripe
 
     context "#retrieve_reversal" do
       should "retrieve a reversal" do
-        reversal = StripeClient.new.transfers.retrieve_reversal(
+        reversal = StripeClient.new.transfer.retrieve_reversal(
           "tr_123",
           "trr_123"
         )
@@ -64,7 +64,7 @@ module Stripe
 
     context "#update_reversal" do
       should "update a reversal" do
-        reversal = StripeClient.new.transfers.update_reversal(
+        reversal = StripeClient.new.transfer.update_reversal(
           "tr_123",
           "trr_123",
           metadata: { foo: "bar" }
@@ -76,7 +76,7 @@ module Stripe
 
     context "#list_reversals" do
       should "list the transfer's reversals" do
-        reversals = StripeClient.new.transfers.list_reversals(
+        reversals = StripeClient.new.transfer.list_reversals(
           "tr_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals"

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class TransferTest < Test::Unit::TestCase
     should "be listable" do
-      transfers = Stripe::Transfer.list
+      transfers = StripeClient.new.transfers.list
       assert_requested :get, "#{Stripe.api_base}/v1/transfers"
       assert transfers.data.is_a?(Array)
       assert transfers.data[0].is_a?(Stripe::Transfer)
     end
 
     should "be retrievable" do
-      transfer = Stripe::Transfer.retrieve("tr_123")
+      transfer = StripeClient.new.transfers.retrieve("tr_123")
       assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123"
       assert transfer.is_a?(Stripe::Transfer)
     end
 
     should "be creatable" do
-      transfer = Stripe::Transfer.create(
+      transfer = StripeClient.new.transfers.create(
         amount: 100,
         currency: "USD",
         destination: "acct_123"
@@ -28,21 +28,21 @@ module Stripe
     end
 
     should "be saveable" do
-      transfer = Stripe::Transfer.retrieve("tr_123")
+      transfer = StripeClient.new.transfers.retrieve("tr_123")
       transfer.metadata["key"] = "value"
       transfer.save
       assert_requested :post, "#{Stripe.api_base}/v1/transfers/#{transfer.id}"
     end
 
     should "be updateable" do
-      transfer = Stripe::Transfer.update("tr_123", metadata: { foo: "bar" })
+      transfer = StripeClient.new.transfers.update("tr_123", metadata: { foo: "bar" })
       assert_requested :post, "#{Stripe.api_base}/v1/transfers/tr_123"
       assert transfer.is_a?(Stripe::Transfer)
     end
 
     context "#create_reversal" do
       should "create a reversal" do
-        reversal = Stripe::Transfer.create_reversal(
+        reversal = StripeClient.new.transfers.create_reversal(
           "tr_123",
           amount: 100
         )
@@ -53,7 +53,7 @@ module Stripe
 
     context "#retrieve_reversal" do
       should "retrieve a reversal" do
-        reversal = Stripe::Transfer.retrieve_reversal(
+        reversal = StripeClient.new.transfers.retrieve_reversal(
           "tr_123",
           "trr_123"
         )
@@ -64,7 +64,7 @@ module Stripe
 
     context "#update_reversal" do
       should "update a reversal" do
-        reversal = Stripe::Transfer.update_reversal(
+        reversal = StripeClient.new.transfers.update_reversal(
           "tr_123",
           "trr_123",
           metadata: { foo: "bar" }
@@ -76,7 +76,7 @@ module Stripe
 
     context "#list_reversals" do
       should "list the transfer's reversals" do
-        reversals = Stripe::Transfer.list_reversals(
+        reversals = StripeClient.new.transfers.list_reversals(
           "tr_123"
         )
         assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals"

--- a/test/stripe/usage_record_summary_test.rb
+++ b/test/stripe/usage_record_summary_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class UsageRecordSummaryTest < Test::Unit::TestCase
     setup do
-      @sub_item = StripeClient.new.subscription_items.retrieve("si_123")
+      @sub_item = StripeClient.new.subscription_item.retrieve("si_123")
     end
 
     should "be listable" do

--- a/test/stripe/usage_record_summary_test.rb
+++ b/test/stripe/usage_record_summary_test.rb
@@ -5,7 +5,7 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class UsageRecordSummaryTest < Test::Unit::TestCase
     setup do
-      @sub_item = Stripe::SubscriptionItem.retrieve("si_123")
+      @sub_item = StripeClient.new.subscription_items.retrieve("si_123")
     end
 
     should "be listable" do

--- a/test/stripe/webhook_endpoint_test.rb
+++ b/test/stripe/webhook_endpoint_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class WebhookEndpointTest < Test::Unit::TestCase
     should "be listable" do
-      webhook_endpoints = Stripe::WebhookEndpoint.list
+      webhook_endpoints = StripeClient.new.webhook_endpoints.list
       assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints"
       assert webhook_endpoints.data.is_a?(Array)
       assert webhook_endpoints.first.is_a?(Stripe::WebhookEndpoint)
     end
 
     should "be retrievable" do
-      webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+      webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
       assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
       assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
     end
 
     should "be creatable" do
-      webhook_endpoint = Stripe::WebhookEndpoint.create(
+      webhook_endpoint = StripeClient.new.webhook_endpoints.create(
         enabled_events: ["charge.succeeded"],
         url: "https://stripe.com"
       )
@@ -27,21 +27,21 @@ module Stripe
     end
 
     should "be saveable" do
-      webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+      webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
       webhook_endpoint.enabled_events = ["charge.succeeded"]
       webhook_endpoint.save
       assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
     end
 
     should "be updateable" do
-      webhook_endpoint = Stripe::WebhookEndpoint.update("we_123", enabled_events: ["charge.succeeded"])
+      webhook_endpoint = StripeClient.new.webhook_endpoints.update("we_123", enabled_events: ["charge.succeeded"])
       assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
       assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
     end
 
     context "#delete" do
       should "be deletable" do
-        webhook_endpoint = Stripe::WebhookEndpoint.retrieve("we_123")
+        webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
         webhook_endpoint = webhook_endpoint.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
         assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
@@ -50,7 +50,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        webhook_endpoint = Stripe::WebhookEndpoint.delete("we_123")
+        webhook_endpoint = StripeClient.new.webhook_endpoints.delete("we_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
         assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
       end

--- a/test/stripe/webhook_endpoint_test.rb
+++ b/test/stripe/webhook_endpoint_test.rb
@@ -5,20 +5,20 @@ require ::File.expand_path("../test_helper", __dir__)
 module Stripe
   class WebhookEndpointTest < Test::Unit::TestCase
     should "be listable" do
-      webhook_endpoints = StripeClient.new.webhook_endpoints.list
+      webhook_endpoints = StripeClient.new.webhook_endpoint.list
       assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints"
       assert webhook_endpoints.data.is_a?(Array)
       assert webhook_endpoints.first.is_a?(Stripe::WebhookEndpoint)
     end
 
     should "be retrievable" do
-      webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
+      webhook_endpoint = StripeClient.new.webhook_endpoint.retrieve("we_123")
       assert_requested :get, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
       assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
     end
 
     should "be creatable" do
-      webhook_endpoint = StripeClient.new.webhook_endpoints.create(
+      webhook_endpoint = StripeClient.new.webhook_endpoint.create(
         enabled_events: ["charge.succeeded"],
         url: "https://stripe.com"
       )
@@ -27,21 +27,21 @@ module Stripe
     end
 
     should "be saveable" do
-      webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
+      webhook_endpoint = StripeClient.new.webhook_endpoint.retrieve("we_123")
       webhook_endpoint.enabled_events = ["charge.succeeded"]
       webhook_endpoint.save
       assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
     end
 
     should "be updateable" do
-      webhook_endpoint = StripeClient.new.webhook_endpoints.update("we_123", enabled_events: ["charge.succeeded"])
+      webhook_endpoint = StripeClient.new.webhook_endpoint.update("we_123", enabled_events: ["charge.succeeded"])
       assert_requested :post, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
       assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
     end
 
     context "#delete" do
       should "be deletable" do
-        webhook_endpoint = StripeClient.new.webhook_endpoints.retrieve("we_123")
+        webhook_endpoint = StripeClient.new.webhook_endpoint.retrieve("we_123")
         webhook_endpoint = webhook_endpoint.delete
         assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/#{webhook_endpoint.id}"
         assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
@@ -50,7 +50,7 @@ module Stripe
 
     context ".delete" do
       should "be deletable" do
-        webhook_endpoint = StripeClient.new.webhook_endpoints.delete("we_123")
+        webhook_endpoint = StripeClient.new.webhook_endpoint.delete("we_123")
         assert_requested :delete, "#{Stripe.api_base}/v1/webhook_endpoints/we_123"
         assert webhook_endpoint.is_a?(Stripe::WebhookEndpoint)
       end


### PR DESCRIPTION
This change introduces convenience methods to access API resources
through `StripeClient` for per-client configuration. The instance client
can be configured with the same global Stripe configurations. As a
result, an instance of `StripeClient` is able to override or fallback
to the global configuration that was present at the time of
initialization.

Here's an example:

```ruby
Stripe::Customer.list() == StripeClient.new.customers.list()
```

The primary workhorse for this feature is a new module called
`Stripe::ClientAPIOperations` that defines instance methods on
`StripeClient` when it is included. A `ClientProxy` is used to send any
method calls to an API resource with the instantiated client injected.
There are a few noteworthy aspects of this approach:

- Many resources are namespaced, which introduces a unique challenge
  when it comes to method chaining calls (e.g.
  client.issuing.authorizations).  In order to handle those cases, we
  create a `ClientProxy` object for the root namespace (e.g., "issuing")
  and define all resource methods (e.g. "authorizations") at once to
  avoid re-defining the proxy object when there are multiple resources
  per namespace.

- Sigma deviates from other namespaced API resources and does not have
  an `OBJECT_NAME` separated by a period. We account for that nuance
  directly.

- `method_missing` is substantially slower than direct calls. Therefore,
  methods are defined where possible but `method_missing` is still used
  at the last step when delegating resource methods to the actual
  resource.

- Each API resource is pluralized to align with the conventions of other
  Stripe libraries (e.g. Node and PHP). The pluralization itself is
  quite naive but can easily be switched out for something more advanced
  once the need arises.

- Each API resource spec was converted to use instance based
  methods and was done to ensure adequate test coverage. Since this
  entire feature is built on proxying methods, testing via the client
  implicitly tests the original implementation for "free".

**This is a clean-up of https://github.com/stripe/stripe-ruby/pull/921 as I felt that it didn't have reliable enough test coverage**.