### PR TITLE
Extract other CRUDL api operations from mixins

### DIFF
--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -10,7 +10,6 @@ module Stripe
   # account has started to go through Connect Onboarding. Once you create an [Account Link](https://stripe.com/docs/api/account_links) or [Account Session](https://stripe.com/docs/api/account_sessions),
   # some properties are only returned for Custom accounts. Learn about the differences [between accounts](https://stripe.com/docs/connect/accounts).
   class Account < APIResource
-    extend Gem::Deprecate
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
@@ -194,6 +193,67 @@ module Stripe
         update_hash[i.to_s] = update
       end
       update_hash
+    end
+
+    # With [Connect](https://stripe.com/docs/connect), you can create Stripe accounts for your users.
+    # To do this, you'll first need to [register your platform](https://dashboard.stripe.com/account/applications/settings).
+    #
+    # If you've already collected information for your connected accounts, you [can prefill that information](https://stripe.com/docs/connect/best-practices#onboarding) when
+    # creating the account. Connect Onboarding won't ask for the prefilled information during account onboarding.
+    # You can prefill any information on the account.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/accounts", params: params, opts: opts)
+    end
+
+    # With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.
+    #
+    # Accounts created using test-mode keys can be deleted at any time. Standard accounts created using live-mode keys cannot be deleted. Custom or Express accounts created using live-mode keys can only be deleted once all balances are zero.
+    #
+    # If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/accounts/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.
+    #
+    # Accounts created using test-mode keys can be deleted at any time. Standard accounts created using live-mode keys cannot be deleted. Custom or Express accounts created using live-mode keys can only be deleted once all balances are zero.
+    #
+    # If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/accounts/%<account>s", { account: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of accounts connected to your platform via [Connect](https://stripe.com/docs/connect). If you're not a platform, the list is empty.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/accounts", params: filters, opts: opts)
+    end
+
+    # Updates a [connected account](https://stripe.com/docs/connect/accounts) by setting the values of the parameters passed. Any parameters not provided are
+    # left unchanged.
+    #
+    # For Custom accounts, you can update any information on the account. For other accounts, you can update all information until that
+    # account has started to go through Connect Onboarding. Once you create an [Account Link or <a href="/docs/api/account_sessions">Account Session](https://stripe.com/docs/api/account_links),
+    # some properties can only be changed or updated for Custom accounts.
+    #
+    # To update your own account, use the [Dashboard](https://dashboard.stripe.com/settings/account). Refer to our
+    # [Connect](https://stripe.com/docs/connect/updating-accounts) documentation to learn more about updating accounts.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/accounts/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/account_link.rb
+++ b/lib/stripe/resources/account_link.rb
@@ -10,5 +10,10 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "account_link"
+
+    # Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/account_links", params: params, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/account_session.rb
+++ b/lib/stripe/resources/account_session.rb
@@ -13,5 +13,10 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "account_session"
+
+    # Creates a AccountSession object that includes a single-use token that the platform can use on their front-end to grant client-side API access.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/account_sessions", params: params, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/apple_pay_domain.rb
+++ b/lib/stripe/resources/apple_pay_domain.rb
@@ -13,5 +13,45 @@ module Stripe
     def self.resource_url
       "/v1/apple_pay/domains"
     end
+
+    # Create an apple pay domain.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/apple_pay/domains",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Delete an apple pay domain.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/apple_pay/domains/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Delete an apple pay domain.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/apple_pay/domains/%<domain>s", { domain: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # List apple pay domains.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/apple_pay/domains",
+        params: filters,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/application_fee.rb
+++ b/lib/stripe/resources/application_fee.rb
@@ -9,5 +9,10 @@ module Stripe
     OBJECT_NAME = "application_fee"
 
     nested_resource_class_methods :refund, operations: %i[create retrieve update list]
+
+    # Returns a list of application fees you've previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/application_fees", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/apps/secret.rb
+++ b/lib/stripe/resources/apps/secret.rb
@@ -37,6 +37,16 @@ module Stripe
           opts: opts
         )
       end
+
+      # Create or replace a secret in the secret store.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(method: :post, path: "/v1/apps/secrets", params: params, opts: opts)
+      end
+
+      # List all secrets stored on the given scope.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(method: :get, path: "/v1/apps/secrets", params: filters, opts: opts)
+      end
     end
   end
 end

--- a/lib/stripe/resources/balance_transaction.rb
+++ b/lib/stripe/resources/balance_transaction.rb
@@ -10,5 +10,17 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "balance_transaction"
+
+    # Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.
+    #
+    # Note that this endpoint was previously called “Balance history” and used the path /v1/balance/history.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/balance_transactions",
+        params: filters,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/bank_account.rb
+++ b/lib/stripe/resources/bank_account.rb
@@ -46,5 +46,32 @@ module Stripe
             "or `Account.retrieve_external_account('account_id', " \
             "'bank_account_id')`"
     end
+
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: "#{resource_url}/#{id}",
+        params: params,
+        opts: opts
+      )
+    end
+
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: resource_url.to_s,
+        params: params,
+        opts: opts
+      )
+    end
+
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: resource_url.to_s,
+        params: filters,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/billing_portal/configuration.rb
+++ b/lib/stripe/resources/billing_portal/configuration.rb
@@ -10,6 +10,36 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "billing_portal.configuration"
+
+      # Creates a configuration that describes the functionality and behavior of a PortalSession
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/billing_portal/configurations",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of configurations that describe the functionality of the customer portal.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/billing_portal/configurations",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a configuration that describes the functionality of the customer portal.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/billing_portal/configurations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/billing_portal/session.rb
+++ b/lib/stripe/resources/billing_portal/session.rb
@@ -21,6 +21,16 @@ module Stripe
       extend Stripe::APIOperations::Create
 
       OBJECT_NAME = "billing_portal.session"
+
+      # Creates a session of the customer portal.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/billing_portal/sessions",
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/card.rb
+++ b/lib/stripe/resources/card.rb
@@ -37,5 +37,32 @@ module Stripe
             "'customer_id', 'card_id')` or " \
             "`Account.retrieve_external_account('account_id', 'card_id')`"
     end
