### PR TITLE
Update AllowedChars in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,11 @@ Metrics/ModuleLength:
 Style/AccessModifierDeclarations:
   EnforcedStyle: inline
 
+Style/AsciiComments:
+  AllowedChars:
+    - ’
+    - €
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 


### PR DESCRIPTION
r? @dcr-stripe 

### Summary
Update rubocop config to allow some non-ASCII characters in comments.