### PR TITLE
refactor: :art: Dynamically generate object names and cache them

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -11,13 +11,16 @@ module Stripe
     # for example, where this is allowed.
     attr_accessor :save_with_parent
 
-    # TODO: (major) Remove OBJECT_NAME and stop using const_get here
-    # This is a workaround to avoid breaking users who have defined their own
-    # APIResource subclasses with a custom OBJECT_NAME. We should never fallback
-    # on this case otherwise.
     OBJECT_NAME = ""
     def self.object_name
-      const_get(:OBJECT_NAME)
+      @object_name ||= compute_object_name
+    end
+
+    def self.compute_object_name
+      name.split("::").last.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+          .tr("-", "_")
+          .downcase
     end
 
     def self.class_name


### PR DESCRIPTION
Implement dynamic object name generation in APIResource to replace the static OBJECT_NAME constant. Utilize memoization with @object_name to cache the generated name for efficiency. This change enhances flexibility and maintainability for the handling of API resource object names.