### PR TITLE
fix: variable typo in README for instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For example:
 ```ruby
 Stripe::Instrumentation.subscribe(:request_end) do |request_event|
   # Filter out high-cardinality ids from `path`
-  path_parts = event.path.split("/").drop(2)
+  path_parts = request_event.path.split("/").drop(2)
   resource = path_parts.map { |part| part.match?(/\A[a-z_]+\z/) ? part : ":id" }.join("/")
 
   tags = {


### PR DESCRIPTION
This PR fixes what I believe is a typo in the README example for instrumentation. The variable's name doesn't seem to match.