### PR TITLE
Add Stripe.with_api_key helper to make working with multiple keys easier

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -110,6 +110,19 @@ module Stripe
       version: version,
     }
   end
+
+  # A block helper to temporarily switch api_keys in a thread-safe fashion.
+  def self.with_api_key(api_key)
+    raise ArgumentError, "An api_key is required" unless api_key
+
+    unless block_given?
+      raise ArgumentError, "A block is required when overriding global api_key"
+    end
+
+    StripeClient.current_thread_context.api_key = api_key
+    yield
+    StripeClient.current_thread_context.api_key = nil
+  end
 end
 
 Stripe.log_level = ENV["STRIPE_LOG"] unless ENV["STRIPE_LOG"].nil?

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -120,8 +120,9 @@ module Stripe
     end
 
     StripeClient.current_thread_context.api_key = api_key
-    yield
+    block_value = yield
     StripeClient.current_thread_context.api_key = nil
+    block_value
   end
 end
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -180,6 +180,10 @@ module Stripe
       end
     end
 
+    def api_key
+      self.class.current_thread_context.api_key || Stripe.api_key
+    end
+
     def execute_request(method, path,
                         api_base: nil, api_key: nil, headers: {}, params: {})
       raise ArgumentError, "method should be a symbol" \
@@ -188,7 +192,7 @@ module Stripe
         unless path.is_a?(String)
 
       api_base ||= Stripe.api_base
-      api_key ||= Stripe.api_key
+      api_key ||= self.api_key
       params = Util.objects_to_ids(params)
 
       check_api_key!(api_key)
@@ -345,6 +349,12 @@ module Stripe
       # because that's wrapped in an `ensure` block, they should never leave
       # garbage in `Thread.current`.
       attr_accessor :last_responses
+
+      # A thread-local api_key that is preferentially used over the globally
+      # defined Stripe.api_key.
+      # This is nil by default and is only set temporarily when using the
+      # the `Stripe.with_api_key` block helper.
+      attr_accessor :api_key
     end
 
     # Access data stored for `StripeClient` within the thread's current

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -144,6 +144,14 @@ class StripeTest < Test::Unit::TestCase
       end
     end
 
+    should "return the value of the block" do
+      four = Stripe.with_api_key "sk_some_key" do
+        2 * 2
+      end
+
+      assert_equal four, 4
+    end
+
     should "temporarily override Stripe.api_key and reset it after the block is complete" do
       Stripe.api_key = "sk_global_key"
 


### PR DESCRIPTION
This pull request adds a block helper to temporarily wrap calls to the Stripe API with a thread-local API key.

Our app works with multiple Stripe API keys and we have wrapped our common operations in service objects. We've found that passing API keys all the way down to the calls to this gem can get cumbersome.

Before this addition, we would pass an `api_key` param down 3-4 method calls, but now we can wrap at the most logical level and be sure that any calls in the block will be executed with the specified key.

```ruby
Stripe.api_key = "sk_global_one"

StripeKeys = OpenStruct.new(client1: "sk_client1", client2: "sk_client2")

# Adding a customer outside the helper uses the global key, as usual
our_customer = Stripe::Customer.create(...)

# Updates a customer belonging to Client 1's account
Stripe.with_api_key StripeKeys.client1 do
  customer = Stripe::Customer.retrieve("cus_123abc")
  Stripe::Customer.update("cus_123abc", { ... })
end

# Updates a customer belonging to Client 2's account
Stripe.with_api_key StripeKeys.client2 do
  customer = Stripe::Customer.retrieve("cus_567xyz")
  Stripe::Customer.update("cus_567xyz", { ... })
end
```

This helper has really helped to DRY up the code in some of our service objects that have to make multiple calls to the Stripe API.

Existing functionality hasn't been changed and this should be fully backwards compatible.

I've included tests that cover all the new functionality. 
It was the first time I've written a test to cover thread-safety and that test looks a bit hairy, so let me know if there's a better way to handle that.

Thanks!
