### PR TITLE
Rename `Stripe.configuration` to `Stripe.config`

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -57,36 +57,36 @@ module Stripe
 
   @app_info = nil
 
-  @configuration = Stripe::StripeConfiguration.setup
+  @config = Stripe::StripeConfiguration.setup
 
   class << self
     extend Forwardable
 
-    attr_reader :configuration
+    attr_reader :config
 
     # User configurable options
-    def_delegators :@configuration, :api_key, :api_key=
-    def_delegators :@configuration, :api_version, :api_version=
-    def_delegators :@configuration, :stripe_account, :stripe_account=
-    def_delegators :@configuration, :api_base, :api_base=
-    def_delegators :@configuration, :uploads_base, :uploads_base=
-    def_delegators :@configuration, :connect_base, :connect_base=
-    def_delegators :@configuration, :open_timeout, :open_timeout=
-    def_delegators :@configuration, :read_timeout, :read_timeout=
-    def_delegators :@configuration, :write_timeout, :write_timeout=
-    def_delegators :@configuration, :proxy, :proxy=
-    def_delegators :@configuration, :verify_ssl_certs, :verify_ssl_certs=
-    def_delegators :@configuration, :ca_bundle_path, :ca_bundle_path=
-    def_delegators :@configuration, :log_level, :log_level=
-    def_delegators :@configuration, :logger, :logger=
-    def_delegators :@configuration, :max_network_retries, :max_network_retries=
-    def_delegators :@configuration, :enable_telemetry=, :enable_telemetry?
-    def_delegators :@configuration, :client_id=, :client_id
+    def_delegators :@config, :api_key, :api_key=
+    def_delegators :@config, :api_version, :api_version=
+    def_delegators :@config, :stripe_account, :stripe_account=
+    def_delegators :@config, :api_base, :api_base=
+    def_delegators :@config, :uploads_base, :uploads_base=
+    def_delegators :@config, :connect_base, :connect_base=
+    def_delegators :@config, :open_timeout, :open_timeout=
+    def_delegators :@config, :read_timeout, :read_timeout=
+    def_delegators :@config, :write_timeout, :write_timeout=
+    def_delegators :@config, :proxy, :proxy=
+    def_delegators :@config, :verify_ssl_certs, :verify_ssl_certs=
+    def_delegators :@config, :ca_bundle_path, :ca_bundle_path=
+    def_delegators :@config, :log_level, :log_level=
+    def_delegators :@config, :logger, :logger=
+    def_delegators :@config, :max_network_retries, :max_network_retries=
+    def_delegators :@config, :enable_telemetry=, :enable_telemetry?
+    def_delegators :@config, :client_id=, :client_id
 
     # Internal configurations
-    def_delegators :@configuration, :max_network_retry_delay
-    def_delegators :@configuration, :initial_network_retry_delay
-    def_delegators :@configuration, :ca_store
+    def_delegators :@config, :max_network_retry_delay
+    def_delegators :@config, :initial_network_retry_delay
+    def_delegators :@config, :ca_store
   end
 
   # Gets the application for a plugin that's identified some. See

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -17,7 +17,7 @@ module Stripe
     attr_reader :last_used
     attr_reader :config
 
-    def initialize(config = Stripe.configuration)
+    def initialize(config = Stripe.config)
       @config = config
       @active_connections = {}
       @last_used = Util.monotonic_time

--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -25,7 +25,7 @@ module Stripe
         end
       end
 
