### PR TITLE
Retry for all error codes >= 500

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -487,7 +487,7 @@ module Stripe
         end
 
       http_resp =
-        execute_request_with_rescues(method, api_base, headers, usage, context) do
+        execute_request_with_rescues(api_base, headers, usage, context) do
           self.class
               .default_connection_manager(config)
               .execute_request(method, url,
@@ -557,7 +557,7 @@ module Stripe
       http_status >= 400
     end
 
-    private def execute_request_with_rescues(method, api_base, headers, usage, context)
+    private def execute_request_with_rescues(api_base, headers, usage, context)
       num_retries = 0
 
       begin

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -110,7 +110,7 @@ module Stripe
     # both socket errors that may represent an intermittent problem and some
     # special HTTP statuses.
     def self.should_retry?(error,
-                           method:, num_retries:, config: Stripe.config)
+                           num_retries:, config: Stripe.config)
       return false if num_retries >= config.max_network_retries
 
       case error
@@ -608,7 +608,6 @@ module Stripe
                            user_data, resp, headers)
 
         if self.class.should_retry?(e,
-                                    method: method,
                                     num_retries: num_retries,
                                     config: config)
           num_retries += 1

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -358,7 +358,7 @@ module Stripe
                                           method: :post, num_retries: 0)
       end
 
-      should "retry on a 500 Internal Server Error when non-POST" do
+      should "retry on a 500 Internal Server Error" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
                                           method: :get, num_retries: 0)
       end
@@ -381,11 +381,6 @@ module Stripe
       should "not retry on a 429 Too Many Requests when not lock timeout" do
         refute StripeClient.should_retry?(Stripe::StripeError.new(http_status: 429,
                                                                   code: "rate_limited"),
-                                          method: :post, num_retries: 0)
-      end
-
-      should "not retry on a 500 Internal Server Error when POST" do
-        refute StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
                                           method: :post, num_retries: 0)
       end
     end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -287,42 +287,42 @@ module Stripe
 
       should "retry on Errno::ECONNREFUSED" do
         assert StripeClient.should_retry?(Errno::ECONNREFUSED.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on EOFError" do
         assert StripeClient.should_retry?(EOFError.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on Errno::ECONNRESET" do
         assert StripeClient.should_retry?(Errno::ECONNRESET.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on Errno::ETIMEDOUT" do
         assert StripeClient.should_retry?(Errno::ETIMEDOUT.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on Errno::EHOSTUNREACH" do
         assert StripeClient.should_retry?(Errno::EHOSTUNREACH.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on Net::OpenTimeout" do
         assert StripeClient.should_retry?(Net::OpenTimeout.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on Net::ReadTimeout" do
         assert StripeClient.should_retry?(Net::ReadTimeout.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on SocketError" do
         assert StripeClient.should_retry?(SocketError.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry when the `Stripe-Should-Retry` header is `true`" do
@@ -333,7 +333,7 @@ module Stripe
         # Note we send status 400 here, which would normally not be retried.
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_headers: headers,
                                                                   http_status: 400),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "not retry when the `Stripe-Should-Retry` header is `false`" do
@@ -344,44 +344,44 @@ module Stripe
         # Note we send status 409 here, which would normally be retried.
         refute StripeClient.should_retry?(Stripe::StripeError.new(http_headers: headers,
                                                                   http_status: 409),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on a 409 Conflict" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 409),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on a 429 Too Many Requests when lock timeout" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 429,
                                                                   code: "lock_timeout"),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on a 500 Internal Server Error" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 500),
-                                          method: :get, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "retry on a 503 Service Unavailable" do
         assert StripeClient.should_retry?(Stripe::StripeError.new(http_status: 503),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "not retry at maximum count" do
         refute StripeClient.should_retry?(RuntimeError.new,
-                                          method: :post, num_retries: Stripe.max_network_retries)
+                                          num_retries: Stripe.max_network_retries)
       end
 
       should "not retry on a certificate validation error" do
         refute StripeClient.should_retry?(OpenSSL::SSL::SSLError.new,
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
 
       should "not retry on a 429 Too Many Requests when not lock timeout" do
         refute StripeClient.should_retry?(Stripe::StripeError.new(http_status: 429,
                                                                   code: "rate_limited"),
-                                          method: :post, num_retries: 0)
+                                          num_retries: 0)
       end
     end
 


### PR DESCRIPTION
This PR updates the retry behavior in the Ruby SDK to be the same as rest of our languages in terms of when to retry for errors with code >=500

From @richardm-stripe who lead this investigation previously

> The additional restrictions in stripe-go/stripe-ruby (don't bother retrying POST status=500) is a sensible optimization but the logic also misses some statuses (503/504/502) that possibly could succeed on retry. It's better for cases more granular than `>=500` to be captured in the logic that produces `x-stripe-should-retry` rather than to be hardcoded/maintained across 7+ official server SDKs, Terminal SDKs, direct integrations, etc.

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1711


## Changelog
* When no `x-stripe-should-retry` header is set in the response, the library now retries all requests with `status >= 500`, not just non-POST methods.
* Remove `method` parameter from `StripeClient.should_retry?`


