### PR TITLE
Use the generated API version

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -15,6 +15,7 @@ require "uri"
 require "forwardable"
 
 # Version
+require "stripe/api_version"
 require "stripe/version"
 
 # API operations

--- a/lib/stripe/api_version.rb
+++ b/lib/stripe/api_version.rb
@@ -1,0 +1,8 @@
+# File generated from our OpenAPI spec
+# frozen_string_literal: true
+
+module Stripe
+  module ApiVersion
+    CURRENT = "2020-08-27"
+  end
+end

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -63,6 +63,8 @@ module Stripe
     end
 
     def initialize
+      @api_version = ApiVersion::CURRENT
+
       @ca_bundle_path = Stripe::DEFAULT_CA_BUNDLE_PATH
       @enable_telemetry = true
       @verify_ssl_certs = true

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -20,7 +20,7 @@ module Stripe
         assert_equal "https://api.stripe.com", config.api_base
         assert_equal "https://connect.stripe.com", config.connect_base
         assert_equal "https://files.stripe.com", config.uploads_base
-        assert_equal nil, config.api_version
+        assert !config.api_version.nil?
       end
 
       should "allow for overrides when a block is passed" do


### PR DESCRIPTION
To support generating beta header values, use the generated ApiVersion value instead of the hardcoded one.

This change applies to beta only.

r? @dcr-stripe