-      config = opts[:client]&.config || Stripe.configuration
+      config = opts[:client]&.config || Stripe.config
       opts = {
         api_base: config.uploads_base,
         content_type: MultipartEncoder::MULTIPART_FORM_DATA,

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -20,15 +20,15 @@ module Stripe
 
       @config = case config_arg
                 when Hash
-                  Stripe.configuration.reverse_duplicate_merge(config_arg)
+                  Stripe.config.reverse_duplicate_merge(config_arg)
                 when Stripe::ConnectionManager
                   # Supports accepting a connection manager object for backwards
                   # compatibility only, and that use is DEPRECATED.
-                  Stripe.configuration.dup
+                  Stripe.config.dup
                 when Stripe::StripeConfiguration
                   config_arg
                 when String
-                  Stripe.configuration.reverse_duplicate_merge(
+                  Stripe.config.reverse_duplicate_merge(
                     { api_key: config_arg }
                   )
                 else
@@ -91,13 +91,12 @@ module Stripe
 
     # A default client for the current thread.
     def self.default_client
-      current_thread_context.default_client ||=
-        StripeClient.new(Stripe.configuration)
+      current_thread_context.default_client ||= StripeClient.new(Stripe.config)
     end
 
     # A default connection manager for the current thread scoped to the
     # configuration object that may be provided.
-    def self.default_connection_manager(config = Stripe.configuration)
+    def self.default_connection_manager(config = Stripe.config)
       current_thread_context.default_connection_managers[config.key] ||= begin
         connection_manager = ConnectionManager.new(config)
 
@@ -114,7 +113,7 @@ module Stripe
     # both socket errors that may represent an intermittent problem and some
     # special HTTP statuses.
     def self.should_retry?(error,
-                           method:, num_retries:, config: Stripe.configuration)
+                           method:, num_retries:, config: Stripe.config)
       return false if num_retries >= config.max_network_retries
 
       case error
@@ -161,7 +160,7 @@ module Stripe
       end
     end
 
-    def self.sleep_time(num_retries, config: Stripe.configuration)
+    def self.sleep_time(num_retries, config: Stripe.config)
       # Apply exponential backoff with initial_network_retry_delay on the
       # number of num_retries so far as inputs. Do not allow the number to
       # exceed max_network_retry_delay.

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -76,7 +76,7 @@ module Stripe
     end
 
     def self.log_error(message, data = {})
-      config = data.delete(:config) || Stripe.configuration
+      config = data.delete(:config) || Stripe.config
       logger = config.logger || Stripe.logger
       if !logger.nil? ||
          !config.log_level.nil? && config.log_level <= Stripe::LEVEL_ERROR
@@ -86,7 +86,7 @@ module Stripe
     end
 
     def self.log_info(message, data = {})
-      config = data.delete(:config) || Stripe.configuration
+      config = data.delete(:config) || Stripe.config
       logger = config.logger || Stripe.logger
       if !logger.nil? ||
          !config.log_level.nil? && config.log_level <= Stripe::LEVEL_INFO
@@ -96,7 +96,7 @@ module Stripe
     end
 
     def self.log_debug(message, data = {})
-      config = data.delete(:config) || Stripe.configuration
+      config = data.delete(:config) || Stripe.config
       logger = config.logger || Stripe.logger
       if !logger.nil? ||
          !config.log_level.nil? && config.log_level <= Stripe::LEVEL_DEBUG

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -22,7 +22,7 @@ module Stripe
       end
 
       should "support passing a full configuration object" do
-        config = Stripe.configuration.reverse_duplicate_merge({ api_key: "test_123", open_timeout: 100 })
+        config = Stripe.config.reverse_duplicate_merge({ api_key: "test_123", open_timeout: 100 })
         client = StripeClient.new(config)
         assert_equal config, client.config
       end
@@ -393,7 +393,7 @@ module Stripe
     context ".sleep_time" do
       should "should grow exponentially" do
         StripeClient.stubs(:rand).returns(1)
-        Stripe.configuration.stubs(:max_network_retry_delay).returns(999)
+        Stripe.config.stubs(:max_network_retry_delay).returns(999)
         assert_equal(Stripe.initial_network_retry_delay, StripeClient.sleep_time(1))
         assert_equal(Stripe.initial_network_retry_delay * 2, StripeClient.sleep_time(2))
         assert_equal(Stripe.initial_network_retry_delay * 4, StripeClient.sleep_time(3))
@@ -402,8 +402,8 @@ module Stripe
 
       should "enforce the max_network_retry_delay" do
         StripeClient.stubs(:rand).returns(1)
-        Stripe.configuration.stubs(:initial_network_retry_delay).returns(1)
-        Stripe.configuration.stubs(:max_network_retry_delay).returns(2)
+        Stripe.config.stubs(:initial_network_retry_delay).returns(1)
+        Stripe.config.stubs(:max_network_retry_delay).returns(2)
         assert_equal(1, StripeClient.sleep_time(1))
         assert_equal(2, StripeClient.sleep_time(2))
         assert_equal(2, StripeClient.sleep_time(3))
@@ -413,8 +413,8 @@ module Stripe
       should "add some randomness" do
         random_value = 0.8
         StripeClient.stubs(:rand).returns(random_value)
-        Stripe.configuration.stubs(:initial_network_retry_delay).returns(1)
-        Stripe.configuration.stubs(:max_network_retry_delay).returns(8)
+        Stripe.config.stubs(:initial_network_retry_delay).returns(1)
+        Stripe.config.stubs(:max_network_retry_delay).returns(8)
 
         base_value = Stripe.initial_network_retry_delay * (0.5 * (1 + random_value))
 
@@ -436,8 +436,8 @@ module Stripe
         end
 
         # Set the global configuration to be different than the client
-        Stripe.configuration.stubs(:initial_network_retry_delay).returns(100)
-        Stripe.configuration.stubs(:max_network_retry_delay).returns(200)
+        Stripe.config.stubs(:initial_network_retry_delay).returns(100)
+        Stripe.config.stubs(:max_network_retry_delay).returns(200)
 
         assert_equal(1, StripeClient.sleep_time(1, config: config))
         assert_equal(2, StripeClient.sleep_time(2, config: config))
@@ -478,9 +478,9 @@ module Stripe
           # this.
           Util.stubs(:monotonic_time).returns(0.0)
 
-          # Stub the Stripe configuration so that mocha matchers will succeed. Currently,
+          # Stub the Stripe.config so that mocha matchers will succeed. Currently,
           # mocha does not support using param matchers within hashes.
-          StripeClient.any_instance.stubs(:config).returns(Stripe.configuration)
+          StripeClient.any_instance.stubs(:config).returns(Stripe.config)
         end
 
         should "produce appropriate logging" do
@@ -493,12 +493,12 @@ module Stripe
                                        method: :post,
                                        num_retries: 0,
                                        path: "/v1/account",
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
           Util.expects(:log_debug).with("Request details",
                                         body: "",
                                         idempotency_key: "abc",
                                         query: nil,
-                                        config: Stripe.configuration)
+                                        config: Stripe.config)
 
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: "acct_123",
@@ -509,17 +509,17 @@ module Stripe
                                        path: "/v1/account",
                                        request_id: "req_123",
                                        status: 200,
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
           Util.expects(:log_debug).with("Response details",
                                         body: body,
                                         idempotency_key: "abc",
                                         request_id: "req_123",
-                                        config: Stripe.configuration)
+                                        config: Stripe.config)
           Util.expects(:log_debug).with("Dashboard link for request",
                                         idempotency_key: "abc",
                                         request_id: "req_123",
                                         url: Util.request_id_dashboard_url("req_123", Stripe.api_key),
-                                        config: Stripe.configuration)
+                                        config: Stripe.config)
 
           stub_request(:post, "#{Stripe.api_base}/v1/account")
             .to_return(
@@ -549,7 +549,7 @@ module Stripe
                                        method: :post,
                                        num_retries: 0,
                                        path: "/v1/account",
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: nil,
                                        api_version: nil,
@@ -559,7 +559,7 @@ module Stripe
                                        path: "/v1/account",
                                        request_id: nil,
                                        status: 500,
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
 
           error = {
             code: "code",
@@ -575,7 +575,7 @@ module Stripe
                                         error_type: error[:type],
                                         idempotency_key: nil,
                                         request_id: nil,
-                                        config: Stripe.configuration)
+                                        config: Stripe.config)
 
           stub_request(:post, "#{Stripe.api_base}/v1/account")
             .to_return(
@@ -597,7 +597,7 @@ module Stripe
                                        method: :post,
                                        num_retries: 0,
                                        path: "/oauth/token",
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
           Util.expects(:log_info).with("Response from Stripe API",
                                        account: nil,
                                        api_version: nil,
@@ -607,7 +607,7 @@ module Stripe
                                        path: "/oauth/token",
                                        request_id: nil,
                                        status: 400,
-                                       config: Stripe.configuration)
+                                       config: Stripe.config)
 
           Util.expects(:log_error).with("Stripe OAuth error",
                                         status: 400,
@@ -615,7 +615,7 @@ module Stripe
                                         error_description: "No grant type specified",
                                         idempotency_key: nil,
                                         request_id: nil,
-                                        config: Stripe.configuration)
+                                        config: Stripe.config)
 
           stub_request(:post, "#{Stripe.connect_base}/oauth/token")
             .to_return(body: JSON.generate(error: "invalid_request",


### PR DESCRIPTION
This is just a cosmetic change that renames `Stripe.configuration` to
just `Stripe.config`. We use the shorter "config" in most other places
including `StripeClient#config`, so I feel that this is overall more
consistent.

This change is backwards compatible because the new accessor came in
with #968, and that hasn't been given a formal release yet.

I've left the class name as `StripeConfiguration` which IMO is fine. The
class uses the expanded form of the name while vars and accessors use
the shorter `config`. Also, `StripeConfiguration` has been around a
little bit longer, so renaming it is somewhat backwards incompatible
too.

r? @richardm-stripe This one's pretty tiny. Mind taking a look?