### PR TITLE
Update save deprecation message

### DIFF
--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -72,7 +72,7 @@ module Stripe
         initialize_from(resp.data, opts)
       end
       extend Gem::Deprecate
-      deprecate :save, "the `update` class method, (for examples"\
+      deprecate :save, "the `update` class method (for examples"\
                 " see https://github.com/stripe/stripe-ruby"\
                 "/wiki/Migration-guide-for-v8)", 2022, 11
 

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -72,7 +72,9 @@ module Stripe
         initialize_from(resp.data, opts)
       end
       extend Gem::Deprecate
-      deprecate :save, :update, 2022, 11
+      deprecate :save, "the `update` class method, (for examples"\
+                " see https://github.com/stripe/stripe-ruby"\
+                "/wiki/Migration-guide-for-v8)", 2022, 11
 
       def self.included(base)
         # Set `metadata` as additive so that when it's set directly we remember


### PR DESCRIPTION
closes https://github.com/stripe/stripe-ruby/issues/1200

Provide a better deprecation message for the `save` instance method to make it more clear that `update` is a class method. The message now looks like:
```
NOTE: Stripe::Subscription#save is deprecated; use the `update` class method (for examples see https://github.com/stripe/stripe-ruby/wiki/Migration-guide-for-v8) instead. It will be removed on or after 2022-11-01.
```