### PR TITLE
Explicitly format timestamp in SignatureVerificationError message

### DIFF
--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -108,8 +108,9 @@ module Stripe
         end
 
         if tolerance && timestamp < Time.now - tolerance
+          formatted_timestamp = Time.at(timestamp).strftime("%F %T")
           raise SignatureVerificationError.new(
-            "Timestamp outside the tolerance zone (#{Time.at(timestamp)})",
+            "Timestamp outside the tolerance zone (#{formatted_timestamp})",
             header, http_body: payload
           )
         end


### PR DESCRIPTION
When interpolating a Time object in a String, Ruby calls `to_s` under the hood.

For Rails applications defining a `default` string format, this triggers deprecation warnings as of v7.0.7: https://github.com/rails/rails/pull/48555

This change fixes that by explicitly formatting the timestamp (using the same `YYYY-MM-DD HH:mm:ss` format currently implicitly used).