### PR TITLE
fix: Add params to the APIOperations NestedResource retrieve_ method

### DIFF
--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -54,11 +54,11 @@ module Stripe
           end
         when :retrieve
           define_singleton_method(:"retrieve_#{resource}") \
-              do |id, nested_id, opts = {}|
+              do |id, nested_id, params = {}, opts = {}|
             request_stripe_object(
               method: :get,
               path: send(resource_url_method, id, nested_id),
-              params: {},
+              params: params,
               opts: opts
             )
           end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -60,6 +60,16 @@ module Stripe
         assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123"
         assert reversal.is_a?(Stripe::Reversal)
       end
+
+      should "retrieve a reversal with expand" do
+        reversal = Stripe::Transfer.retrieve_reversal(
+          "tr_123",
+          "trr_123",
+          expand: %w[transfer]
+        )
+        assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123?expand%5B%5D=transfer"
+        assert reversal.is_a?(Stripe::Reversal)
+      end
     end
 
     context "#update_reversal" do


### PR DESCRIPTION
https://github.com/stripe/stripe-ruby/issues/1393