### PR TITLE
Add test coverage using Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
       run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
     - name: test
       run: bundle install && bundle exec rake test
+      env:
+        GITHUB_TOKEN: ${{ secrets.github_token }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_SERVICE_NAME: github-action
 
   publish:
     name: Publish

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "coveralls_reborn", "~> 0.25.0" if RUBY_VERSION >= "3.1"
   gem "mocha", "~> 0.13.2"
   gem "rack", ">= 2.0.6"
   gem "rake"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/stripe.svg)](https://badge.fury.io/rb/stripe)
 [![Build Status](https://github.com/stripe/stripe-ruby/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-ruby/actions?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
 
 The Stripe Ruby library provides convenient access to the Stripe API from
 applications written in the Ruby language. It includes a pre-defined set of

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if RUBY_VERSION >= "3.1"
+  require "coveralls"
+  Coveralls.wear!
+end
+
 require "stripe"
 require "test/unit"
 require "mocha/setup"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-if RUBY_VERSION >= "3.1"
+# Report test coverage to coveralls for only one Ruby version to avoid
+# repeated builds. This also accounts for coveralls_reborn requiring
+# RUBY_VERSION >= 2.5.
+if RUBY_VERSION.start_with?("3.1")
   require "coveralls"
   Coveralls.wear!
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 # Report test coverage to coveralls for only one Ruby version to avoid
 # repeated builds. This also accounts for coveralls_reborn requiring
 # RUBY_VERSION >= 2.5.
-if RUBY_VERSION.start_with?("3.1")
+if RUBY_VERSION.start_with?("3.1.")
   require "coveralls"
   Coveralls.wear!
 end


### PR DESCRIPTION
### Summary
Add test coverage reporting to coveralls for Ruby version 3.1. Test coverage data will be published to https://coveralls.io/github/stripe/stripe-ruby and displayed as a badge in the README.

Example build: https://coveralls.io/builds/51915924

r? @dcr-stripe 