### PR TITLE
CI: github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: rubocop
-      run: rake rubocop
+      run: bundle exec rake rubocop
 
   test:
     runs-on: ubuntu-latest
@@ -32,4 +32,4 @@ jobs:
     - name: Start stripe-mock
       run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
     - name: test
-      run: rake test
+      run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
     - name: rubocop
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Start stripe-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v2
+      uses: actions/setup-ruby
       with:
         ruby-version: 2.7
     - name: rubocop
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v2
+      uses: actions/setup-ruby
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Start stripe-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.2.7.0]
-        ruby-version: [2.3, jruby-9.2.7.0]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.2.16.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.2.16.0]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, jruby-9.2.16.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: rubocop
-      run: bundle exec rake rubocop
+      run: bundle install && bundle exec rake rubocop
 
   test:
     runs-on: ubuntu-latest
@@ -32,4 +32,4 @@ jobs:
     - name: Start stripe-mock
       run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
     - name: test
-      run: bundle exec rake test
+      run: bundle install && bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby
+      uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.7
     - name: rubocop
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby
+      uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Start stripe-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v2
+      with:
+        ruby-version: 2.7
+    - name: rubocop
+      run: rake rubocop
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.2.7.0]
+        ruby-version: [2.3, jruby-9.2.7.0]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v2
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Start stripe-mock
+      run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
+    - name: test
+      run: rake test

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
   gem "rack", ">= 2.0.6"
   gem "rake"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/stripe.svg)](https://badge.fury.io/rb/stripe)
 [![Build Status](https://travis-ci.org/stripe/stripe-ruby.svg?branch=master)](https://travis-ci.org/stripe/stripe-ruby)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
 
 The Stripe Ruby library provides convenient access to the Stripe API from
 applications written in the Ruby language. It includes a pre-defined set of

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "coveralls"
-Coveralls.wear!("test_frameworks")
-
 require "stripe"
 require "test/unit"
 require "mocha/setup"


### PR DESCRIPTION
r? @ob-stripe this is the last library!
- Adds a github actions ci workflow.
  - Removes coveralls.
  - `bundle exec rubocop` runs in Ruby 2.7.
  - `bundle exec test` runs in all supported ruby versions.
    - And a slightly newer version of JRuby than travis runs.