### PR TITLE
Update until.rb to fix an issue with a gsub method

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -142,7 +142,7 @@ module Stripe
         # Don't use strict form encoding by changing the square bracket control
         # characters back to their literals. This is fine by the server, and
         # makes these parameter strings easier to read.
-        gsub("%5B", "[").gsub("%5D", "]")
+        gsub("[", "%5B").gsub("]", "%5D")
     end
 
     def self.flatten_params(params, parent_key = nil)


### PR DESCRIPTION
I see that the gsub method wrote with wrong arguments. The first argument is what we want to change and the second is what we set.