### PR TITLE
Trigger workflows on beta branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,15 @@ name: CI
 on:
   workflow_dispatch: {}
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - beta
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - beta
 
 jobs:
   build:


### PR DESCRIPTION
Add `beta` branch to `push` and `pr` triggers.

r? @kamil-stripe 