### PR TITLE
Add ReportRun#contents to get the actual report data

### DIFF
--- a/lib/stripe/resources/reporting/report_run.rb
+++ b/lib/stripe/resources/reporting/report_run.rb
@@ -16,6 +16,24 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "reporting.report_run"
+
+      def contents(params = {}, opts = {}, &read_body_chunk_block)
+        unless block_given?
+          raise ArgumentError, "A read_body_chunk_block block parameter is required when calling the contents method."
+        end
+
+        config = opts[:client]&.config || Stripe.config
+
+        request_stream(
+          method: :get,
+          path: "/v1/files/#{result.id}/contents",
+          params: params,
+          opts: {
+            api_base: config.uploads_base,
+          }.merge(opts),
+          &read_body_chunk_block
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
As far as I can see the Ruby client currently only has methods to create a report run and retrieve it (ie. its metadata), not the actual report content.

This PR adds an action to download the content, based on Quote#pdf.

I tried to add a test to cover it, but found that stripe-mock doesn't have mocked reponses for the binary `contents` endpoint on files (only the file metadata endpoint), so I can't add a working test at this time.