### PR TITLE
Carry forward params (filters) to StripeObject sub-lists

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -145,7 +145,7 @@ module Stripe
     end
 
     def self.set_filters(obj, params)
-      return unless obj&.is_a?(StripeObject)
+      return unless obj&.is_a?(StripeObject) && params
 
       # set filters so that we can fetch the same limit, expansions, and
       # predicates when accessing the next and previous pages

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -132,6 +132,18 @@ module Stripe
       assert_equal [1, 2, 3], obj
     end
 
+    should "#convert_to_stripe_object_with_params should preserve filters for ListObjects" do
+      obj = Util.convert_to_stripe_object_with_params({ object: "list" }, { some_filter: true })
+
+      assert obj.filters.key?(:some_filter)
+    end
+
+    should "#convert_to_stripe_object_with_params should preserve filters for ListObject values" do
+      obj = Util.convert_to_stripe_object_with_params({ foo: "bar", baz: { object: "list" } }, { some_filter: true })
+      assert obj.baz.is_a?(ListObject)
+      assert obj.baz.filters.key?(:some_filter)
+    end
+
     context ".request_id_dashboard_url" do
       should "generate a livemode URL" do
         assert_equal "https://dashboard.stripe.com/live/logs/request-id",


### PR DESCRIPTION
r? @anniel-stripe 

## Summary
Set filters (from request params) for `SearchResultObject` and `ListObject` sub-hashes within a `StripeObject`. This should  fix the bug where, when calling `Stripe::Invoice.upcoming` with `subscription_items`, `Invoice.lines.auto_paging_each` was not carrying forward the `subscription_items` param, so the subsequent pages had incorrect results.