### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,8 +24,9 @@ If applicable, add code snippets and/or screenshots to help explain your problem
 
 **Environment (please complete the following information):**
  - OS: [e.g. macOS]
- - Library version [e.g. 5.52.0]
- - API version: [e.g. 2020-08-27]
+ - Language version: [e.g. Ruby 3.1.2]
+ - Library version [e.g. stripe-ruby v5.52.0]
+ - API version: [e.g. 2020-08-27] (See [Versioning](https://stripe.com/docs/api/versioning) in the API Reference to find which version you're using)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Fetch a '...'
+2. Update the '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code snippets and outputs**
+If applicable, add code snippets and/or screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. macOS]
+ - Library version [e.g. 5.52.0]
+ - API version: [e.g. 2020-08-27]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this library
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.


### PR DESCRIPTION
Add issue templates for bug reports and feature requests, using the default ones on GitHub.