### PR TITLE
Removed jaro_winkler as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,6 @@ group :development do
   # The latest version of rubocop is only compatible with Ruby 2.7+
   gem "rubocop", "1.57.2" if RUBY_VERSION >= "2.7"
 
-  # jaro_winkler 1.5.5 installation fails for jruby
-  # don't install on truffleruby
-  gem "jaro_winkler", "1.5.4" unless RUBY_ENGINE == "truffleruby"
-
   gem "sorbet"
   gem "tapioca"
 


### PR DESCRIPTION
Seems like `jaro_winkler` is not used anywhere even in dependency tree. I can't seem to bundle install `jaro_winkler:v1.5.4`. Once I upgrade to `1.5.6` it install seamlessly.

CI works with `1.5.6` and even after removing the dependency.

Do we have more context on this? Why was this introduced or where is it being used? Are we okay with removing this?

`bundle exec gem dependency` outputs:

```
Gem addressable-2.8.6
  bundler (>= 1.0, < 3.0, development)
  public_suffix (>= 2.0.2, < 6.0)

Gem ast-2.4.2
  bacon (~> 1.2, development)
  bacon-colored_output (>= 0, development)
  coveralls (~> 0.8.23, development)
  kramdown (>= 0, development)
  rake (~> 12.3, development)
  simplecov (>= 0, development)
  yard (>= 0, development)

Gem bigdecimal-3.1.7

Gem bundler-2.1.2

Gem byebug-11.1.3
  bundler (~> 2.0, development)

Gem coderay-1.1.3

Gem coveralls_reborn-0.25.0
  bundler (>= 1.16, < 3, development)
  simplecov (>= 0.18.1, < 0.22.0)
  simplecov-lcov (~> 0.8.0, development)
  term-ansicolor (~> 1.6)
  thor (>= 0.20.3, < 2.0)
  tins (~> 1.16)

Gem crack-1.0.0
  bigdecimal (>= 0)
  rexml (>= 0)

Gem diff-lcs-1.5.1
  hoe (>= 3.0, < 5, development)
  hoe-doofus (~> 1.0, development)
  hoe-gemspec2 (~> 1.1, development)
  hoe-git2 (~> 1.7, development)
  hoe-rubygems (~> 1.0, development)
  rake (>= 10.0, < 14, development)
  rdoc (>= 6.3.1, < 7, development)
  rspec (>= 2.0, < 4, development)

Gem docile-1.4.0

Gem hashdiff-1.1.0
  bluecloth (>= 0, development)
  rspec (~> 3.5, development)
  rubocop (>= 1.52.1, development)
  rubocop-rspec (> 1.16.0, development)
  yard (>= 0, development)

Gem jaro_winkler-1.5.6
  minitest (>= 0, development)
  rake (~> 13.0, development)
  rake-compiler (>= 0, development)

Gem json-2.7.1

Gem language_server-protocol-3.17.0.3
  activesupport (>= 0, development)
  bundler (>= 2.0.0, development)
  m (>= 0, development)
  minitest (~> 5.0, development)
  minitest-power_assert (>= 0, development)
  rake (>= 12.3.3, development)

Gem method_source-1.0.0
  rake (~> 0.9, development)
  rspec (~> 3.6, development)

Gem mocha-1.16.1

Gem netrc-0.11.0
  minitest (>= 0, development)

Gem parallel-1.24.0

Gem parser-3.3.0.5
  ast (~> 2.4.1)
  bundler (>= 1.15, < 3.0.0, development)
  cliver (~> 0.3.2, development)
  gauntlet (>= 0, development)
  kramdown (>= 0, development)
  minitest (~> 5.10, development)
  racc (>= 0)
  rake (~> 13.0.1, development)
  simplecov (~> 0.15.1, development)
  yard (>= 0, development)

Gem power_assert-2.0.3
  benchmark-ips (>= 0, development)
  bundler (>= 0, development)
  byebug (>= 0, development)
  irb (>= 1.3.1, development)
  rake (>= 0, development)
  simplecov (>= 0, development)
  test-unit (>= 0, development)

Gem pry-0.14.2
  coderay (~> 1.1)
  method_source (~> 1.0)

Gem pry-byebug-3.10.1
  byebug (~> 11.0)
  pry (>= 0.13, < 0.15)

Gem public_suffix-5.0.4

Gem racc-1.7.3

Gem rack-3.0.10
  bundler (>= 0, development)
  minitest (~> 5.0, development)
  minitest-global_expectations (>= 0, development)
  rake (>= 0, development)

Gem rainbow-3.1.1
  bundler (>= 1.3, < 3, development)

Gem rake-13.1.0

Gem rbi-0.0.17
  ast (>= 0)
  parser (>= 3.0.0)
  sorbet-runtime (>= 0.5.9204)
  unparser (>= 0.5.6)

Gem regexp_parser-2.9.0

Gem rexml-3.2.6
  bundler (>= 0, development)
  rake (>= 0, development)
  test-unit (>= 0, development)

Gem rubocop-1.57.2
  json (~> 2.3)
  language_server-protocol (>= 3.17.0)
  parallel (~> 1.10)
  parser (>= 3.2.2.4)
  rainbow (>= 2.2.2, < 4.0)
  regexp_parser (>= 1.8, < 3.0)
  rexml (>= 3.2.5, < 4.0)
  rubocop-ast (>= 1.28.1, < 2.0)
  ruby-progressbar (~> 1.7)
  unicode-display_width (>= 2.4.0, < 3.0)

Gem rubocop-ast-1.31.2
  parser (>= 3.3.0.4)

Gem ruby-progressbar-1.13.0
  fuubar (~> 2.3, development)
  rspec (~> 3.7, development)
  rspectacular (~> 0.70.6, development)
  timecop (~> 0.9, development)

Gem shoulda-context-2.0.0

Gem simplecov-0.21.2
  docile (~> 1.1)
  simplecov-html (~> 0.11)
  simplecov_json_formatter (~> 0.1)

Gem simplecov-html-0.12.3

Gem simplecov_json_formatter-0.1.4

Gem sorbet-0.5.11319
  minitest (~> 5.11, development)
  mocha (~> 1.7, development)
  rake (>= 0, development)
  sorbet-static (= 0.5.11319)

Gem sorbet-runtime-0.5.11319
  concurrent-ruby (~> 1.1.5, development)
  minitest (~> 5.11, development)
  mocha (~> 2.1, development)
  pry (>= 0, development)
  pry-byebug (>= 0, development)
  rake (>= 0, development)
  rubocop (= 1.57.1, development)
  rubocop-performance (= 1.13.2, development)
  subprocess (~> 1.5.3, development)

Gem sorbet-static-0.5.11319-universal-darwin

Gem sorbet-static-and-runtime-0.5.11319
  sorbet (= 0.5.11319)
  sorbet-runtime (= 0.5.11319)

Gem spoom-1.1.16
  bundler (>= 2.2.10, development)
  minitest (~> 5.0, development)
  minitest-reporters (>= 0, development)
  rake (~> 13.0.1, development)
  sorbet (>= 0.5.10187)
  sorbet-runtime (>= 0.5.9204)
  thor (>= 0.19.2)

Gem stripe-11.2.0

Gem sync-0.5.0
  bundler (>= 0, development)
  rake (>= 0, development)
  test-unit (>= 0, development)

Gem tapioca-0.11.2
  bundler (>= 1.17.3)
  netrc (>= 0.11.0)
  parallel (>= 1.21.0)
  rbi (~> 0.0.0, >= 0.0.16)
  sorbet-static-and-runtime (>= 0.5.10187)
  spoom (~> 1.1.0, >= 1.1.11)
  thor (>= 1.2.0)
  yard-sorbet (>= 0)

Gem term-ansicolor-1.8.0
  gem_hadar (~> 1.15.0, development)
  simplecov (>= 0, development)
  test-unit (>= 0, development)
  tins (~> 1.0)
  utils (>= 0, development)

Gem test-unit-3.6.2
  bundler (>= 0, development)
  kramdown (>= 0, development)
  packnga (>= 0, development)
  power_assert (>= 0)
  rake (>= 0, development)
  yard (>= 0, development)

Gem thor-1.3.1
  bundler (>= 1.0, < 3, development)

Gem tins-1.33.0
  all_images (>= 0, development)
  bigdecimal (>= 0)
  debug (>= 0, development)
  gem_hadar (~> 1.15.0, development)
  simplecov (>= 0, development)
  sync (>= 0)
  term-ansicolor (>= 0, development)
  test-unit (~> 3.1, development)
  utils (>= 0, development)

Gem unicode-display_width-2.5.0
  rake (~> 13.0, development)
  rspec (~> 3.4, development)

Gem unparser-0.6.10
  diff-lcs (~> 1.3)
  mutant (~> 0.11.22, development)
  mutant-rspec (~> 0.11.22, development)
  parser (>= 3.2.2.4)
  rspec (~> 3.9, development)
  rspec-core (~> 3.9, development)
  rspec-its (~> 1.3.0, development)
  rubocop (~> 1.7, development)
  rubocop-packaging (~> 0.5, development)

Gem webmock-3.23.0
  addressable (>= 2.8.0)
  async-http (>= 0.48.0, development)
  crack (>= 0.3.2)
  curb (>= 0.7.16, development)
  em-http-request (>= 1.0.2, development)
  em-synchrony (>= 1.0.0, development)
  excon (>= 0.27.5, development)
  hashdiff (>= 0.4.0, < 2.0.0)
  http (>= 0.8.0, development)
  httpclient (>= 2.2.4, development)
  minitest (>= 5.0.0, development)
  mutex_m (>= 0, development)
  patron (>= 0.4.18, development)
  rack (> 1.6, development)
  rdoc (> 3.5.0, development)
  rspec (>= 3.1.0, development)
  rspec-retry (>= 0, development)
  test-unit (>= 3.0.0, development)
  typhoeus (>= 0.5.0, development)
  webrick (>= 0, development)

Gem yard-0.9.36

Gem yard-sorbet-0.8.1
  bundler-audit (~> 0.9.1, development)
  codecov (~> 0.6.0, development)
  rake (~> 13.0, development)
  redcarpet (~> 3.5, development)
  rspec (~> 3.10, development)
  rubocop (~> 1.49.0, development)
  rubocop-performance (~> 1.16.0, development)
  rubocop-rake (~> 0.6.0, development)
  rubocop-rspec (~> 2.19.0, development)
  rubocop-sorbet (~> 0.7.0, development)
  sorbet (~> 0.5.9204, development)
  sorbet-runtime (>= 0.5)
  tapioca (~> 0.11.1, development)
  yard (>= 0.9)
```


