### PR TITLE
Disable AsciiComments rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,9 +45,7 @@ Style/AccessModifierDeclarations:
   EnforcedStyle: inline
 
 Style/AsciiComments:
-  AllowedChars:
-    - ’
-    - €
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always


### PR DESCRIPTION
## Summary
To support documentation that contains UTF-8 encoded characters, disable Rubocop's `Style/AsciiComments` rule. In the future we will want to upgrade Rubocop to a more recent version, since as of [1.21.0](https://github.com/rubocop/rubocop/issues/9674) this rule is disabled by default.