### PR TITLE
Remove test for a method without stripe-mock support

### DIFF
--- a/test/stripe/source_test.rb
+++ b/test/stripe/source_test.rb
@@ -78,16 +78,6 @@ module Stripe
       end
     end
 
-    context ".retrieve_source_transaction" do
-      should "retrieve a source transaction" do
-        Stripe::Source.retrieve_source_transaction(
-          "src_123",
-          "srctxn_123"
-        )
-        assert_requested :get, "#{Stripe.api_base}/v1/sources/src_123/source_transactions/srctxn_123"
-      end
-    end
-
     context ".list_source_transactions" do
       should "list source transactions" do
         Stripe::Source.list_source_transactions(


### PR DESCRIPTION
spec3.sdk doesn't have this method, it's added via overrides only for ruby.