### PR TITLE
fix: Update logging to coerce ASCII-8BIT into UTF-8.

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -416,6 +416,15 @@ module Stripe
       # Hopefully val is a string, but protect in case it's not.
       val = val.to_s
 
+      # Some values returned by the server are encoded in ASCII-8BIT before
+      # being parsed as UTF-8 by Marshal. If we don't transform these here, then
+      # puts will fail as it tries to render UTF-8 characters as ASCII-8BIT
+      # which is not valid.
+      if val && val.encoding == Encoding::ASCII_8BIT
+        # Dup the string as it is a frozen literal.
+        val = val.dup.force_encoding("UTF-8")
+      end
+
       if %r{[^\w\-/]} =~ val
         # If the string contains any special characters, escape any double
         # quotes it has, remove newlines, and wrap the whole thing in quotes.

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -397,6 +397,13 @@ module Stripe
       should "not error if given a non-string" do
         assert_equal "true", Util.send(:wrap_logfmt_value, true)
       end
+
+      should "handle UTF-8 characters encoded in ASCII-8BIT" do
+        expected_utf8_str = "\"é\"".dup.force_encoding(Encoding::UTF_8.name)
+        ascii_8bit_str = "é".dup.force_encoding(Encoding::ASCII_8BIT.name)
+
+        assert_equal expected_utf8_str, Util.send(:wrap_logfmt_value, ascii_8bit_str)
+      end
     end
   end
 end


### PR DESCRIPTION
r? @stripe/server-api-libraries-admins 

## Summary

Updates our logging utilities to transform any string encoded as ASCII-8bit (raw binary) to UTF-8 when logging out. 

The strings returned from the server are in ASCII-8bit until the JSON marshaller transforms them to UTF-8. Unfortunately we have logging statements which pass the raw content sent back from the server. puts fails to interpret these as 8bit because they're actually utf-8 characters.

So, we force any binary string to actually be encoded as UTF-8 for the purposes of debug logging.

Alternatives:
1. We could do a more localized fix here just for the body, but my worry is this will then become a game of whack-a-mole and finding all of the logging calls which pass the raw body.  
2. We could potentially immediately encode the response received from the server, but I'm worried about the downstream implications here (eg. if anyone is using the requesting infra). This change is limited to debug logging infra.

## Motivation

Fix https://github.com/stripe/stripe-ruby/issues/1059