### PR TITLE
Accept sign as lambda function

### DIFF
--- a/lib/stripe/request_signing_authenticator.rb
+++ b/lib/stripe/request_signing_authenticator.rb
@@ -12,14 +12,14 @@ module Stripe
 
     attr_reader :auth_token
 
-    def initialize(auth_token, sign_method)
+    def initialize(auth_token, sign_lambda)
       @auth_token = case auth_token
                     when String
                       auth_token
                     else
                       raise ArgumentError, "auth_token must be a string"
                     end
-      @sign_method = sign_method
+      @sign_lambda = sign_lambda
     end
 
     def authenticate(method, headers, body)
@@ -57,7 +57,7 @@ module Stripe
     end
 
     private def sign(signature_base)
-      @sign_method.call(signature_base)
+      @sign_lambda.call(signature_base)
     end
 
     private def encoded_signature(signature_base)

--- a/lib/stripe/request_signing_authenticator.rb
+++ b/lib/stripe/request_signing_authenticator.rb
@@ -12,13 +12,14 @@ module Stripe
 
     attr_reader :auth_token
 
-    def initialize(auth_token)
+    def initialize(auth_token, sign_method)
       @auth_token = case auth_token
                     when String
                       auth_token
                     else
                       raise ArgumentError, "auth_token must be a string"
                     end
+      @sign_method = sign_method
     end
 
     def authenticate(method, headers, body)
@@ -55,11 +56,8 @@ module Stripe
         "sig1=:#{encoded_signature(signature_base)}:"
     end
 
-    # To be overriden by the user with their own signing implementation
-    private def sign(_signature_base)
-      raise NoMethodError, "`sign()` not implemented. Please override " \
-       "the `sign` method on Stripe::RequestSigningAuthenticator with your " \
-       "custom signing implementation."
+    private def sign(signature_base)
+      @sign_method.call(signature_base)
     end
 
     private def encoded_signature(signature_base)

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -485,7 +485,8 @@ module Stripe
             RequestSigningAuthenticator.any_instance.stubs(:encoded_signature).returns("signature")
 
             Stripe.api_key = nil
-            Stripe.authenticator = RequestSigningAuthenticator.new("keyinfo_test_123")
+            sign_method = -> {}
+            Stripe.authenticator = RequestSigningAuthenticator.new("keyinfo_test_123", sign_method)
           end
 
           should "apply valid signing headers for get requests" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -485,8 +485,8 @@ module Stripe
             RequestSigningAuthenticator.any_instance.stubs(:encoded_signature).returns("signature")
 
             Stripe.api_key = nil
-            sign_method = -> {}
-            Stripe.authenticator = RequestSigningAuthenticator.new("keyinfo_test_123", sign_method)
+            sign_lambda = -> {}
+            Stripe.authenticator = RequestSigningAuthenticator.new("keyinfo_test_123", sign_lambda)
           end
 
           should "apply valid signing headers for get requests" do


### PR DESCRIPTION
## Summary
Represent the sign method as a lambda for simpler `RequestSigningAuthenticator` creation.