### PR TITLE
Revert Makefile change to allow autoformatting in codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ update-version:
 
 codegen-format:
 	bundle install --quiet
-	bundle exec rubocop --autocorrect
+	bundle exec rubocop -o /dev/null --autocorrect
 
 ci-test:
 	bundle install && bundle exec rake test


### PR DESCRIPTION
The output to /dev/null was included so autoformatting would happen quietly in codegen CI. Rubocop fails if there are any violations, even if they're autocorrected.