### PR TITLE
API Updates

### DIFF
--- a/lib/stripe/resources/refund.rb
+++ b/lib/stripe/resources/refund.rb
@@ -19,5 +19,24 @@ module Stripe
         opts: opts
       )
     end
+
+    def test_helpers
+      TestHelpers.new(self)
+    end
+
+    class TestHelpers < APIResourceTestHelpers
+      RESOURCE_CLASS = Refund
+
+      custom_method :expire, http_verb: :post
+
+      def expire(params = {}, opts = {})
+        @resource.request_stripe_object(
+          method: :post,
+          path: resource_url + "/expire",
+          params: params,
+          opts: opts
+        )
+      end
+    end
   end
 end

--- a/test/stripe/generated_examples_test.rb
+++ b/test/stripe/generated_examples_test.rb
@@ -1241,6 +1241,12 @@ module Stripe
         assert_requested :post, "#{Stripe.api_base}/v1/refunds"
       end
     end
+    context "Refund.expire" do
+      should "support requests with args: refund" do
+        Stripe::Refund::TestHelpers.expire("re_123")
+        assert_requested :post, "#{Stripe.api_base}/v1/test_helpers/refunds/re_123/expire?"
+      end
+    end
     context "Refund.list" do
       should "support requests with args: limit" do
         Stripe::Refund.list(limit: 3)


### PR DESCRIPTION
Codegen for openapi e07f049.
r? @pakrym-stripe (test_helpers expertise)
cc @stripe/api-libraries

## Changelog
* Add support for `expire` test helper method on resource `Refund`

