### PR TITLE
Add support for updatable singleton resources

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -25,6 +25,7 @@ require "stripe/api_operations/list"
 require "stripe/api_operations/nested_resource"
 require "stripe/api_operations/request"
 require "stripe/api_operations/save"
+require "stripe/api_operations/singleton_save"
 require "stripe/api_operations/search"
 
 # API resource support classes

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -33,7 +33,7 @@ module Stripe
       # The `save` method is DEPRECATED and will be removed in a future major
       # version of the library. Use the `update` method on the resource instead.
       #
-      # Creates or updates an API resource.
+      # Updates a singleton API resource.
       #
       # If the resource doesn't yet have an assigned ID and the resource is one
       # that can be created, then the method attempts to create the resource.

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -4,7 +4,7 @@ module Stripe
   module APIOperations
     module SingletonSave
       module ClassMethods
-        # Updates an API resource
+        # Updates a singleton API resource
         #
         # Updates the identified resource with the passed in parameters.
         #

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Stripe
+  module APIOperations
+    module SingletonSave
+      module ClassMethods
+
+        # Updates an API resource
+        #
+        # Updates the identified resource with the passed in parameters.
+        #
+        # ==== Attributes
+        #
+        # * +params+ - A hash of parameters to pass to the API
+        # * +opts+ - A Hash of additional options (separate from the params /
+        #   object values) to be added to the request. E.g. to allow for an
+        #   idempotency_key to be passed in the request headers, or for the
+        #   api_key to be overwritten. See
+        #   {APIOperations::Request.execute_resource_request}.
+        def update(params = {}, opts = {})
+          params.each_key do |k|
+            raise ArgumentError, "Cannot update protected field: #{k}" if protected_fields.include?(k)
+          end
+
+          request_stripe_object(
+            method: :post,
+            path: resource_url,
+            params: params,
+            opts: opts
+          )
+        end
+      end
+
+      # The `save` method is DEPRECATED and will be removed in a future major
+      # version of the library. Use the `update` method on the resource instead.
+      #
+      # Creates or updates an API resource.
+      #
+      # If the resource doesn't yet have an assigned ID and the resource is one
+      # that can be created, then the method attempts to create the resource.
+      # The resource is updated otherwise.
+      #
+      # ==== Attributes
+      #
+      # * +params+ - Overrides any parameters in the resource's serialized data
+      #   and includes them in the create or update. If +:req_url:+ is included
+      #   in the list, it overrides the update URL used for the create or
+      #   update.
+      # * +opts+ - A Hash of additional options (separate from the params /
+      #   object values) to be added to the request. E.g. to allow for an
+      #   idempotency_key to be passed in the request headers, or for the
+      #   api_key to be overwritten. See
+      #   {APIOperations::Request.execute_resource_request}.
+      def save(params = {}, opts = {})
+        # We started unintentionally (sort of) allowing attributes sent to
+        # +save+ to override values used during the update. So as not to break
+        # the API, this makes that official here.
+        update_attributes(params)
+
+        # Now remove any parameters that look like object attributes.
+        params = params.reject { |k, _| respond_to?(k) }
+
+        values = serialize_params(self).merge(params)
+
+        resp, opts = execute_resource_request(:post, resource_url, values, opts, ["save"])
+        initialize_from(resp.data, opts)
+      end
+      extend Gem::Deprecate
+      deprecate :save, "the `update` class method (for examples " \
+        "see https://github.com/stripe/stripe-ruby" \
+        "/wiki/Migration-guide-for-v8)", 2022, 11
+
+      def self.included(base)
+        # Set `metadata` as additive so that when it's set directly we remember
+        # to clear keys that may have been previously set by sending empty
+        # values for them.
+        #
+        # It's possible that not every object with `Save` has `metadata`, but
+        # it's a close enough heuristic, and having this option set when there
+        # is no `metadata` field is not harmful.
+        base.additive_object_param(:metadata)
+
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -4,7 +4,6 @@ module Stripe
   module APIOperations
     module SingletonSave
       module ClassMethods
-
         # Updates an API resource
         #
         # Updates the identified resource with the passed in parameters.
@@ -67,8 +66,8 @@ module Stripe
       end
       extend Gem::Deprecate
       deprecate :save, "the `update` class method (for examples " \
