### PR TITLE
Remove entries from CHANGELOG.md that are not user facing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 ## 11.1.0 - 2024-04-16
 * [#1379](https://github.com/stripe/stripe-ruby/pull/1379) Update generated code
   * Add support for new resource `Entitlements.ActiveEntitlementSummary`
-* [#1382](https://github.com/stripe/stripe-ruby/pull/1382) Revert Makefile change to allow autoformatting in codegen
-* [#1380](https://github.com/stripe/stripe-ruby/pull/1380) Rename section for object types
 
 ## 11.0.0 - 2024-04-10
 * [#1374](https://github.com/stripe/stripe-ruby/pull/1374) 


### PR DESCRIPTION
I missed cleaning up the changelog when making the release. This is a post release attempt in doing so. We would like to keep the changelog free of non user facing changes to reduce noise for users