+
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: "#{resource_url}/#{id}",
+        params: params,
+        opts: opts
+      )
+    end
+
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: resource_url.to_s,
+        params: params,
+        opts: opts
+      )
+    end
+
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: resource_url.to_s,
+        params: filters,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/charge.rb
+++ b/lib/stripe/resources/charge.rb
@@ -42,12 +42,34 @@ module Stripe
       )
     end
 
+    # This method is no longer recommended—use the [Payment Intents API](https://stripe.com/docs/api/payment_intents)
+    # to initiate a new payment instead. Confirmation of the PaymentIntent creates the Charge
+    # object used to request payment.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/charges", params: params, opts: opts)
+    end
+
+    # Returns a list of charges you've previously created. The charges are returned in sorted order, with the most recent charges appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/charges", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(method: :get, path: "/v1/charges/search", params: params, opts: opts)
     end
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/charges/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/checkout/session.rb
+++ b/lib/stripe/resources/checkout/session.rb
@@ -66,6 +66,26 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates a Session object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/checkout/sessions",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Checkout Sessions.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/checkout/sessions",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/climate/order.rb
+++ b/lib/stripe/resources/climate/order.rb
@@ -37,6 +37,28 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates a Climate order object for a given Climate product. The order will be processed immediately
+      # after creation and payment will be deducted your Stripe balance.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(method: :post, path: "/v1/climate/orders", params: params, opts: opts)
+      end
+
+      # Lists all Climate order objects. The orders are returned sorted by creation date, with the
+      # most recently created orders appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(method: :get, path: "/v1/climate/orders", params: filters, opts: opts)
+      end
+
+      # Updates the specified order by setting the values of the parameters passed.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/climate/orders/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/climate/product.rb
+++ b/lib/stripe/resources/climate/product.rb
@@ -9,6 +9,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "climate.product"
+
+      # Lists all available Climate product objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/climate/products",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/climate/supplier.rb
+++ b/lib/stripe/resources/climate/supplier.rb
@@ -8,6 +8,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "climate.supplier"
+
+      # Lists all available Climate supplier objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/climate/suppliers",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/country_spec.rb
+++ b/lib/stripe/resources/country_spec.rb
@@ -12,5 +12,10 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "country_spec"
+
+    # Lists all Country Spec objects available in the API.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/country_specs", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/coupon.rb
+++ b/lib/stripe/resources/coupon.rb
@@ -12,5 +12,47 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "coupon"
+
+    # You can create coupons easily via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.
+    #
+    # A coupon has either a percent_off or an amount_off and currency. If you set an amount_off, that amount will be subtracted from any invoice's subtotal. For example, an invoice with a subtotal of 100 will have a final total of 0 if a coupon with an amount_off of 200 is applied to it and an invoice with a subtotal of 300 will have a final total of 100 if a coupon with an amount_off of 200 is applied to it.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/coupons", params: params, opts: opts)
+    end
+
+    # You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/coupons/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can't redeem the coupon. You can also delete coupons via the API.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/coupons/%<coupon>s", { coupon: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your coupons.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/coupons", params: filters, opts: opts)
+    end
+
+    # Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/coupons/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/credit_note.rb
+++ b/lib/stripe/resources/credit_note.rb
@@ -51,5 +51,38 @@ module Stripe
         opts: opts
       )
     end
+
+    # Issue a credit note to adjust the amount of a finalized invoice. For a status=open invoice, a credit note reduces
+    # its amount_due. For a status=paid invoice, a credit note does not affect its amount_due. Instead, it can result
+    # in any combination of the following:
+    #
+    #
+    # Refund: create a new refund (using refund_amount) or link an existing refund (using refund).
+    # Customer balance credit: credit the customer's balance (using credit_amount) which will be automatically applied to their next invoice when it's finalized.
+    # Outside of Stripe credit: record the amount that is or will be credited outside of Stripe (using out_of_band_amount).
+    #
+    #
+    # For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts must equal the credit note total.
+    #
+    # You may issue multiple credit notes for an invoice. Each credit note will increment the invoice's pre_payment_credit_notes_amount
+    # or post_payment_credit_notes_amount depending on its status at the time of credit note creation.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/credit_notes", params: params, opts: opts)
+    end
+
+    # Returns a list of credit notes.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/credit_notes", params: filters, opts: opts)
+    end
+
+    # Updates an existing credit note.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/credit_notes/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/customer.rb
+++ b/lib/stripe/resources/customer.rb
@@ -113,12 +113,54 @@ module Stripe
       alias detach_source delete_source
     end
 
+    # Creates a new customer object.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/customers", params: params, opts: opts)
+    end
+
+    # Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/customers/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/customers/%<customer>s", { customer: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/customers", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(method: :get, path: "/v1/customers/search", params: params, opts: opts)
     end
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the source parameter, that becomes the customer's active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the source parameter: for each of the customer's current subscriptions, if the subscription bills automatically and is in the past_due state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the default_source for a customer will not trigger this behavior.
+    #
+    # This request accepts mostly the same arguments as the customer creation call.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/customers/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
 
     # Retrieves a customer's cash balance.

--- a/lib/stripe/resources/customer_session.rb
+++ b/lib/stripe/resources/customer_session.rb
@@ -8,5 +8,15 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "customer_session"
+
+    # Creates a customer session object that includes a single-use client secret that you can use on your front-end to grant client-side API access for certain customer resources.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/customer_sessions",
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/dispute.rb
+++ b/lib/stripe/resources/dispute.rb
@@ -36,5 +36,22 @@ module Stripe
         opts: opts
       )
     end
+
+    # Returns a list of your disputes.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/disputes", params: filters, opts: opts)
+    end
+
+    # When you get a dispute, contacting your customer is always the best first step. If that doesn't work, you can submit evidence to help us resolve the dispute in your favor. You can do this in your [dashboard](https://dashboard.stripe.com/disputes), but if you prefer, you can use the API to submit evidence programmatically.
+    #
+    # Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our [guide to dispute types](https://stripe.com/docs/disputes/categories).
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/disputes/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/ephemeral_key.rb
+++ b/lib/stripe/resources/ephemeral_key.rb
@@ -16,5 +16,25 @@ module Stripe
       end
       super
     end
