### PR TITLE
API Version 2022-11-09

### DIFF
--- a/lib/stripe/api_version.rb
+++ b/lib/stripe/api_version.rb
@@ -3,6 +3,6 @@
 
 module Stripe
   module ApiVersion
-    CURRENT = "2022-08-01"
+    CURRENT = "2022-11-09"
   end
 end

--- a/lib/stripe/resources/subscription.rb
+++ b/lib/stripe/resources/subscription.rb
@@ -50,31 +50,6 @@ module Stripe
     end
 
     save_nested_resource :source
-    def delete(params = {}, opts = {})
-      request_stripe_object(
-        method: :delete,
-        path: format("/v1/subscriptions/%<subscription_exposed_id>s", { subscription_exposed_id: CGI.escape(self["id"]) }),
-        params: params,
-        opts: opts
-      )
-    end
-
-    def self.delete(subscription_exposed_id, params = {}, opts = {})
-      request_stripe_object(
-        method: :delete,
-        path: format("/v1/subscriptions/%<subscription_exposed_id>s", { subscription_exposed_id: CGI.escape(subscription_exposed_id) }),
-        params: params,
-        opts: opts
-      )
-    end
-
-    extend Gem::Deprecate
-    deprecate :delete, "Stripe::Subscription.cancel", 2022, 7
-
-    class << self
-      extend Gem::Deprecate
-      deprecate :delete, "Stripe::Subscription#cancel", 2022, 7
-    end
 
     def self.search(params = {}, opts = {})
       _search("/v1/subscriptions/search", params, opts)


### PR DESCRIPTION
## Changelog
* Update current API version to 2022-11-09
* Remove deprecated `Subscription.delete`. Use `Subscription.cancel`.