### PR TITLE
Do not run Coveralls if secret token is not available

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 # Report test coverage to coveralls for only one Ruby version to avoid
 # repeated builds. This also accounts for coveralls_reborn requiring
 # RUBY_VERSION >= 2.5.
-if RUBY_VERSION.start_with?("3.1.")
+if ENV.key?("COVERALLS_REPO_TOKEN") && RUBY_VERSION.start_with?("3.1.")
   require "coveralls"
   Coveralls.wear!
 end


### PR DESCRIPTION
## Summary
Do not run Coveralls step if the secret token does not exist (for pushes triggered by outside collaborators).

## Motivation
https://github.com/stripe/stripe-php/pull/1379 - make this change consistent across all languages