+
+    # Invalidates a short-lived API key for a given resource.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/ephemeral_keys/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Invalidates a short-lived API key for a given resource.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/ephemeral_keys/%<key>s", { key: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/event.rb
+++ b/lib/stripe/resources/event.rb
@@ -36,5 +36,10 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "event"
+
+    # List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://stripe.com/docs/api/events/object) api_version attribute (not according to your current Stripe API version or Stripe-Version header).
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/events", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/exchange_rate.rb
+++ b/lib/stripe/resources/exchange_rate.rb
@@ -32,5 +32,10 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "exchange_rate"
+
+    # Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/exchange_rates", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/file.rb
+++ b/lib/stripe/resources/file.rb
@@ -37,5 +37,10 @@ module Stripe
       }.merge(Util.normalize_opts(opts))
       super
     end
+
+    # Returns a list of the files that your account has access to. Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/files", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/file_link.rb
+++ b/lib/stripe/resources/file_link.rb
@@ -11,5 +11,25 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "file_link"
+
+    # Creates a new file link object.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/file_links", params: params, opts: opts)
+    end
+
+    # Returns a list of file links.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/file_links", params: filters, opts: opts)
+    end
+
+    # Updates an existing file link object. Expired links can no longer be updated.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/file_links/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/financial_connections/account.rb
+++ b/lib/stripe/resources/financial_connections/account.rb
@@ -108,6 +108,16 @@ module Stripe
           opts: opts
         )
       end
+
+      # Returns a list of Financial Connections Account objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/financial_connections/accounts",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/financial_connections/session.rb
+++ b/lib/stripe/resources/financial_connections/session.rb
@@ -8,6 +8,16 @@ module Stripe
       extend Stripe::APIOperations::Create
 
       OBJECT_NAME = "financial_connections.session"
+
+      # To launch the Financial Connections authorization flow, create a Session. The session's client_secret can be used to launch the flow using Stripe.js.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/financial_connections/sessions",
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/financial_connections/transaction.rb
+++ b/lib/stripe/resources/financial_connections/transaction.rb
@@ -8,6 +8,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "financial_connections.transaction"
+
+      # Returns a list of Financial Connections Transaction objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/financial_connections/transactions",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/identity/verification_report.rb
+++ b/lib/stripe/resources/identity/verification_report.rb
@@ -18,6 +18,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "identity.verification_report"
+
+      # List all verification reports.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/identity/verification_reports",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/identity/verification_session.rb
+++ b/lib/stripe/resources/identity/verification_session.rb
@@ -100,6 +100,45 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates a VerificationSession object.
+      #
+      # After the VerificationSession is created, display a verification modal using the session client_secret or send your users to the session's url.
+      #
+      # If your API key is in test mode, verification checks won't actually process, though everything else will occur as if in live mode.
+      #
+      # Related guide: [Verify your users' identity documents](https://stripe.com/docs/identity/verify-identity-documents)
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/identity/verification_sessions",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of VerificationSessions
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/identity/verification_sessions",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a VerificationSession object.
+      #
+      # When the session status is requires_input, you can use this method to update the
+      # verification check and options.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/identity/verification_sessions/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/invoice.rb
+++ b/lib/stripe/resources/invoice.rb
@@ -166,12 +166,57 @@ module Stripe
       )
     end
 
+    # This endpoint creates a draft invoice for a given customer. The invoice remains a draft until you [finalize the invoice, which allows you to [pay](#pay_invoice) or <a href="#send_invoice">send](https://stripe.com/docs/api#finalize_invoice) the invoice to your customers.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/invoices", params: params, opts: opts)
+    end
+
+    # Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/invoices/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/invoices/%<invoice>s", { invoice: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/invoices", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(method: :get, path: "/v1/invoices/search", params: params, opts: opts)
     end
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Draft invoices are fully editable. Once an invoice is [finalized](https://stripe.com/docs/billing/invoices/workflow#finalized),
+    # monetary values, as well as collection_method, become uneditable.
+    #
+    # If you would like to stop the Stripe Billing engine from automatically finalizing, reattempting payments on,
+    # sending reminders for, or [automatically reconciling](https://stripe.com/docs/billing/invoices/reconciliation) invoices, pass
+    # auto_advance=false.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/invoices/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/invoice_item.rb
+++ b/lib/stripe/resources/invoice_item.rb
@@ -20,5 +20,45 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "invoiceitem"
+
+    # Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is specified, the item will be on the next invoice created for the customer specified.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/invoiceitems", params: params, opts: opts)
+    end
+
+    # Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/invoiceitems/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they're not attached to invoices, or if it's attached to a draft invoice.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/invoiceitems/%<invoiceitem>s", { invoiceitem: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/invoiceitems", params: filters, opts: opts)
+    end
+
+    # Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it's attached to is closed.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/invoiceitems/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/issuing/authorization.rb
+++ b/lib/stripe/resources/issuing/authorization.rb
@@ -58,6 +58,26 @@ module Stripe
         )
       end
 
+      # Returns a list of Issuing Authorization objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/issuing/authorizations",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates the specified Issuing Authorization object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/authorizations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/issuing/card.rb
+++ b/lib/stripe/resources/issuing/card.rb
@@ -11,6 +11,26 @@ module Stripe
 
       OBJECT_NAME = "issuing.card"
 
