### PR TITLE
Handle developer message in preview error responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ group :development do
   # up-to-date, but it's not the end of the world if it's not.
   gem "rubocop", "0.80"
 
+  # jaro_winkler 1.5.5 installation fails for jruby
+  gem "jaro_winkler", "1.5.4"
+
   platforms :mri do
     gem "byebug"
     gem "pry"

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -768,10 +768,11 @@ module Stripe
     end
 
     private def specific_api_error(resp, error_data, context)
+      message = error_data[:message] || error_data[:developer_message]
       Util.log_error("Stripe API error",
                      status: resp.http_status,
                      error_code: error_data[:code],
-                     error_message: error_data[:message],
+                     error_message: message,
                      error_param: error_data[:param],
                      error_type: error_data[:type],
                      idempotency_key: context.idempotency_key,
@@ -792,26 +793,26 @@ module Stripe
       when 400, 404
         case error_data[:type]
         when "idempotency_error"
-          IdempotencyError.new(error_data[:message], **opts)
+          IdempotencyError.new(message, **opts)
         else
           InvalidRequestError.new(
-            error_data[:message], error_data[:param],
+            message, error_data[:param],
             **opts
           )
         end
       when 401
-        AuthenticationError.new(error_data[:message], **opts)
+        AuthenticationError.new(message, **opts)
       when 402
         CardError.new(
-          error_data[:message], error_data[:param],
+          message, error_data[:param],
           **opts
         )
       when 403
-        PermissionError.new(error_data[:message], **opts)
+        PermissionError.new(message, **opts)
       when 429
-        RateLimitError.new(error_data[:message], **opts)
+        RateLimitError.new(message, **opts)
       else
-        APIError.new(error_data[:message], **opts)
+        APIError.new(message, **opts)
       end
     end
 

--- a/test/stripe/preview_test.rb
+++ b/test/stripe/preview_test.rb
@@ -80,5 +80,16 @@ class PreviewTest < Test::Unit::TestCase
       assert_equal "application/json", req.headers["Content-Type"]
       assert_equal stripe_context, req.headers["Stripe-Context"]
     end
+
+    should "include developer_message in error message" do
+      expected_body = "{\"error\": {\"developer_message\": \"Unacceptable!\"}}"
+      stub_request(:get, "#{Stripe.api_base}/v2/accounts/acc_123")
+        .to_return(body: expected_body, status: 400)
+
+      e = assert_raises do
+        Stripe::Preview.get("/v2/accounts/acc_123")
+      end
+      assert_equal "Unacceptable!", e.message
+    end
   end
 end


### PR DESCRIPTION
The error message can be returned in a `developer_message` field, handle this case and throw a useful error.