### PR TITLE
Fix return value of `Customer#delete_discount`

### DIFF
--- a/lib/stripe/resources/customer.rb
+++ b/lib/stripe/resources/customer.rb
@@ -28,9 +28,14 @@ module Stripe
       alias detach_source delete_source
     end
 
+    # Deletes a discount associated with the customer.
+    #
+    # Returns the deleted discount. The customer object is not updated,
+    # so you must call `refresh` on it to get a new version with the
+    # discount removed.
     def delete_discount
       resp, opts = execute_resource_request(:delete, resource_url + "/discount")
-      initialize_from(resp.data, opts, true)
+      Util.convert_to_stripe_object(resp.data, opts)
     end
   end
 end

--- a/test/stripe/customer_test.rb
+++ b/test/stripe/customer_test.rb
@@ -56,9 +56,9 @@ module Stripe
     context "#delete_discount" do
       should "delete a discount" do
         customer = Stripe::Customer.retrieve("cus_123")
-        customer = customer.delete_discount
+        discount = customer.delete_discount
         assert_requested :delete, "#{Stripe.api_base}/v1/customers/cus_123/discount"
-        assert customer.is_a?(Stripe::Customer)
+        assert discount.is_a?(Stripe::Discount)
       end
     end
 


### PR DESCRIPTION
`Customer#delete_discount` has been broken for some time in that it
tries to re-initialize `self` (which is a customer) with a received
discount response. This is incorrect and leads to various problems.

Here, we redefine the return value of `delete_discount` as a discount,
and have it no longer mutate the object on which is was called. We add a
comment as well just to help flag some of the behavior which could
potentially be confusing.

Fixes #963.

r? @richardm-stripe

@richardm-stripe @remi-stripe I know there are some concerns around
backwards compatibility here, but given that anyone current trying to
use the return value of this method is pretty broken, and has been for a
while, I was thinking about just releasing it as a patch version. Any
objections?