### PR TITLE
Allow StripeClient to be configured per instance

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -62,6 +62,8 @@ module Stripe
   class << self
     extend Forwardable
 
+    attr_reader :configuration
+
     # User configurable options
     def_delegators :@configuration, :api_key, :api_key=
     def_delegators :@configuration, :api_version, :api_version=

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -7,8 +7,8 @@ module Stripe
 
       def self.execute_resource_request(method, url, params, opts)
         opts = Util.normalize_opts(opts)
-        opts[:client] ||= StripeClient.active_client
-        opts[:api_base] ||= Stripe.connect_base
+        opts[:client] ||= opts[:client] || StripeClient.active_client
+        opts[:api_base] ||= opts[:client].config.connect_base
 
         super(method, url, params, opts)
       end
@@ -29,7 +29,8 @@ module Stripe
     end
 
     def self.authorize_url(params = {}, opts = {})
-      base = opts[:connect_base] || Stripe.connect_base
+      client = opts[:client] || StripeClient.active_client
+      base = opts[:connect_base] || client.config.connect_base
 
       path = "/oauth/authorize"
       path = "/express" + path if opts[:express]

--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -45,12 +45,8 @@ module Stripe
     end
 
     # @override To make id optional
-    def self.retrieve(id = ARGUMENT_NOT_PROVIDED, opts = {})
-      id = if id.equal?(ARGUMENT_NOT_PROVIDED)
-             nil
-           else
-             Util.check_string_argument!(id)
-           end
+    def self.retrieve(id = nil, opts = {})
+      Util.check_string_argument!(id) if id
 
       # Account used to be a singleton, where this method's signature was
       # `(opts={})`. For the sake of not breaking folks who pass in an OAuth
@@ -136,10 +132,9 @@ module Stripe
         client_id: client_id,
         stripe_user_id: id,
       }
+      opts = @opts.merge(Util.normalize_opts(opts))
       OAuth.deauthorize(params, opts)
     end
-
-    ARGUMENT_NOT_PROVIDED = Object.new
 
     private def serialize_additional_owners(legal_entity, additional_owners)
       original_value =

--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -25,8 +25,9 @@ module Stripe
         end
       end
 
+      config = opts[:client]&.config || Stripe.configuration
       opts = {
-        api_base: Stripe.uploads_base,
+        api_base: config.uploads_base,
         content_type: MultipartEncoder::MULTIPART_FORM_DATA,
       }.merge(Util.normalize_opts(opts))
       super

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -101,6 +101,14 @@ module Stripe
       @max_network_retries = val.to_i
     end
 
+    def max_network_retry_delay=(val)
+      @max_network_retry_delay = val.to_i
+    end
+
+    def initial_network_retry_delay=(val)
+      @initial_network_retry_delay = val.to_i
+    end
+
     def open_timeout=(open_timeout)
       @open_timeout = open_timeout
       StripeClient.clear_all_connection_managers
@@ -173,6 +181,14 @@ module Stripe
 
     def enable_telemetry?
       enable_telemetry
