### PR TITLE
Fix broken URIs in gemspec

### DIFF
--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                   "See https://stripe.com for details."
   s.author = "Stripe"
   s.email = "support@stripe.com"
-  s.homepage = "https://stripe.com/docs/api/ruby"
+  s.homepage = "https://stripe.com/docs/api?lang=ruby"
   s.license = "MIT"
 
   s.metadata = {
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
       "https://github.com/stripe/stripe-ruby/blob/master/CHANGELOG.md",
     "documentation_uri" => "https://stripe.com/docs/api/ruby",
     "github_repo" => "ssh://github.com/stripe/stripe-ruby",
-    "homepage_uri" => "https://stripe.com/docs/api/ruby",
+    "homepage_uri" => "https://stripe.com/docs/api?lang=ruby",
     "source_code_uri" => "https://github.com/stripe/stripe-ruby",
   }
 

--- a/stripe.gemspec
+++ b/stripe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     "bug_tracker_uri" => "https://github.com/stripe/stripe-ruby/issues",
     "changelog_uri" =>
       "https://github.com/stripe/stripe-ruby/blob/master/CHANGELOG.md",
-    "documentation_uri" => "https://stripe.com/docs/api/ruby",
+    "documentation_uri" => "https://stripe.com/docs/api?lang=ruby",
     "github_repo" => "ssh://github.com/stripe/stripe-ruby",
     "homepage_uri" => "https://stripe.com/docs/api?lang=ruby",
     "source_code_uri" => "https://github.com/stripe/stripe-ruby",


### PR DESCRIPTION
r? @dcr-stripe 

### Summary

Changes the homepage and documentation URIs in  the `.gemspec` from `https://stripe.com/docs/api/ruby` (which returns HTTP 404) to `https://stripe.com/docs/api?lang=ruby`.