### PR TITLE
Remove list method in child resources

### DIFF
--- a/lib/stripe/resources/application_fee_refund.rb
+++ b/lib/stripe/resources/application_fee_refund.rb
@@ -8,7 +8,6 @@ module Stripe
   #
   # Related guide: [Refunding application fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee)
   class ApplicationFeeRefund < APIResource
-    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "fee_refund"

--- a/lib/stripe/resources/capability.rb
+++ b/lib/stripe/resources/capability.rb
@@ -6,7 +6,6 @@ module Stripe
   #
   # Related guide: [Account capabilities](https://stripe.com/docs/connect/account-capabilities)
   class Capability < APIResource
-    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "capability"

--- a/lib/stripe/resources/customer_balance_transaction.rb
+++ b/lib/stripe/resources/customer_balance_transaction.rb
@@ -9,7 +9,6 @@ module Stripe
   #
   # Related guide: [Customer balance](https://stripe.com/docs/billing/customer/balance)
   class CustomerBalanceTransaction < APIResource
-    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "customer_balance_transaction"

--- a/lib/stripe/resources/customer_cash_balance_transaction.rb
+++ b/lib/stripe/resources/customer_cash_balance_transaction.rb
@@ -7,8 +7,6 @@ module Stripe
   # represent when funds are moved into or out of this balance. This includes funding by the customer, allocation
   # to payments, and refunds to the customer.
   class CustomerCashBalanceTransaction < APIResource
-    extend Stripe::APIOperations::List
-
     OBJECT_NAME = "customer_cash_balance_transaction"
   end
 end

--- a/lib/stripe/resources/person.rb
+++ b/lib/stripe/resources/person.rb
@@ -9,7 +9,6 @@ module Stripe
   #
   # Related guide: [Handling identity verification with the API](https://stripe.com/docs/connect/handling-api-verification#person-information)
   class Person < APIResource
-    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "person"

--- a/lib/stripe/resources/reversal.rb
+++ b/lib/stripe/resources/reversal.rb
@@ -16,7 +16,6 @@ module Stripe
   #
   # Related guide: [Reversing transfers](https://stripe.com/docs/connect/separate-charges-and-transfers#reversing-transfers)
   class Reversal < APIResource
-    extend Stripe::APIOperations::List
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "transfer_reversal"

--- a/lib/stripe/resources/tax_id.rb
+++ b/lib/stripe/resources/tax_id.rb
@@ -8,7 +8,6 @@ module Stripe
   # Related guides: [Customer tax identification numbers](https://stripe.com/docs/billing/taxes/tax-ids), [Account tax IDs](https://stripe.com/docs/invoicing/connect#account-tax-ids)
   class TaxId < APIResource
     include Stripe::APIOperations::Delete
-    extend Stripe::APIOperations::List
 
     OBJECT_NAME = "tax_id"
 


### PR DESCRIPTION
See #1316 for tests that prove that this is the case.

## Changelog

Removes list method mixin from child resources, as these methods always return `InvalidRequestError` and never succeed