### PR TITLE
Add `request_id` to RequestEndEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ a success or error. Receives `RequestEndEvent` with the following properties:
 - `path`: Request path. (`String`)
 - `user_data`: A hash on which users may have set arbitrary data in
   `request_begin`. See above for more information. (`Hash`)
+- `request_id`. HTTP request identifier.
 
 #### Example
 

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -32,6 +32,7 @@ module Stripe
       attr_reader :method
       attr_reader :num_retries
       attr_reader :path
+      attr_reader :request_id
 
       # Arbitrary user-provided data in the form of a Ruby hash that's passed
       # from subscribers on `request_begin` to subscribers on `request_end`.
@@ -40,12 +41,13 @@ module Stripe
       attr_reader :user_data
 
       def initialize(duration:, http_status:, method:, num_retries:, path:,
-                     user_data: nil)
+                     request_id:, user_data: nil)
         @duration = duration
         @http_status = http_status
         @method = method
         @num_retries = num_retries
         @path = path
+        @request_id = request_id
         @user_data = user_data
         freeze
       end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -667,6 +667,7 @@ module Stripe
         method: context.method,
         num_retries: num_retries,
         path: context.path,
+        request_id: context.request_id,
         user_data: user_data || {}
       )
       Stripe::Instrumentation.notify(:request_end, event)

--- a/test/stripe/instrumentation_test.rb
+++ b/test/stripe/instrumentation_test.rb
@@ -64,7 +64,7 @@ module Stripe
           method: :get,
           num_retries: 0,
           path: "/v1/test",
-          request_id: 'req_123',
+          request_id: "req_123",
           user_data: nil
         )
 

--- a/test/stripe/instrumentation_test.rb
+++ b/test/stripe/instrumentation_test.rb
@@ -64,6 +64,7 @@ module Stripe
           method: :get,
           num_retries: 0,
           path: "/v1/test",
+          request_id: 'req_123',
           user_data: nil
         )
 

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1418,7 +1418,7 @@ module Stripe
         assert_equal(200, event.http_status)
         assert(event.duration.positive?)
         assert_equal(0, event.num_retries)
-        assert_equal('req_123', event.request_id)
+        assert_equal("req_123", event.request_id)
       end
 
       should "notify a subscriber of a StripeError" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1408,7 +1408,7 @@ module Stripe
         Stripe::Instrumentation.subscribe(:request_end, :test) { |event| events << event }
 
         stub_request(:get, "#{Stripe.api_base}/v1/charges")
-          .to_return(body: JSON.generate(object: "charge"))
+          .to_return(body: JSON.generate(object: "charge"), headers: { "Request-ID": "req_123" })
         Stripe::Charge.list
 
         assert_equal(1, events.size)
@@ -1418,6 +1418,7 @@ module Stripe
         assert_equal(200, event.http_status)
         assert(event.duration.positive?)
         assert_equal(0, event.num_retries)
+        assert_equal('req_123', event.request_id)
       end
 
       should "notify a subscriber of a StripeError" do


### PR DESCRIPTION
We'd like to trace back a request back to a particular request_id. To do this we'll need to pass the `request_id` to RequestEndEvent.

### Example:

```#<Stripe::Instrumentation::RequestEndEvent:0x00007f8c3d231218
 @duration=0.02757700002985075,
 @http_status=200,
 @method=:get,
 @num_retries=0,
 @path="/v1/charges/ch_sp_sale_charge",
 @request_id='req_123',
 @user_data={}>
```

### Questions

Will the `request_id` always be available? What about scenarios where a request fails? 