### PR TITLE
Add connection manager logging and include object IDs in logging.

### DIFF
--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -109,7 +109,8 @@ module Stripe
                      process_id: Process.pid,
                      thread_object_id: Thread.current.object_id,
                      connection_manager_object_id: object_id,
-                     connection_object_id: connection.object_id)
+                     connection_object_id: connection.object_id,
+                     log_timestamp: Util.monotonic_time)
 
       resp = @mutex.synchronize do
         # The block parameter is special here. If a block is provided, the block
@@ -126,7 +127,8 @@ module Stripe
                      thread_object_id: Thread.current.object_id,
                      connection_manager_object_id: object_id,
                      connection_object_id: connection.object_id,
-                     response_object_id: resp.object_id)
+                     response_object_id: resp.object_id,
+                     log_timestamp: Util.monotonic_time)
 
       resp
     end

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -106,6 +106,7 @@ module Stripe
       Util.log_debug("ConnectionManager starting request",
                      method_name: method_name,
                      path: path,
+                     process_id: Process.pid,
                      thread_object_id: Thread.current.object_id,
                      connection_manager_object_id: object_id,
                      connection_object_id: connection.object_id)
@@ -121,6 +122,7 @@ module Stripe
       Util.log_debug("ConnectionManager request complete",
                      method_name: method_name,
                      path: path,
+                     process_id: Process.pid,
                      thread_object_id: Thread.current.object_id,
                      connection_manager_object_id: object_id,
                      connection_object_id: connection.object_id,

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -103,13 +103,30 @@ module Stripe
         headers
       )
 
-      @mutex.synchronize do
+      Util.log_debug("ConnectionManager starting request",
+                     method_name: method_name,
+                     path: path,
+                     thread_object_id: Thread.current.object_id,
+                     connection_manager_object_id: object_id,
+                     connection_object_id: connection.object_id)
+
+      resp = @mutex.synchronize do
         # The block parameter is special here. If a block is provided, the block
         # is invoked with the Net::HTTPResponse. However, the body will not have
         # been read yet in the block, and can be streamed by calling
         # HTTPResponse#read_body.
         connection.request(request, body, &block)
       end
+
+      Util.log_debug("ConnectionManager request complete",
+                     method_name: method_name,
+                     path: path,
+                     thread_object_id: Thread.current.object_id,
+                     connection_manager_object_id: object_id,
+                     connection_object_id: connection.object_id,
+                     response_object_id: resp.object_id)
+
+      resp
     end
 
     #

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -585,7 +585,7 @@ module Stripe
           handle_error_response(resp, context)
         end
 
-        log_response(context, request_start, http_status, resp.body)
+        log_response(context, request_start, http_status, resp.body, resp)
         notify_request_end(context, request_duration, http_status,
                            num_retries, user_data)
 
@@ -609,7 +609,7 @@ module Stripe
           error_context = context.dup_from_response_headers(e.http_headers)
           http_status = resp.code.to_i
           log_response(error_context, request_start,
-                       e.http_status, e.http_body)
+                       e.http_status, e.http_body, resp)
         else
           log_response_error(error_context, request_start, e)
         end
@@ -903,10 +903,11 @@ module Stripe
                      body: context.body,
                      idempotency_key: context.idempotency_key,
                      query: context.query,
-                     config: config)
+                     config: config,
+                     thread_object_id: Thread.current.object_id)
     end
 
-    private def log_response(context, request_start, status, body)
+    private def log_response(context, request_start, status, body, resp)
       Util.log_info("Response from Stripe API",
                     account: context.account,
                     api_version: context.api_version,
@@ -921,7 +922,9 @@ module Stripe
                      body: body,
                      idempotency_key: context.idempotency_key,
                      request_id: context.request_id,
-                     config: config)
+                     config: config,
+                     thread_object_id: Thread.current.object_id,
+                     response_object_id: resp.object_id)
 
       return unless context.request_id
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -905,7 +905,8 @@ module Stripe
                      query: context.query,
                      config: config,
                      process_id: Process.pid,
-                     thread_object_id: Thread.current.object_id)
+                     thread_object_id: Thread.current.object_id,
+                     log_timestamp: Util.monotonic_time)
     end
 
     private def log_response(context, request_start, status, body, resp)
@@ -926,7 +927,8 @@ module Stripe
                      config: config,
                      process_id: Process.pid,
                      thread_object_id: Thread.current.object_id,
-                     response_object_id: resp.object_id)
+                     response_object_id: resp.object_id,
+                     log_timestamp: Util.monotonic_time)
 
       return unless context.request_id
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -904,6 +904,7 @@ module Stripe
                      idempotency_key: context.idempotency_key,
                      query: context.query,
                      config: config,
+                     process_id: Process.pid,
                      thread_object_id: Thread.current.object_id)
     end
 
@@ -923,6 +924,7 @@ module Stripe
                      idempotency_key: context.idempotency_key,
                      request_id: context.request_id,
                      config: config,
+                     process_id: Process.pid,
                      thread_object_id: Thread.current.object_id,
                      response_object_id: resp.object_id)
 

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -495,6 +495,32 @@ module Stripe
           should "produce appropriate logging" do
             body = JSON.generate(object: "account")
 
