### PR TITLE
Alias to_h to the same method as to_hash

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -196,6 +196,8 @@ module Stripe
       end
     end
 
+    alias to_h to_hash
+
     def each(&blk)
       @values.each(&blk)
     end


### PR DESCRIPTION
It's confusing that `to_h` would be a completely different method than `to_hash`.