### PR TITLE
Update normalize_opts to use dup instead of clone.

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -208,7 +208,9 @@ module Stripe
         { api_key: opts }
       when Hash
         check_api_key!(opts.fetch(:api_key)) if opts.key?(:api_key)
-        opts.clone
+        # Explicitly use dup here instead of clone to avoid preserving freeze
+        # state on input params.
+        opts.dup
       else
         raise TypeError, "normalize_opts expects a string or a hash"
       end

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -23,6 +23,14 @@ module Stripe
         assert_equal("bar", resource.foo)
       end
 
+      should "handle a frozen set of opts" do
+        stub_request(:post, "#{Stripe.api_base}/v1/updateableresources/id")
+          .with(body: { foo: "bar" })
+          .to_return(body: JSON.generate(foo: "bar"))
+        resource = UpdateableResource.update("id", { foo: "bar" }, {}.freeze)
+        assert_equal("bar", resource.foo)
+      end
+
       should "error on protected fields" do
         e = assert_raises do
           UpdateableResource.update("id", protected: "bar")


### PR DESCRIPTION
# Notify

r? @richardm-stripe 

# Summary

Updates `normalize_opts` to use `dup` instead of `clone` when copying the user-provided `opts`. This does not copy over the freeze state and avoids issues where internal classes (eg. `execute_request_internal`) receive frozen opts, normalize them, and then try to mutate them

# Motivation

Fixes https://github.com/stripe/stripe-ruby/issues/984

# Test Plan

Added unit test to cover this case for regressions.