+            connection_manager_data = nil
+
+            Util.expects(:log_debug).with do |message, data|
+              connection_manager_data = data
+              message == "ConnectionManager starting request" &&
+                data[:path] == "/v1/account" &&
+                data[:method_name] == "POST" &&
+                data[:thread_object_id] == Thread.current.object_id &&
+                (data[:connection_manager_object_id].is_a? Numeric) &&
+                (data[:connection_object_id].is_a? Numeric)
+            end
+
+            response_object_id = nil
+
+            Util.expects(:log_debug).with do |message, data|
+              if message == "ConnectionManager request complete" &&
+                 data[:path] == "/v1/account" &&
+                 data[:method_name] == "POST" &&
+                 data[:thread_object_id] == connection_manager_data[:thread_object_id] &&
+                 data[:connection_manager_object_id] == connection_manager_data[:connection_manager_object_id] &&
+                 data[:connection_object_id] == connection_manager_data[:connection_object_id] &&
+                 (data[:response_object_id].is_a? Numeric)
+                response_object_id = data[:response_object_id]
+              end
+            end
+
             Util.expects(:log_info).with("Request to Stripe API",
                                          account: "acct_123",
                                          api_version: "2010-11-12",
@@ -507,7 +533,8 @@ module Stripe
                                           body: "",
                                           idempotency_key: "abc",
                                           query: nil,
-                                          config: Stripe.config)
+                                          config: Stripe.config,
+                                          thread_object_id: Thread.current.object_id)
 
             Util.expects(:log_info).with("Response from Stripe API",
                                          account: "acct_123",
@@ -523,7 +550,8 @@ module Stripe
               if message == "Response details" &&
                  data[:idempotency_key] == "abc" &&
                  data[:request_id] == "req_123" &&
-                 data[:config] == Stripe.config
+                 data[:config] == Stripe.config &&
+                 data[:response_object_id] == response_object_id
                 # Streaming requests have a different body.
                 if request_method == "execute_request_stream"
                   data[:body].is_a? Net::ReadAdapter

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -502,6 +502,7 @@ module Stripe
               message == "ConnectionManager starting request" &&
                 data[:path] == "/v1/account" &&
                 data[:method_name] == "POST" &&
+                data[:process_id] == Process.pid &&
                 data[:thread_object_id] == Thread.current.object_id &&
                 (data[:connection_manager_object_id].is_a? Numeric) &&
                 (data[:connection_object_id].is_a? Numeric)
@@ -513,6 +514,7 @@ module Stripe
               if message == "ConnectionManager request complete" &&
                  data[:path] == "/v1/account" &&
                  data[:method_name] == "POST" &&
+                 data[:process_id] == Process.pid &&
                  data[:thread_object_id] == connection_manager_data[:thread_object_id] &&
                  data[:connection_manager_object_id] == connection_manager_data[:connection_manager_object_id] &&
                  data[:connection_object_id] == connection_manager_data[:connection_object_id] &&
@@ -534,6 +536,7 @@ module Stripe
                                           idempotency_key: "abc",
                                           query: nil,
                                           config: Stripe.config,
+                                          process_id: Process.pid,
                                           thread_object_id: Thread.current.object_id)
 
             Util.expects(:log_info).with("Response from Stripe API",
@@ -551,6 +554,8 @@ module Stripe
                  data[:idempotency_key] == "abc" &&
                  data[:request_id] == "req_123" &&
                  data[:config] == Stripe.config &&
+                 data[:process_id] == Process.pid &&
+                 data[:thread_object_id] == Thread.current.object_id &&
                  data[:response_object_id] == response_object_id
                 # Streaming requests have a different body.
                 if request_method == "execute_request_stream"

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -505,7 +505,8 @@ module Stripe
                 data[:process_id] == Process.pid &&
                 data[:thread_object_id] == Thread.current.object_id &&
                 (data[:connection_manager_object_id].is_a? Numeric) &&
-                (data[:connection_object_id].is_a? Numeric)
+                (data[:connection_object_id].is_a? Numeric) &&
+                data[:log_timestamp] == 0.0
             end
 
             response_object_id = nil
@@ -518,7 +519,8 @@ module Stripe
                  data[:thread_object_id] == connection_manager_data[:thread_object_id] &&
                  data[:connection_manager_object_id] == connection_manager_data[:connection_manager_object_id] &&
                  data[:connection_object_id] == connection_manager_data[:connection_object_id] &&
-                 (data[:response_object_id].is_a? Numeric)
+                 (data[:response_object_id].is_a? Numeric) &&
+                 data[:log_timestamp] == 0.0
                 response_object_id = data[:response_object_id]
               end
             end
@@ -537,7 +539,8 @@ module Stripe
                                           query: nil,
                                           config: Stripe.config,
                                           process_id: Process.pid,
-                                          thread_object_id: Thread.current.object_id)
+                                          thread_object_id: Thread.current.object_id,
+                                          log_timestamp: 0.0)
 
             Util.expects(:log_info).with("Response from Stripe API",
                                          account: "acct_123",
@@ -556,7 +559,8 @@ module Stripe
                  data[:config] == Stripe.config &&
                  data[:process_id] == Process.pid &&
                  data[:thread_object_id] == Thread.current.object_id &&
-                 data[:response_object_id] == response_object_id
+                 data[:response_object_id] == response_object_id &&
+                 data[:log_timestamp] == 0.0
                 # Streaming requests have a different body.
                 if request_method == "execute_request_stream"
                   data[:body].is_a? Net::ReadAdapter


### PR DESCRIPTION
r? @richardm-stripe 

### Summary

Adds extra logging details around the connection manager as well as begins including the following for exsiting requesting logs:

* response object ID
* thread ID
* process ID
* timestamp

This can help us track down cross-thread interaction in logs. This is all local logging (ie. this is not part of telemetry).