### PR TITLE
Remove internal usages of _search

### DIFF
--- a/lib/stripe/search_result_object.rb
+++ b/lib/stripe/search_result_object.rb
@@ -80,7 +80,7 @@ module Stripe
 
       params = filters.merge(page: next_page).merge(params)
 
-      _search(url, params, opts)
+      request_stripe_object(method: :get, path: url, params: params, opts: opts)
     end
   end
 end


### PR DESCRIPTION
There was an internal usages of the `Stripe::SearchResultObject#_search` method we deprecated in https://github.com/stripe/stripe-ruby/pull/1311.

https://github.com/stripe/stripe-ruby/issues/1319 can be resolved after this change goes out in the next release