+      # Creates an Issuing Card object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(method: :post, path: "/v1/issuing/cards", params: params, opts: opts)
+      end
+
+      # Returns a list of Issuing Card objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(method: :get, path: "/v1/issuing/cards", params: filters, opts: opts)
+      end
+
+      # Updates the specified Issuing Card object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/cards/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/issuing/cardholder.rb
+++ b/lib/stripe/resources/issuing/cardholder.rb
@@ -12,6 +12,36 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "issuing.cardholder"
+
+      # Creates a new Issuing Cardholder object that can be issued cards.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/issuing/cardholders",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Issuing Cardholder objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/issuing/cardholders",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates the specified Issuing Cardholder object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/cardholders/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/issuing/dispute.rb
+++ b/lib/stripe/resources/issuing/dispute.rb
@@ -32,6 +32,36 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates an Issuing Dispute object. Individual pieces of evidence within the evidence object are optional at this point. Stripe only validates that required evidence is present during submission. Refer to [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence) for more details about evidence requirements.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/issuing/disputes",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Issuing Dispute objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/issuing/disputes",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates the specified Issuing Dispute object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Properties on the evidence object can be unset by passing in an empty string.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/disputes/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/issuing/token.rb
+++ b/lib/stripe/resources/issuing/token.rb
@@ -9,6 +9,21 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "issuing.token"
+
+      # Lists all Issuing Token objects for a given card.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(method: :get, path: "/v1/issuing/tokens", params: filters, opts: opts)
+      end
+
+      # Attempts to update the specified Issuing Token object to the status specified.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/tokens/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/issuing/transaction.rb
+++ b/lib/stripe/resources/issuing/transaction.rb
@@ -14,6 +14,26 @@ module Stripe
 
       OBJECT_NAME = "issuing.transaction"
 
+      # Returns a list of Issuing Transaction objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/issuing/transactions",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates the specified Issuing Transaction object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/issuing/transactions/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/payment_intent.rb
+++ b/lib/stripe/resources/payment_intent.rb
@@ -247,6 +247,25 @@ module Stripe
       )
     end
 
+    # Creates a PaymentIntent object.
+    #
+    # After the PaymentIntent is created, attach a payment method and [confirm](https://stripe.com/docs/api/payment_intents/confirm)
+    # to continue the payment. Learn more about <a href="/docs/payments/payment-intents">the available payment flows
+    # with the Payment Intents API.
+    #
+    # When you use confirm=true during creation, it's equivalent to creating
+    # and confirming the PaymentIntent in the same call. You can use any parameters
+    # available in the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) when you supply
+    # confirm=true.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/payment_intents", params: params, opts: opts)
+    end
+
+    # Returns a list of PaymentIntents.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/payment_intents", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(
         method: :get,
@@ -258,6 +277,22 @@ module Stripe
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates properties on a PaymentIntent object without confirming.
+    #
+    # Depending on which properties you update, you might need to confirm the
+    # PaymentIntent again. For example, updating the payment_method
+    # always requires you to confirm the PaymentIntent again. If you prefer to
+    # update and confirm at the same time, we recommend updating properties through
+    # the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) instead.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payment_intents/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/payment_link.rb
+++ b/lib/stripe/resources/payment_link.rb
@@ -33,5 +33,25 @@ module Stripe
         opts: opts
       )
     end
+
+    # Creates a payment link.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/payment_links", params: params, opts: opts)
+    end
+
+    # Returns a list of your payment links.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/payment_links", params: filters, opts: opts)
+    end
+
+    # Updates a payment link.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payment_links/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/payment_method.rb
+++ b/lib/stripe/resources/payment_method.rb
@@ -77,5 +77,27 @@ module Stripe
         opts: opts
       )
     end
+
+    # Creates a PaymentMethod object. Read the [Stripe.js reference](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method) to learn how to create PaymentMethods via Stripe.js.
+    #
+    # Instead of creating a PaymentMethod directly, we recommend using the [PaymentIntents API to accept a payment immediately or the <a href="/docs/payments/save-and-reuse">SetupIntent](https://stripe.com/docs/payments/accept-a-payment) API to collect payment method details ahead of a future payment.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/payment_methods", params: params, opts: opts)
+    end
+
+    # Returns a list of PaymentMethods for Treasury flows. If you want to list the PaymentMethods attached to a Customer for payments, you should use the [List a Customer's PaymentMethods](https://stripe.com/docs/api/payment_methods/customer_list) API instead.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/payment_methods", params: filters, opts: opts)
+    end
+
+    # Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payment_methods/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/payment_method_configuration.rb
+++ b/lib/stripe/resources/payment_method_configuration.rb
@@ -22,5 +22,35 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "payment_method_configuration"
+
+    # Creates a payment method configuration
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/payment_method_configurations",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # List payment method configurations
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/payment_method_configurations",
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # Update payment method configuration
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payment_method_configurations/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/payment_method_domain.rb
+++ b/lib/stripe/resources/payment_method_domain.rb
@@ -42,5 +42,35 @@ module Stripe
         opts: opts
       )
     end
+
+    # Creates a payment method domain.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/payment_method_domains",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Lists the details of existing payment method domains.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/payment_method_domains",
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # Updates an existing payment method domain.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payment_method_domains/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/payout.rb
+++ b/lib/stripe/resources/payout.rb
@@ -60,5 +60,29 @@ module Stripe
         opts: opts
       )
     end
+
+    # To send funds to your own bank account, create a new payout object. Your [Stripe balance](https://stripe.com/docs/api#balance) must cover the payout amount. If it doesn't, you receive an “Insufficient Funds” error.
+    #
+    # If your API key is in test mode, money won't actually be sent, though every other action occurs as if you're in live mode.
+    #
+    # If you create a manual payout on a Stripe account that uses multiple payment source types, you need to specify the source type balance that the payout draws from. The [balance object](https://stripe.com/docs/api#balance_object) details available and pending amounts by source type.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/payouts", params: params, opts: opts)
+    end
+
+    # Returns a list of existing payouts sent to third-party bank accounts or payouts that Stripe sent to you. The payouts return in sorted order, with the most recently created payouts appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/payouts", params: filters, opts: opts)
+    end
+
+    # Updates the specified payout by setting the values of the parameters you pass. We don't change parameters that you don't provide. This request only accepts the metadata as arguments.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/payouts/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/plan.rb
+++ b/lib/stripe/resources/plan.rb
@@ -17,5 +17,45 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "plan"
+
+    # You can now model subscriptions more flexibly using the [Prices API](https://stripe.com/docs/api#prices). It replaces the Plans API and is backwards compatible to simplify your migration.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/plans", params: params, opts: opts)
+    end
+
+    # Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/plans/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Deleting plans means new subscribers can't be added. Existing subscribers aren't affected.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/plans/%<plan>s", { plan: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your plans.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/plans", params: filters, opts: opts)
+    end
+
+    # Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan's ID, amount, currency, or billing cycle.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/plans/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/price.rb
+++ b/lib/stripe/resources/price.rb
@@ -16,12 +16,32 @@ module Stripe
 
     OBJECT_NAME = "price"
 
