### PR TITLE
Deprecate save()

### DIFF
--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -33,6 +33,9 @@ module Stripe
         end
       end
 
+      # The `save` method is DEPRECATED and will be removed in a future major
+      # version of the library. Use the `update` method on the resource instead.
+      #
       # Creates or updates an API resource.
       #
       # If the resource doesn't yet have an assigned ID and the resource is one
@@ -50,9 +53,6 @@ module Stripe
       #   idempotency_key to be passed in the request headers, or for the
       #   api_key to be overwritten. See
       #   {APIOperations::Request.execute_resource_request}.
-      #
-      # The `save` method is DEPRECATED and will be removed in a future major
-      # version of the library. Use the `update` method on the resource instead.
       def save(params = {}, opts = {})
         # We started unintentionally (sort of) allowing attributes sent to
         # +save+ to override values used during the update. So as not to break
@@ -72,7 +72,7 @@ module Stripe
         initialize_from(resp.data, opts)
       end
       extend Gem::Deprecate
-      deprecate :save, :none, 2022, 11
+      deprecate :save, :update, 2022, 11
 
       def self.included(base)
         # Set `metadata` as additive so that when it's set directly we remember

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -51,7 +51,7 @@ module Stripe
       #   api_key to be overwritten. See
       #   {APIOperations::Request.execute_resource_request}.
       #
-      # The `save` method is DEPRECATED and will be removed in future major
+      # The `save` method is DEPRECATED and will be removed in a future major
       # version of the library. Use the `update` method on the resource instead.
       def save(params = {}, opts = {})
         # We started unintentionally (sort of) allowing attributes sent to

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -51,8 +51,8 @@ module Stripe
       #   api_key to be overwritten. See
       #   {APIOperations::Request.execute_resource_request}.
       #
-      # This method is DEPRECATED and for backwards compatibility only.
-      # Use the update method with the resource ID instead.
+      # The `save` method is DEPRECATED and will be removed in future major
+      # version of the library. Use the `update` method on the resource instead.
       def save(params = {}, opts = {})
         # We started unintentionally (sort of) allowing attributes sent to
         # +save+ to override values used during the update. So as not to break

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -50,6 +50,9 @@ module Stripe
       #   idempotency_key to be passed in the request headers, or for the
       #   api_key to be overwritten. See
       #   {APIOperations::Request.execute_resource_request}.
+      #
+      # This method is DEPRECATED and for backwards compatibility only.
+      # Use the update method with the resource ID instead.
       def save(params = {}, opts = {})
         # We started unintentionally (sort of) allowing attributes sent to
         # +save+ to override values used during the update. So as not to break
@@ -68,6 +71,8 @@ module Stripe
         resp, opts = execute_resource_request(:post, save_url, values, opts)
         initialize_from(resp.data, opts)
       end
+      extend Gem::Deprecate
+      deprecate :save, :none, 2022, 11
 
       def self.included(base)
         # Set `metadata` as additive so that when it's set directly we remember


### PR DESCRIPTION
### Summary
Mark `save()` method as deprecated.