Install failure log:

```
Installing jaro_winkler 1.5.4 (was 1.5.6) with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/jaro_winkler-1.5.4/ext/jaro_winkler
/Users/prathmesh/.rbenv/versions/2.7.2/bin/ruby -I /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0 -r
./siteconf20240426-4172-144yrkq.rb extconf.rb
creating Makefile

current directory: /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/jaro_winkler-1.5.4/ext/jaro_winkler
make "DESTDIR=" clean

current directory: /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/jaro_winkler-1.5.4/ext/jaro_winkler
make "DESTDIR="
compiling adj_matrix.c
compiling codepoints.c
compiling jaro.c
compiling jaro_winkler.c
jaro_winkler.c:19:3: error: incompatible function pointer types passing 'VALUE (size_t, VALUE *, VALUE)' (aka 'unsigned long (unsigned long,
unsigned long *, unsigned long)') to parameter of type 'VALUE (*)(int, union (unnamed union at
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1), VALUE)' (aka 'unsigned long (*)(int, union (unnamed at
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1), unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_singleton_method(rb_mJaroWinkler, "distance",
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1218:137: note: expanded from macro 'rb_define_singleton_method'
#define rb_define_singleton_method(klass, mid, func, arity)
rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
                                                                                                                                        ^~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1: note: passing argument to parameter 'func' here
RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1091:77: note: expanded from macro 'RB_METHOD_DEFINITION_DECL'
RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##m2,-2,decl,vars,(VALUE,VALUE)) \
                                                                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1108:5: note: expanded from macro '\
RB_METHOD_DEFINITION_DECL_M1'
    RB_METHOD_DEFINITION_DECL_C(def,nonnull,defname,decl,vars,(int,union{VALUE*x;const VALUE*y;}__attribute__((__transparent_union__)),VALUE))
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1042:118: note: expanded from macro 'RB_METHOD_DEFINITION_DECL_C'
    __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
                                                                                                                     ^
jaro_winkler.c:21:3: error: incompatible function pointer types passing 'VALUE (size_t, VALUE *, VALUE)' (aka 'unsigned long (unsigned long,
unsigned long *, unsigned long)') to parameter of type 'VALUE (*)(int, union (unnamed union at
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1), VALUE)' (aka 'unsigned long (*)(int, union (unnamed at
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1), unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_singleton_method(rb_mJaroWinkler, "jaro_distance", rb_jaro_distance,
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1218:137: note: expanded from macro 'rb_define_singleton_method'
#define rb_define_singleton_method(klass, mid, func, arity)
rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
                                                                                                                                        ^~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1195:1: note: passing argument to parameter 'func' here
RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1091:77: note: expanded from macro 'RB_METHOD_DEFINITION_DECL'
RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##m2,-2,decl,vars,(VALUE,VALUE)) \
                                                                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1108:5: note: expanded from macro '\
RB_METHOD_DEFINITION_DECL_M1'
    RB_METHOD_DEFINITION_DECL_C(def,nonnull,defname,decl,vars,(int,union{VALUE*x;const VALUE*y;}__attribute__((__transparent_union__)),VALUE))
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/intern.h:1042:118: note: expanded from macro 'RB_METHOD_DEFINITION_DECL_C'
    __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
                                                                                                                     ^
jaro_winkler.c:37:45: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
    VALUE weight = rb_hash_aref(opt, ID2SYM(rb_intern("weight"))),
                                            ^~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:37:45: note: '{' token is here
    VALUE weight = rb_hash_aref(opt, ID2SYM(rb_intern("weight"))),
                                            ^~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:37:45: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
    VALUE weight = rb_hash_aref(opt, ID2SYM(rb_intern("weight"))),
                                            ^~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:37:45: note: ')' token is here
    VALUE weight = rb_hash_aref(opt, ID2SYM(rb_intern("weight"))),
                                            ^~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:38:48: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          threshold = rb_hash_aref(opt, ID2SYM(rb_intern("threshold"))),
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:38:48: note: '{' token is here
          threshold = rb_hash_aref(opt, ID2SYM(rb_intern("threshold"))),
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:38:48: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          threshold = rb_hash_aref(opt, ID2SYM(rb_intern("threshold"))),
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:38:48: note: ')' token is here
          threshold = rb_hash_aref(opt, ID2SYM(rb_intern("threshold"))),
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:39:50: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          ignore_case = rb_hash_aref(opt, ID2SYM(rb_intern("ignore_case"))),
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:39:50: note: '{' token is here
          ignore_case = rb_hash_aref(opt, ID2SYM(rb_intern("ignore_case"))),
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:39:50: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          ignore_case = rb_hash_aref(opt, ID2SYM(rb_intern("ignore_case"))),
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:39:50: note: ')' token is here
          ignore_case = rb_hash_aref(opt, ID2SYM(rb_intern("ignore_case"))),
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:40:48: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          adj_table = rb_hash_aref(opt, ID2SYM(rb_intern("adj_table")));
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:40:48: note: '{' token is here
          adj_table = rb_hash_aref(opt, ID2SYM(rb_intern("adj_table")));
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:40:48: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts
[-Wcompound-token-split-by-macro]
          adj_table = rb_hash_aref(opt, ID2SYM(rb_intern("adj_table")));
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
jaro_winkler.c:40:48: note: ')' token is here
          adj_table = rb_hash_aref(opt, ID2SYM(rb_intern("adj_table")));
                                               ^~~~~~~~~~~~~~~~~~~~~~
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/prathmesh/.rbenv/versions/2.7.2/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
8 warnings and 2 errors generated.
make: *** [jaro_winkler.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/jaro_winkler-1.5.4 for inspection.
Results logged to /Users/prathmesh/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/extensions/arm64-darwin-23/2.7.0/jaro_winkler-1.5.4/gem_make.out

An error occurred while installing jaro_winkler (1.5.4), and Bundler cannot continue.
Make sure that `gem install jaro_winkler -v '1.5.4' --source 'https://rubygems.org/'` succeeds before bundling.
```

cc @richardm-stripe @pakrym-stripe