### PR TITLE
Update PaymentIntents API to match real world specs

### DIFF
--- a/lib/stripe/resources/payment_intent.rb
+++ b/lib/stripe/resources/payment_intent.rb
@@ -13,7 +13,7 @@ module Stripe
     custom_method :capture, http_verb: :post
     custom_method :confirm, http_verb: :post
 
-    def cancel(params = {}, opts = {})
+    def cancel(id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/cancel",
@@ -22,7 +22,7 @@ module Stripe
       )
     end
 
-    def capture(params = {}, opts = {})
+    def capture(id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/capture",
@@ -31,7 +31,7 @@ module Stripe
       )
     end
 
-    def confirm(params = {}, opts = {})
+    def confirm(id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/confirm",

--- a/lib/stripe/resources/payment_intent.rb
+++ b/lib/stripe/resources/payment_intent.rb
@@ -13,7 +13,7 @@ module Stripe
     custom_method :capture, http_verb: :post
     custom_method :confirm, http_verb: :post
 
-    def cancel(id, params = {}, opts = {})
+    def cancel(_id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/cancel",
@@ -22,7 +22,7 @@ module Stripe
       )
     end
 
-    def capture(id, params = {}, opts = {})
+    def capture(_id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/capture",
@@ -31,7 +31,7 @@ module Stripe
       )
     end
 
-    def confirm(id, params = {}, opts = {})
+    def confirm(_id, params = {}, opts = {})
       request_stripe_object(
         method: :post,
         path: resource_url + "/confirm",


### PR DESCRIPTION
All three methods `cancel`, `capture` and `confirm` were missing the
`id` parameter in the specs. 

This can be seen in here https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/api_resource.rb#L72
where the real method definition occurs.

Since this is updating the OpenAPI spec maybe the OpenAPI definition requires
updating as well? I'm happy to update those as well if I get pointed to where they exist.