### PR TITLE
Use shared stripe-mock action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,49 +42,49 @@ jobs:
       with:
         bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  test:
-    name: Test (${{ matrix.ruby-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.4.0.0, truffleruby-head]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - uses: stripe/openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
-    - name: test
-      run: make test
-      env:
-        GITHUB_TOKEN: ${{ secrets.github_token }}
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_SERVICE_NAME: github-action
+  # test:
+  #   name: Test (${{ matrix.ruby-version }})
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.4.0.0, truffleruby-head]
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Set up Ruby
+  #     uses: ruby/setup-ruby@v1
+  #     with:
+  #       ruby-version: ${{ matrix.ruby-version }}
+  #   - uses: stripe/openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
+  #   - name: test
+  #     run: make test
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.github_token }}
+  #       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+  #       COVERALLS_SERVICE_NAME: github-action
 
-  publish:
-    name: Publish
-    if: >-
-      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
-      startsWith(github.ref, 'refs/tags/v') &&
-      endsWith(github.actor, '-stripe')
-    needs: [build, test]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: gems
-        path: gems
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version:  3.1
-    - name: Publish gems to Rubygems
-      run: gem push gems/*.gem
-      env:
-        GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
-    - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
-      if: always()
-      with:
-        bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+  # publish:
+  #   name: Publish
+  #   if: >-
+  #     ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
+  #     startsWith(github.ref, 'refs/tags/v') &&
+  #     endsWith(github.actor, '-stripe')
+  #   needs: [build, test]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download all workflow run artifacts
+  #     uses: actions/download-artifact@v3
+  #     with:
+  #       name: gems
+  #       path: gems
+  #   - name: Set up Ruby
+  #     uses: ruby/setup-ruby@v1
+  #     with:
+  #       ruby-version:  3.1
+  #   - name: Publish gems to Rubygems
+  #     run: gem push gems/*.gem
+  #     env:
+  #       GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
+  #   - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
+  #     if: always()
+  #     with:
+  #       bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,54 +37,50 @@ jobs:
       with:
         name: gems
         path: '*.gem'
-    - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
+
+  test:
+    name: Test (${{ matrix.ruby-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.4.0.0, truffleruby-head]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - uses: stripe/openapi/actions/stripe-mock@master
+    - name: test
+      run: make test
+      env:
+        GITHUB_TOKEN: ${{ secrets.github_token }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_SERVICE_NAME: github-action
+
+  publish:
+    name: Publish
+    if: >-
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      endsWith(github.actor, '-stripe')
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: gems
+        path: gems
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version:  3.1
+    - name: Publish gems to Rubygems
+      run: gem push gems/*.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
+    - uses: stripe/openapi/actions/notify-release@master
       if: always()
       with:
         bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  # test:
-  #   name: Test (${{ matrix.ruby-version }})
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.4.0.0, truffleruby-head]
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Ruby
-  #     uses: ruby/setup-ruby@v1
-  #     with:
-  #       ruby-version: ${{ matrix.ruby-version }}
-  #   - uses: stripe/openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
-  #   - name: test
-  #     run: make test
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.github_token }}
-  #       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-  #       COVERALLS_SERVICE_NAME: github-action
-
-  # publish:
-  #   name: Publish
-  #   if: >-
-  #     ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
-  #     startsWith(github.ref, 'refs/tags/v') &&
-  #     endsWith(github.actor, '-stripe')
-  #   needs: [build, test]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Download all workflow run artifacts
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: gems
-  #       path: gems
-  #   - name: Set up Ruby
-  #     uses: ruby/setup-ruby@v1
-  #     with:
-  #       ruby-version:  3.1
-  #   - name: Publish gems to Rubygems
-  #     run: gem push gems/*.gem
-  #     env:
-  #       GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
-  #   - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
-  #     if: always()
-  #     with:
-  #       bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
       with:
         name: gems
         path: '*.gem'
+    - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
+      if: always()
+      with:
+        bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   test:
     name: Test (${{ matrix.ruby-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - uses: stripe/openapi/actions/stripe-mock@master
     - name: test
-      run: make test
+      run: make ci-test
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,7 @@ jobs:
       run: gem push gems/*.gem
       env:
         GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
+    - uses: openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
+      if: always()
+      with:
+        bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - uses: openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
+    - uses: stripe/openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
     - name: test
       run: make test
       env:
@@ -80,7 +80,7 @@ jobs:
       run: gem push gems/*.gem
       env:
         GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
-    - uses: openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
+    - uses: stripe/openapi/actions/notify-release@pakrym/Add_stripe-mock_shared_action
       if: always()
       with:
         bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Start stripe-mock
-      run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
+    - uses: openapi/actions/stripe-mock@pakrym/Add_stripe-mock_shared_action
     - name: test
-      run: bundle install && bundle exec rake test
+      run: make test
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: update-version codegen-format
+.PHONY: update-version codegen-format test ci-test
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|VERSION = "[.\-\w\d]+"|VERSION = "$(VERSION)"|' lib/stripe/version.rb
@@ -6,3 +6,8 @@ update-version:
 codegen-format:
 	bundle install --quiet
 	bundle exec rubocop -o /dev/null --auto-correct
+
+ci-test:
+	bundle install && bundle exec rake test
+
+test: ci-test


### PR DESCRIPTION
Uses a shared stripe-mock action that has logic to load `beta` spec when needed.