+    # Creates a new price for an existing product. The price can be recurring or one-time.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/prices", params: params, opts: opts)
+    end
+
+    # Returns a list of your active prices, excluding [inline prices](https://stripe.com/docs/products-prices/pricing-models#inline-pricing). For the list of inactive prices, set active to false.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/prices", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(method: :get, path: "/v1/prices/search", params: params, opts: opts)
     end
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/prices/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/product.rb
+++ b/lib/stripe/resources/product.rb
@@ -19,12 +19,52 @@ module Stripe
 
     OBJECT_NAME = "product"
 
+    # Creates a new product object.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/products", params: params, opts: opts)
+    end
+
+    # Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/products/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with type=good is only possible if it has no SKUs associated with it.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/products/%<id>s", { id: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/products", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(method: :get, path: "/v1/products/search", params: params, opts: opts)
     end
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/products/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/promotion_code.rb
+++ b/lib/stripe/resources/promotion_code.rb
@@ -10,5 +10,25 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "promotion_code"
+
+    # A promotion code points to a coupon. You can optionally restrict the code to a specific customer, redemption limit, and expiration date.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/promotion_codes", params: params, opts: opts)
+    end
+
+    # Returns a list of your promotion codes.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/promotion_codes", params: filters, opts: opts)
+    end
+
+    # Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/promotion_codes/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/quote.rb
+++ b/lib/stripe/resources/quote.rb
@@ -136,5 +136,25 @@ module Stripe
         &read_body_chunk_block
       )
     end
+
+    # A quote models prices and services for a customer. Default options for header, description, footer, and expires_at can be set in the dashboard via the [quote template](https://dashboard.stripe.com/settings/billing/quote).
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/quotes", params: params, opts: opts)
+    end
+
+    # Returns a list of your quotes.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/quotes", params: filters, opts: opts)
+    end
+
+    # A quote models prices and services for a customer.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/quotes/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/radar/early_fraud_warning.rb
+++ b/lib/stripe/resources/radar/early_fraud_warning.rb
@@ -11,6 +11,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "radar.early_fraud_warning"
+
+      # Returns a list of early fraud warnings.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/radar/early_fraud_warnings",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/radar/value_list.rb
+++ b/lib/stripe/resources/radar/value_list.rb
@@ -13,6 +13,56 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "radar.value_list"
+
+      # Creates a new ValueList object, which can then be referenced in rules.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/radar/value_lists",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/radar/value_lists/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a ValueList object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/radar/value_lists/%<value_list>s", { value_list: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of ValueList objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/radar/value_lists",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a ValueList object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that item_type is immutable.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/radar/value_lists/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/radar/value_list_item.rb
+++ b/lib/stripe/resources/radar/value_list_item.rb
@@ -12,6 +12,46 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "radar.value_list_item"
+
+      # Creates a new ValueListItem object, which is added to the specified parent value list.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/radar/value_list_items",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a ValueListItem object, removing it from its parent value list.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/radar/value_list_items/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a ValueListItem object, removing it from its parent value list.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/radar/value_list_items/%<item>s", { item: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of ValueListItem objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/radar/value_list_items",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/refund.rb
+++ b/lib/stripe/resources/refund.rb
@@ -38,6 +38,42 @@ module Stripe
       )
     end
 
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: format("/v1/refunds"),
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.
+    #
+    # Creating a new refund will refund a charge that has previously been created but not yet refunded.
+    # Funds will be refunded to the credit or debit card that was originally charged.
+    #
+    # You can optionally refund only part of a charge.
+    # You can do so multiple times, until the entire charge has been refunded.
+    #
+    # Once entirely refunded, a charge can't be refunded again.
+    # This method will raise an error when called on an already-refunded charge,
+    # or when trying to refund more money than is left on a charge.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/refunds", params: params, opts: opts)
+    end
+
+    # Updates the refund that you specify by setting the values of the passed parameters. Any parameters that you don't provide remain unchanged.
+    #
+    # This request only accepts metadata as an argument.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/refunds/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
     def test_helpers
       TestHelpers.new(self)
     end

--- a/lib/stripe/resources/reporting/report_run.rb
+++ b/lib/stripe/resources/reporting/report_run.rb
@@ -16,6 +16,26 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "reporting.report_run"
+
+      # Creates a new object and begin running the report. (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/reporting/report_runs",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Report Runs, with the most recent appearing first.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/reporting/report_runs",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/reporting/report_type.rb
+++ b/lib/stripe/resources/reporting/report_type.rb
@@ -15,6 +15,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "reporting.report_type"
+
+      # Returns a full list of Report Types.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/reporting/report_types",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/review.rb
+++ b/lib/stripe/resources/review.rb
@@ -30,5 +30,10 @@ module Stripe
         opts: opts
       )
     end
+
+    # Returns a list of Review objects that have open set to true. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/reviews", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/setup_attempt.rb
+++ b/lib/stripe/resources/setup_attempt.rb
@@ -10,5 +10,10 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "setup_attempt"
+
+    # Returns a list of SetupAttempts that associate with a provided SetupIntent.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/setup_attempts", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/setup_intent.rb
+++ b/lib/stripe/resources/setup_intent.rb
@@ -119,5 +119,28 @@ module Stripe
         opts: opts
       )
     end