-        "see https://github.com/stripe/stripe-ruby" \
-        "/wiki/Migration-guide-for-v8)", 2022, 11
+                       "see https://github.com/stripe/stripe-ruby" \
+                       "/wiki/Migration-guide-for-v8)", 2022, 11
 
       def self.included(base)
         # Set `metadata` as additive so that when it's set directly we remember

--- a/lib/stripe/resources/tax/settings.rb
+++ b/lib/stripe/resources/tax/settings.rb
@@ -7,7 +7,7 @@ module Stripe
     #
     # Related guide: [Using the Settings API](https://stripe.com/docs/tax/settings-api)
     class Settings < SingletonAPIResource
-      include Stripe::APIOperations::Save
+      include Stripe::APIOperations::SingletonSave
 
       OBJECT_NAME = "tax.settings"
     end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -783,12 +783,10 @@ module Stripe
     end
 
     context "singleton resource" do
-
       class TestSingletonResource < SingletonAPIResource # rubocop:todo Lint/ConstantDefinitionInBlock
         include Stripe::APIOperations::SingletonSave
         OBJECT_NAME = "test.singleton"
       end
-
 
       setup do
         Util.instance_variable_set(

--- a/test/stripe/generated_examples_test.rb
+++ b/test/stripe/generated_examples_test.rb
@@ -1571,6 +1571,30 @@ module Stripe
       Stripe::TaxRate.update("txr_xxxxxxxxxxxxx", { active: false })
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/txr_xxxxxxxxxxxxx"
     end
+    should "Test tax registrations get" do
+      Stripe::Tax::Registration.list({ status: "all" })
+      assert_requested :get, "#{Stripe.api_base}/v1/tax/registrations?status=all"
+    end
+    should "Test tax registrations post" do
+      Stripe::Tax::Registration.create({
+        country: "IE",
+        country_options: { ie: { type: "oss_union" } },
+        active_from: "now",
+      })
+      assert_requested :post, "#{Stripe.api_base}/v1/tax/registrations"
+    end
+    should "Test tax registrations post 2" do
+      Stripe::Tax::Registration.update("taxreg_xxxxxxxxxxxxx", { expires_at: "now" })
+      assert_requested :post, "#{Stripe.api_base}/v1/tax/registrations/taxreg_xxxxxxxxxxxxx"
+    end
+    should "Test tax settings get" do
+      Stripe::Tax::Settings.retrieve
+      assert_requested :get, "#{Stripe.api_base}/v1/tax/settings?"
+    end
+    should "Test tax settings post" do
+      Stripe::Tax::Settings.update({ defaults: { tax_code: "txcd_10000000" } })
+      assert_requested :post, "#{Stripe.api_base}/v1/tax/settings"
+    end
     should "Test tax transactions create from calculation post" do
       Stripe::Tax::Transaction.create_from_calculation({
         calculation: "xxx",

--- a/test/stripe/generated_examples_test.rb
+++ b/test/stripe/generated_examples_test.rb
@@ -1571,22 +1571,6 @@ module Stripe
       Stripe::TaxRate.update("txr_xxxxxxxxxxxxx", { active: false })
       assert_requested :post, "#{Stripe.api_base}/v1/tax_rates/txr_xxxxxxxxxxxxx"
     end
-    should "Test tax registrations get" do
-      Stripe::Tax::Registration.list({ status: "all" })
-      assert_requested :get, "#{Stripe.api_base}/v1/tax/registrations?status=all"
-    end
-    should "Test tax registrations post" do
-      Stripe::Tax::Registration.create({
-        country: "IE",
-        country_options: { ie: { type: "oss_union" } },
-        active_from: "now",
-      })
-      assert_requested :post, "#{Stripe.api_base}/v1/tax/registrations"
-    end
-    should "Test tax registrations post 2" do
-      Stripe::Tax::Registration.update("taxreg_xxxxxxxxxxxxx", { expires_at: "now" })
-      assert_requested :post, "#{Stripe.api_base}/v1/tax/registrations/taxreg_xxxxxxxxxxxxx"
-    end
     should "Test tax settings get" do
       Stripe::Tax::Settings.retrieve
       assert_requested :get, "#{Stripe.api_base}/v1/tax/settings?"


### PR DESCRIPTION
Singleton resources do not need the `id` parameter that method from `Stripe::APIOperations::Save` have.