### PR TITLE
Update log level error message to include `error`

### DIFF
--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -94,7 +94,8 @@ module Stripe
 
       if !val.nil? && !levels.include?(val)
         raise ArgumentError,
-              "log_level should only be set to `nil`, `debug` or `info`"
+              "log_level should only be set to `nil`, `debug`, `info`," \
+              " or `error`"
       end
       @log_level = val
     end


### PR DESCRIPTION
"error" was introduced as a valid value for `LOG_LEVEL` in https://github.com/stripe/stripe-ruby/pull/1235. Update the error message to also reflect this.