+    end
+
+    # Generates a deterministic key to identify configuration objects with
+    # identical configuration values.
+    def key
+      instance_variables
+        .collect { |variable| instance_variable_get(variable) }
+        .join
     end
   end
 end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -76,24 +76,30 @@ module Stripe
     end
 
     def self.log_error(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_ERROR
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_ERROR
         log_internal(message, data, color: :cyan, level: Stripe::LEVEL_ERROR,
                                     logger: Stripe.logger, out: $stderr)
       end
     end
 
     def self.log_info(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_INFO
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_INFO
         log_internal(message, data, color: :cyan, level: Stripe::LEVEL_INFO,
                                     logger: Stripe.logger, out: $stdout)
       end
     end
 
     def self.log_debug(message, data = {})
-      if !Stripe.logger.nil? ||
-         !Stripe.log_level.nil? && Stripe.log_level <= Stripe::LEVEL_DEBUG
+      config = data.delete(:config) || Stripe.configuration
+      logger = config.logger || Stripe.logger
+      if !logger.nil? ||
+         !config.log_level.nil? && config.log_level <= Stripe::LEVEL_DEBUG
         log_internal(message, data, color: :blue, level: Stripe::LEVEL_DEBUG,
                                     logger: Stripe.logger, out: $stdout)
       end

--- a/test/stripe/oauth_test.rb
+++ b/test/stripe/oauth_test.rb
@@ -44,6 +44,14 @@ module Stripe
         assert_equal("connect.stripe.com", uri.host)
         assert_equal("/express/oauth/authorize", uri.path)
       end
+
+      should "override the api base path when a StripeClient is provided" do
+        client = Stripe::StripeClient.new(connect_base: "https://other.stripe.com")
+        uri_str = OAuth.authorize_url({}, client: client)
+
+        uri = URI.parse(uri_str)
+        assert_equal("other.stripe.com", uri.host)
+      end
     end
 
     context ".token" do
@@ -83,6 +91,29 @@ module Stripe
                            code: "this_is_an_authorization_code")
         assert_equal("another_access_token", resp.access_token)
       end
+
+      should "override the api base path when a StripeClient is provided" do
+        stub_request(:post, "https://other.stripe.com/oauth/token")
+          .with(body: {
+            "grant_type" => "authorization_code",
+            "code" => "this_is_an_authorization_code",
+          })
+          .to_return(body: JSON.generate(access_token: "sk_access_token",
+                                         scope: "read_only",
+                                         livemode: false,
+                                         token_type: "bearer",
+                                         refresh_token: "sk_refresh_token",
+                                         stripe_user_id: "acct_test",
+                                         stripe_publishable_key: "pk_test"))
+
+        client = Stripe::StripeClient.new(connect_base: "https://other.stripe.com")
+        resp = OAuth.token(
+          { grant_type: "authorization_code", code: "this_is_an_authorization_code" },
+          client: client
+        )
+
+        assert_equal("sk_access_token", resp.access_token)
+      end
     end
 
     context ".deauthorize" do
@@ -97,6 +128,20 @@ module Stripe
           .to_return(body: JSON.generate(stripe_user_id: "acct_test_deauth"))
 
         resp = OAuth.deauthorize(stripe_user_id: "acct_test_deauth")
+        assert_equal("acct_test_deauth", resp.stripe_user_id)
+      end
+
+      should "override the api base path when a StripeClient is provided" do
+        stub_request(:post, "https://other.stripe.com/oauth/deauthorize")
+          .with(body: {
+            "client_id" => "ca_test",
+            "stripe_user_id" => "acct_test_deauth",
+          })
+          .to_return(body: JSON.generate(stripe_user_id: "acct_test_deauth"))
+
+        client = Stripe::StripeClient.new(connect_base: "https://other.stripe.com")
+        resp = OAuth.deauthorize({ stripe_user_id: "acct_test_deauth" }, client: client)
+
         assert_equal("acct_test_deauth", resp.stripe_user_id)
       end
     end

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -20,6 +20,7 @@ module Stripe
         assert_equal "https://api.stripe.com", config.api_base
         assert_equal "https://connect.stripe.com", config.connect_base
         assert_equal "https://files.stripe.com", config.uploads_base
+        assert_equal nil, config.api_version
       end
 
       should "allow for overrides when a block is passed" do
@@ -41,7 +42,7 @@ module Stripe
           c.open_timeout = 100
         end
 
-        duped_config = config.reverse_duplicate_merge(read_timeout: 500)
+        duped_config = config.reverse_duplicate_merge(read_timeout: 500, api_version: "2018-08-02")
 
         assert_equal config.open_timeout, duped_config.open_timeout
         assert_equal 500, duped_config.read_timeout
@@ -54,6 +55,24 @@ module Stripe
 
         config.max_network_retries = "10"
         assert_equal 10, config.max_network_retries
+      end
+    end
+
+    context "#max_network_retry_delay=" do
+      should "coerce the option into an integer" do
+        config = Stripe::StripeConfiguration.setup
+
+        config.max_network_retry_delay = "10"
+        assert_equal 10, config.max_network_retry_delay
+      end
+    end
+
+    context "#initial_network_retry_delay=" do
+      should "coerce the option into an integer" do
+        config = Stripe::StripeConfiguration.setup
+
+        config.initial_network_retry_delay = "10"
+        assert_equal 10, config.initial_network_retry_delay
       end
     end
 
@@ -125,6 +144,15 @@ module Stripe
 
         StripeClient.expects(:clear_all_connection_managers)
         config.verify_ssl_certs = false
+      end
+    end
+
+    context "#key" do
+      should "generate the same key when values are identicial" do
+        assert_equal StripeConfiguration.setup.key, StripeConfiguration.setup.key
+
+        custom_config = StripeConfiguration.setup { |c| c.open_timeout = 1000 }
+        refute_equal StripeConfiguration.setup.key, custom_config.key
       end
     end
   end

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -114,6 +114,11 @@ class StripeTest < Test::Unit::TestCase
       assert_equal "https://other.stripe.com", Stripe.api_base
     end
 
+    should "allow api_version to be configured" do
+      Stripe.api_version = "2018-02-28"
+      assert_equal "2018-02-28", Stripe.api_version
+    end
+
     should "allow connect_base to be configured" do
       Stripe.connect_base = "https://other.stripe.com"
       assert_equal "https://other.stripe.com", Stripe.connect_base


### PR DESCRIPTION
This changes allows for each instance of `StripeClient` to have its own
configuration object instead of relying on the global config. Each
instance can be configured to override any global config values
previously set.