+
+    # Creates a SetupIntent object.
+    #
+    # After you create the SetupIntent, attach a payment method and [confirm](https://stripe.com/docs/api/setup_intents/confirm)
+    # it to collect any required permissions to charge the payment method later.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/setup_intents", params: params, opts: opts)
+    end
+
+    # Returns a list of SetupIntents.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/setup_intents", params: filters, opts: opts)
+    end
+
+    # Updates a SetupIntent object.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/setup_intents/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/shipping_rate.rb
+++ b/lib/stripe/resources/shipping_rate.rb
@@ -10,5 +10,25 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "shipping_rate"
+
+    # Creates a new shipping rate object.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/shipping_rates", params: params, opts: opts)
+    end
+
+    # Returns a list of your shipping rates.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/shipping_rates", params: filters, opts: opts)
+    end
+
+    # Updates an existing shipping rate object.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/shipping_rates/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/sigma/scheduled_query_run.rb
+++ b/lib/stripe/resources/sigma/scheduled_query_run.rb
@@ -15,6 +15,16 @@ module Stripe
       def self.resource_url
         "/v1/sigma/scheduled_query_runs"
       end
+
+      # Returns a list of scheduled query runs.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/sigma/scheduled_query_runs",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/source.rb
+++ b/lib/stripe/resources/source.rb
@@ -64,5 +64,22 @@ module Stripe
     end
     extend Gem::Deprecate
     deprecate :source_transactions, :"Source.list_source_transactions", 2020, 1
+
+    # Creates a new source object.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/sources", params: params, opts: opts)
+    end
+
+    # Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+    #
+    # This request accepts the metadata and owner as arguments. It is also possible to update type specific information for selected payment methods. Please refer to our [payment method guides](https://stripe.com/docs/sources) for more detail.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/sources/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/subscription.rb
+++ b/lib/stripe/resources/subscription.rb
@@ -83,6 +83,22 @@ module Stripe
 
     save_nested_resource :source
 
+    # Creates a new subscription on an existing customer. Each customer can have up to 500 active or scheduled subscriptions.
+    #
+    # When you create a subscription with collection_method=charge_automatically, the first invoice is finalized as part of the request.
+    # The payment_behavior parameter determines the exact behavior of the initial payment.
+    #
+    # To start subscriptions where the first invoice always begins in a draft status, use [subscription schedules](https://stripe.com/docs/billing/subscriptions/subscription-schedules#managing) instead.
+    # Schedules provide the flexibility to model more complex billing configurations that change over time.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/subscriptions", params: params, opts: opts)
+    end
+
+    # By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify status=canceled.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/subscriptions", params: filters, opts: opts)
+    end
+
     def self.search(params = {}, opts = {})
       request_stripe_object(
         method: :get,
@@ -94,6 +110,36 @@ module Stripe
 
     def self.search_auto_paging_each(params = {}, opts = {}, &blk)
       search(params, opts).auto_paging_each(&blk)
+    end
+
+    # Updates an existing subscription to match the specified parameters.
+    # When changing prices or quantities, we optionally prorate the price we charge next month to make up for any price changes.
+    # To preview how the proration is calculated, use the [upcoming invoice](https://stripe.com/docs/api/invoices/upcoming) endpoint.
+    #
+    # By default, we prorate subscription changes. For example, if a customer signs up on May 1 for a 100 price, they'll be billed 100 immediately. If on May 15 they switch to a 200 price, then on June 1 they'll be billed 250 (200 for a renewal of her subscription, plus a 50 prorating adjustment for half of the previous month's 100 difference). Similarly, a downgrade generates a credit that is applied to the next invoice. We also prorate when you make quantity changes.
+    #
+    # Switching prices does not normally change the billing date or generate an immediate charge unless:
+    #
+    #
+    # The billing interval is changed (for example, from monthly to yearly).
+    # The subscription moves from free to paid, or paid to free.
+    # A trial starts or ends.
+    #
+    #
+    # In these cases, we apply a credit for the unused time on the previous price, immediately charge the customer using the new price, and reset the billing date.
+    #
+    # If you want to charge for an upgrade immediately, pass proration_behavior as always_invoice to create prorations, automatically invoice the customer for those proration adjustments, and attempt to collect payment. If you pass create_prorations, the prorations are created but not automatically invoiced. If you want to bill the customer for the prorations before the subscription's renewal date, you need to manually [invoice the customer](https://stripe.com/docs/api/invoices/create).
+    #
+    # If you don't want to prorate, set the proration_behavior option to none. With this option, the customer is billed 100 on May 1 and 200 on June 1. Similarly, if you set proration_behavior to none when switching between different billing intervals (for example, from monthly to yearly), we don't generate any credits for the old subscription's unused time. We still reset the billing date and bill immediately for the new subscription.
+    #
+    # Updating the quantity on a subscription many times in an hour may result in [rate limiting. If you need to bill for a frequently changing quantity, consider integrating <a href="/docs/billing/subscriptions/usage-based">usage-based billing](https://stripe.com/docs/rate-limits) instead.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/subscriptions/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
     end
   end
 end

--- a/lib/stripe/resources/subscription_item.rb
+++ b/lib/stripe/resources/subscription_item.rb
@@ -17,5 +17,55 @@ module Stripe
     nested_resource_class_methods :usage_record_summary,
                                   operations: %i[list],
                                   resource_plural: "usage_record_summaries"
+
+    # Adds a new item to an existing subscription. No existing items will be changed or replaced.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/subscription_items",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/subscription_items/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/subscription_items/%<item>s", { item: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your subscription items for a given subscription.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/subscription_items",
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # Updates the plan or quantity of an item on a current subscription.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/subscription_items/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/subscription_schedule.rb
+++ b/lib/stripe/resources/subscription_schedule.rb
@@ -51,5 +51,35 @@ module Stripe
         opts: opts
       )
     end
+
+    # Creates a new subscription schedule object. Each customer can have up to 500 active or scheduled subscriptions.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/subscription_schedules",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Retrieves the list of your subscription schedules.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/subscription_schedules",
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # Updates an existing subscription schedule.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/subscription_schedules/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/tax/calculation.rb
+++ b/lib/stripe/resources/tax/calculation.rb
@@ -30,6 +30,16 @@ module Stripe
           opts: opts
         )
       end
