### PR TITLE
Remove developer_message support

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -768,7 +768,7 @@ module Stripe
     end
 
     private def specific_api_error(resp, error_data, context)
-      message = error_data[:message] || error_data[:developer_message]
+      message = error_data[:message]
       Util.log_error("Stripe API error",
                      status: resp.http_status,
                      error_code: error_data[:code],

--- a/test/stripe/preview_test.rb
+++ b/test/stripe/preview_test.rb
@@ -80,16 +80,5 @@ class PreviewTest < Test::Unit::TestCase
       assert_equal "application/json", req.headers["Content-Type"]
       assert_equal stripe_context, req.headers["Stripe-Context"]
     end
-
-    should "include developer_message in error message" do
-      expected_body = "{\"error\": {\"developer_message\": \"Unacceptable!\"}}"
-      stub_request(:get, "#{Stripe.api_base}/v2/accounts/acc_123")
-        .to_return(body: expected_body, status: 400)
-
-      e = assert_raises do
-        Stripe::Preview.get("/v2/accounts/acc_123")
-      end
-      assert_equal "Unacceptable!", e.message
-    end
   end
 end


### PR DESCRIPTION
Preview error messages now contain a message field.