### PR TITLE
Add a support section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The library also provides other features. For example:
 - Built-in mechanisms for the serialization of parameters according to the
   expectations of Stripe's API.
 
+## Support
+
+New features and bug fixes are released on the latest major version of the Stripe Ruby library. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+
 ## Documentation
 
 See the [Ruby API docs](https://stripe.com/docs/api?lang=ruby).


### PR DESCRIPTION
We have user feedback on the lack of clarity around whether or not we maintain and improve older major versions of the SDK. This PR adds a support section clarifying this