+
+      # Calculates tax based on input and returns a Tax Calculation object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/tax/calculations",
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/tax/registration.rb
+++ b/lib/stripe/resources/tax/registration.rb
@@ -14,6 +14,38 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "tax.registration"
+
+      # Creates a new Tax Registration object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/tax/registrations",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Tax Registration objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/tax/registrations",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates an existing Tax Registration object.
+      #
+      # A registration cannot be deleted after it has been created. If you wish to end a registration you may do so by setting expires_at.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/tax/registrations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/tax_code.rb
+++ b/lib/stripe/resources/tax_code.rb
@@ -7,5 +7,10 @@ module Stripe
     extend Stripe::APIOperations::List
 
     OBJECT_NAME = "tax_code"
+
+    # A list of [all tax codes available](https://stripe.com/docs/tax/tax-categories) to add to Products in order to allow specific tax calculations.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/tax_codes", params: filters, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/tax_id.rb
+++ b/lib/stripe/resources/tax_id.rb
@@ -26,5 +26,25 @@ module Stripe
             "tax ID using `Customer.retrieve_tax_id('customer_id', " \
             "'tax_id_id')`"
     end
+
+    # Deletes an existing tax_id object.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/customers/%<customer>s/tax_ids/%<id>s", { customer: CGI.escape(customer), id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Deletes an existing tax_id object.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/customers/%<customer>s/tax_ids/%<id>s", { customer: CGI.escape(self["id"]), id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/tax_rate.rb
+++ b/lib/stripe/resources/tax_rate.rb
@@ -11,5 +11,25 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "tax_rate"
+
+    # Creates a new tax rate.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/tax_rates", params: params, opts: opts)
+    end
+
+    # Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/tax_rates", params: filters, opts: opts)
+    end
+
+    # Updates an existing tax rate.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/tax_rates/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/terminal/configuration.rb
+++ b/lib/stripe/resources/terminal/configuration.rb
@@ -11,6 +11,56 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "terminal.configuration"
+
+      # Creates a new Configuration object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/terminal/configurations",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Configuration object.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/configurations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Configuration object.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/configurations/%<configuration>s", { configuration: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Configuration objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/terminal/configurations",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a new Configuration object.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/terminal/configurations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/terminal/connection_token.rb
+++ b/lib/stripe/resources/terminal/connection_token.rb
@@ -10,6 +10,16 @@ module Stripe
       extend Stripe::APIOperations::Create
 
       OBJECT_NAME = "terminal.connection_token"
+
+      # To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server. On your backend, add an endpoint that creates and returns a connection token.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/terminal/connection_tokens",
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/terminal/location.rb
+++ b/lib/stripe/resources/terminal/location.rb
@@ -13,6 +13,57 @@ module Stripe
       include Stripe::APIOperations::Save
 
       OBJECT_NAME = "terminal.location"
+
+      # Creates a new Location object.
+      # For further details, including which address fields are required in each country, see the [Manage locations](https://stripe.com/docs/terminal/fleet/locations) guide.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/terminal/locations",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Location object.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/locations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Location object.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/locations/%<location>s", { location: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Location objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/terminal/locations",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/terminal/locations/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/terminal/reader.rb
+++ b/lib/stripe/resources/terminal/reader.rb
@@ -114,6 +114,56 @@ module Stripe
         )
       end
 
+      # Creates a new Reader object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/terminal/readers",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Reader object.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/readers/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a Reader object.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/terminal/readers/%<reader>s", { reader: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of Reader objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/terminal/readers",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates a Reader object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/terminal/readers/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/test_helpers/test_clock.rb
+++ b/lib/stripe/resources/test_helpers/test_clock.rb
@@ -32,6 +32,46 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates a new test clock that can be attached to new customers and quotes.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/test_helpers/test_clocks",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a test clock.
+      def self.delete(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/test_helpers/test_clocks/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Deletes a test clock.
+      def delete(params = {}, opts = {})
+        request_stripe_object(
+          method: :delete,
+          path: format("/v1/test_helpers/test_clocks/%<test_clock>s", { test_clock: CGI.escape(self["id"]) }),
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of your test clocks.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/test_helpers/test_clocks",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/token.rb
+++ b/lib/stripe/resources/token.rb
@@ -26,5 +26,11 @@ module Stripe
     extend Stripe::APIOperations::Create
 
     OBJECT_NAME = "token"
+
+    # Creates a single-use token that represents a bank account's details.
+    # You can use this token with any API method in place of a bank account dictionary. You can only use this token once. To do so, attach it to a [Custom account](https://stripe.com/docs/api#accounts).
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/tokens", params: params, opts: opts)
+    end
   end
 end

--- a/lib/stripe/resources/topup.rb
+++ b/lib/stripe/resources/topup.rb
@@ -33,5 +33,25 @@ module Stripe
         opts: opts
       )
     end
+
+    # Top up the balance of an account
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/topups", params: params, opts: opts)
+    end
+
+    # Returns a list of top-ups.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/topups", params: filters, opts: opts)
+    end
+
+    # Updates the metadata of a top-up. Other top-up details are not editable by design.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/topups/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/transfer.rb
+++ b/lib/stripe/resources/transfer.rb
@@ -21,5 +21,27 @@ module Stripe
     OBJECT_NAME = "transfer"
 
     nested_resource_class_methods :reversal, operations: %i[create retrieve update list]
+
+    # To send funds from your Stripe account to a connected account, you create a new transfer object. Your [Stripe balance](https://stripe.com/docs/api#balance) must be able to cover the transfer amount, or you'll receive an “Insufficient Funds” error.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(method: :post, path: "/v1/transfers", params: params, opts: opts)
+    end
+
+    # Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(method: :get, path: "/v1/transfers", params: filters, opts: opts)
+    end
+
+    # Updates the specified transfer by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
+    #
+    # This request accepts only metadata as an argument.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/transfers/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end

--- a/lib/stripe/resources/treasury/credit_reversal.rb
+++ b/lib/stripe/resources/treasury/credit_reversal.rb
@@ -9,6 +9,26 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "treasury.credit_reversal"
+
+      # Reverses a ReceivedCredit and creates a CreditReversal object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/credit_reversals",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of CreditReversals.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/credit_reversals",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/treasury/debit_reversal.rb
+++ b/lib/stripe/resources/treasury/debit_reversal.rb
@@ -9,6 +9,26 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "treasury.debit_reversal"
+
+      # Reverses a ReceivedDebit and creates a DebitReversal object.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/debit_reversals",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of DebitReversals.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/debit_reversals",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/treasury/financial_account.rb
+++ b/lib/stripe/resources/treasury/financial_account.rb
@@ -51,6 +51,36 @@ module Stripe
           opts: opts
         )
       end
