### PR TITLE
Make deep_copy public

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -432,7 +432,7 @@ module Stripe
     protected def initialize_from(values, opts, partial = false)
       @opts = Util.normalize_opts(opts)
 
-      @original_values = deep_copy(values)
+      @original_values = self.class.deep_copy(values)
 
       removed = partial ? Set.new : Set.new(@values.keys - values.keys)
       added = Set.new(values.keys - @values.keys)

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -432,8 +432,7 @@ module Stripe
     protected def initialize_from(values, opts, partial = false)
       @opts = Util.normalize_opts(opts)
 
-      # the `#send` is here so that we can keep this method private
-      @original_values = self.class.send(:deep_copy, values)
+      @original_values = self.deep_copy(values)
 
       removed = partial ? Set.new : Set.new(@values.keys - values.keys)
       added = Set.new(values.keys - @values.keys)
@@ -538,7 +537,7 @@ module Stripe
 
     # Produces a deep copy of the given object including support for arrays,
     # hashes, and StripeObjects.
-    private_class_method def self.deep_copy(obj)
+    def self.deep_copy(obj)
       case obj
       when Array
         obj.map { |e| deep_copy(e) }

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -432,7 +432,7 @@ module Stripe
     protected def initialize_from(values, opts, partial = false)
       @opts = Util.normalize_opts(opts)
 
-      @original_values = self.deep_copy(values)
+      @original_values = deep_copy(values)
 
       removed = partial ? Set.new : Set.new(@values.keys - values.keys)
       added = Set.new(values.keys - @values.keys)

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -58,10 +58,7 @@ module Stripe
           },
         }
 
-        # it's not good to test methods with `#send` like this, but I've done
-        # it in the interest of trying to keep `.deep_copy` as internal as
-        # possible
-        copy_values = Stripe::StripeObject.send(:deep_copy, values)
+        copy_values = Stripe::StripeObject.deep_copy(values)
 
         # we can't compare the hashes directly because they have embedded
         # objects which are different from each other
@@ -100,7 +97,7 @@ module Stripe
         values = { id: 1, name: "Stripe" }
 
         obj = Stripe::StripeObject.construct_from(values, opts)
-        copy_obj = Stripe::StripeObject.send(:deep_copy, obj)
+        copy_obj = Stripe::StripeObject.deep_copy(obj)
 
         assert_equal values, copy_obj.instance_variable_get(:@values)
         assert_equal opts.reject { |k, _v| k == :client },
@@ -111,7 +108,7 @@ module Stripe
         class TestObject < Stripe::StripeObject; end
 
         obj = TestObject.construct_from(id: 1)
-        copy_obj = obj.class.send(:deep_copy, obj)
+        copy_obj = obj.class.deep_copy(obj)
 
         assert_equal obj.class, copy_obj.class
       end


### PR DESCRIPTION
It's helpful for our users to have this method public. Having a canonical way to duplicate/copy
an object so you can mutate it without fear will be helpful. DM me internally for example code.

Quick use case: pricing tiers contain `inf` when *submitting* the tiers to the API, but use `null` in the return value.
This makes comparing them challenging. To compare, you need to translate null => inf (or the other way around) and then do
a hash comparison. Creating a deep copy of the tiers/price object makes this operation more safe.
