### PR TITLE
On config change, only clear connection managers for changed config

### DIFF
--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -111,12 +111,12 @@ module Stripe
 
     def open_timeout=(open_timeout)
       @open_timeout = open_timeout
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def read_timeout=(read_timeout)
       @read_timeout = read_timeout
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def write_timeout=(write_timeout)
@@ -125,32 +125,32 @@ module Stripe
       end
 
       @write_timeout = write_timeout
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def proxy=(proxy)
       @proxy = proxy
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def verify_ssl_certs=(verify_ssl_certs)
       @verify_ssl_certs = verify_ssl_certs
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def uploads_base=(uploads_base)
       @uploads_base = uploads_base
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def connect_base=(connect_base)
       @connect_base = connect_base
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def api_base=(api_base)
       @api_base = api_base
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     def ca_bundle_path=(path)
@@ -159,7 +159,7 @@ module Stripe
       # empty this field so a new store is initialized
       @ca_store = nil
 
-      StripeClient.clear_all_connection_managers
+      StripeClient.clear_all_connection_managers(config: self)
     end
 
     # A certificate store initialized from the the bundle in #ca_bundle_path and

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -100,49 +100,49 @@ module Stripe
       should "clear when setting allow ca_bundle_path" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.ca_bundle_path = "/path/to/ca/bundle"
       end
 
       should "clear when setting open timeout" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.open_timeout = 10
       end
 
       should "clear when setting read timeout" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.read_timeout = 10
       end
 
       should "clear when setting uploads_base" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.uploads_base = "https://other.stripe.com"
       end
 
-      should "clearn when setting api_base to be configured" do
+      should "clear when setting api_base to be configured" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.api_base = "https://other.stripe.com"
       end
 
       should "clear when setting connect_base" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.connect_base = "https://other.stripe.com"
       end
 
       should "clear when setting verify_ssl_certs" do
         config = Stripe::StripeConfiguration.setup
 
-        StripeClient.expects(:clear_all_connection_managers)
+        StripeClient.expects(:clear_all_connection_managers).with(config: config)
         config.verify_ssl_certs = false
       end
     end


### PR DESCRIPTION
Follows up #968.

As a relic from when we had global configuration, anytime any config value is changed on any client, we still clear all connection managers everywhere on every thread, even though this is not necessary. This means that we lose all open connections, etc.

Here, we make changes so that if a configuration is changed, we only clear the configuration managers pertaining to that one particular configuration, thus conserving resources globally.

@joeltaylor We've foisted enough work on you already, but if you'd like, feel free to take a look at this change set to make sure it's in-line with your implementation's principles.