+
+      # Creates a new FinancialAccount. For now, each connected account can only have one FinancialAccount.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/financial_accounts",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of FinancialAccounts.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/financial_accounts",
+          params: filters,
+          opts: opts
+        )
+      end
+
+      # Updates the details of a FinancialAccount.
+      def self.update(id, params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: format("/v1/treasury/financial_accounts/%<id>s", { id: CGI.escape(id) }),
+          params: params,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/treasury/inbound_transfer.rb
+++ b/lib/stripe/resources/treasury/inbound_transfer.rb
@@ -30,6 +30,26 @@ module Stripe
         )
       end
 
+      # Creates an InboundTransfer.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/inbound_transfers",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of InboundTransfers sent from the specified FinancialAccount.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/inbound_transfers",
+          params: filters,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/treasury/outbound_payment.rb
+++ b/lib/stripe/resources/treasury/outbound_payment.rb
@@ -32,6 +32,26 @@ module Stripe
         )
       end
 
+      # Creates an OutboundPayment.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/outbound_payments",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of OutboundPayments sent from the specified FinancialAccount.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/outbound_payments",
+          params: filters,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/treasury/outbound_transfer.rb
+++ b/lib/stripe/resources/treasury/outbound_transfer.rb
@@ -32,6 +32,26 @@ module Stripe
         )
       end
 
+      # Creates an OutboundTransfer.
+      def self.create(params = {}, opts = {})
+        request_stripe_object(
+          method: :post,
+          path: "/v1/treasury/outbound_transfers",
+          params: params,
+          opts: opts
+        )
+      end
+
+      # Returns a list of OutboundTransfers sent from the specified FinancialAccount.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/outbound_transfers",
+          params: filters,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/treasury/received_credit.rb
+++ b/lib/stripe/resources/treasury/received_credit.rb
@@ -9,6 +9,16 @@ module Stripe
 
       OBJECT_NAME = "treasury.received_credit"
 
+      # Returns a list of ReceivedCredits.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/received_credits",
+          params: filters,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/treasury/received_debit.rb
+++ b/lib/stripe/resources/treasury/received_debit.rb
@@ -9,6 +9,16 @@ module Stripe
 
       OBJECT_NAME = "treasury.received_debit"
 
+      # Returns a list of ReceivedDebits.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/received_debits",
+          params: filters,
+          opts: opts
+        )
+      end
+
       def test_helpers
         TestHelpers.new(self)
       end

--- a/lib/stripe/resources/treasury/transaction.rb
+++ b/lib/stripe/resources/treasury/transaction.rb
@@ -8,6 +8,16 @@ module Stripe
       extend Stripe::APIOperations::List
 
       OBJECT_NAME = "treasury.transaction"
+
+      # Retrieves a list of Transaction objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/transactions",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/treasury/transaction_entry.rb
+++ b/lib/stripe/resources/treasury/transaction_entry.rb
@@ -12,6 +12,16 @@ module Stripe
       def self.resource_url
         "/v1/treasury/transaction_entries"
       end
+
+      # Retrieves a list of TransactionEntry objects.
+      def self.list(filters = {}, opts = {})
+        request_stripe_object(
+          method: :get,
+          path: "/v1/treasury/transaction_entries",
+          params: filters,
+          opts: opts
+        )
+      end
     end
   end
 end

--- a/lib/stripe/resources/webhook_endpoint.rb
+++ b/lib/stripe/resources/webhook_endpoint.rb
@@ -16,5 +16,55 @@ module Stripe
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "webhook_endpoint"
+
+    # A webhook endpoint must have a url and a list of enabled_events. You may optionally specify the Boolean connect parameter. If set to true, then a Connect webhook endpoint that notifies the specified url about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified url only about events from your account is created. You can also create webhook endpoints in the [webhooks settings](https://dashboard.stripe.com/account/webhooks) section of the Dashboard.
+    def self.create(params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: "/v1/webhook_endpoints",
+        params: params,
+        opts: opts
+      )
+    end
+
+    # You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
+    def self.delete(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/webhook_endpoints/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
+    def delete(params = {}, opts = {})
+      request_stripe_object(
+        method: :delete,
+        path: format("/v1/webhook_endpoints/%<webhook_endpoint>s", { webhook_endpoint: CGI.escape(self["id"]) }),
+        params: params,
+        opts: opts
+      )
+    end
+
+    # Returns a list of your webhook endpoints.
+    def self.list(filters = {}, opts = {})
+      request_stripe_object(
+        method: :get,
+        path: "/v1/webhook_endpoints",
+        params: filters,
+        opts: opts
+      )
+    end
+
+    # Updates the webhook endpoint. You may edit the url, the list of enabled_events, and the status of your endpoint.
+    def self.update(id, params = {}, opts = {})
+      request_stripe_object(
+        method: :post,
+        path: format("/v1/webhook_endpoints/%<id>s", { id: CGI.escape(id) }),
+        params: params,
+        opts: opts
+      )
+    end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/stripe/stripe-ruby/pull/1308

## Changelog

Extract more CRUDL operations, namely `create`, `delete`, `update`, and `list` into the resources. These methods will no longer rely on the APIOperation mixins.