### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, jruby-9.2.16.0, truffleruby-head]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2.16.0, truffleruby-head]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This PR just adds Ruby 3.1 to the CI matrix.

It also fixes a syntax issue with the "3.0", which needs to be in quotes inside the YAML configuration file, or else it will lose its precision and get treated like "3". 