### PR TITLE
Pass params to transfer reversal

### DIFF
--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -35,6 +35,7 @@ module Stripe
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       private def define_operation(
         resource,
         operation,
@@ -53,12 +54,30 @@ module Stripe
             )
           end
         when :retrieve
+          # TODO: (Major) Split params_or_opts to params and opts and get rid of the complicated way to add params
           define_singleton_method(:"retrieve_#{resource}") \
-              do |id, nested_id, opts = {}|
+              do |id, nested_id, params_or_opts = {}, definitely_opts = nil|
+            opts = nil
+            params = nil
+            if definitely_opts.nil?
+              unrecognized_key = params_or_opts.keys.find { |k| !Util::OPTS_USER_SPECIFIED.include?(k) }
+              if unrecognized_key
+                raise ArgumentError,
+                      "Unrecognized request option: #{unrecognized_key}. Did you mean to specify this as " \
+                      "retrieve params? " \
+                      "If so, you must explicitly pass an opts hash as a third argument. " \
+                      "For example: .retrieve({#{unrecognized_key}: 'foo'}, {})"
+              end
+
+              opts = params_or_opts
+            else
+              opts = definitely_opts
+              params = params_or_opts
+            end
             request_stripe_object(
               method: :get,
               path: send(resource_url_method, id, nested_id),
-              params: {},
+              params: params,
               opts: opts
             )
           end
@@ -96,6 +115,7 @@ module Stripe
           raise ArgumentError, "Unknown operation: #{operation.inspect}"
         end
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -65,8 +65,8 @@ module Stripe
                 raise ArgumentError,
                       "Unrecognized request option: #{unrecognized_key}. Did you mean to specify this as " \
                       "retrieve params? " \
-                      "If so, you must explicitly pass an opts hash as a third argument. " \
-                      "For example: .retrieve({#{unrecognized_key}: 'foo'}, {})"
+                      "If so, you must explicitly pass an opts hash as a fourth argument. " \
+                      "For example: .retrieve(#{id}, #{nested_id}, {#{unrecognized_key}: 'foo'}, {})"
               end
 
               opts = params_or_opts

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -89,6 +89,36 @@ module Stripe
         assert_equal "bar", nested_resource.foo
       end
 
+      should "define a retrieve method with only opts" do
+        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        nested_resource = MainResource.retrieve_nested("id", "nested_id", { stripe_account: "acct_123" })
+        assert_equal "bar", nested_resource.foo
+      end
+
+      should "define a retrieve method with both opts and params" do
+        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        nested_resource = MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] }, { stripe_account: "acct_123" })
+        assert_equal "bar", nested_resource.foo
+      end
+
+      should "define a retrieve method with params and explicitly empty opts" do
+        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
+          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        nested_resource = MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] }, {})
+        assert_equal "bar", nested_resource.foo
+      end
+
+      should "warns when attempting to retrieve and pass only params" do
+        # stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
+        #   .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
+        exception = assert_raises(ArgumentError) do
+          MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] })
+        end
+        assert_match(/Unrecognized request option/, exception.message)
+      end
+
       should "define an update method" do
         stub_request(:post, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
           .with(body: { foo: "baz" })

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -91,6 +91,7 @@ module Stripe
 
       should "define a retrieve method with only opts" do
         stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
+          .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
         nested_resource = MainResource.retrieve_nested("id", "nested_id", { stripe_account: "acct_123" })
         assert_equal "bar", nested_resource.foo
@@ -98,6 +99,7 @@ module Stripe
 
       should "define a retrieve method with both opts and params" do
         stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
+          .with(headers: { "Stripe-Account" => "acct_123" })
           .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
         nested_resource = MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] }, { stripe_account: "acct_123" })
         assert_equal "bar", nested_resource.foo
@@ -111,8 +113,6 @@ module Stripe
       end
 
       should "warns when attempting to retrieve and pass only params" do
-        # stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
-        #   .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
         exception = assert_raises(ArgumentError) do
           MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] })
         end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -84,5 +84,16 @@ module Stripe
         assert reversals.data.is_a?(Array)
       end
     end
+
+    should "retrieve a reversal with expand" do
+      reversal = Stripe::Transfer.retrieve_reversal(
+        "tr_123",
+        "trr_123",
+        { expand: %w[transfer] },
+        {}
+      )
+      assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123?expand%5B%5D=transfer"
+      assert reversal.is_a?(Stripe::Reversal)
+    end
   end
 end

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -95,5 +95,48 @@ module Stripe
       assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123?expand%5B%5D=transfer"
       assert reversal.is_a?(Stripe::Reversal)
     end
+
+    should "be retrievable with opts only" do
+      transfer_reversal = Stripe::Transfer.retrieve_reversal(
+        "tr_123",
+        "trr_123",
+        { stripe_account: "acct_123" }
+      )
+      assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123" do |req|
+        assert_equal("acct_123", req.headers["Stripe-Account"])
+        true
+      end
+      assert transfer_reversal.is_a?(Stripe::Reversal)
+    end
+    should "be retrievable with opts and params" do
+      transfer_reversal = Stripe::Transfer.retrieve_reversal("tr_123",
+                                                             "trr_123",
+                                                             { expand: ["available"] },
+                                                             { stripe_account: "acct_123" })
+      assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123?expand[]=available" do |req|
+        assert_equal("acct_123", req.headers["Stripe-Account"])
+        true
+      end
+      assert transfer_reversal.is_a?(Stripe::Reversal)
+    end
+    should "be retrievable with params and an explicitly empty opts" do
+      transfer_reversal = Stripe::Transfer.retrieve_reversal(
+        "tr_123",
+        "trr_123",
+        { expand: ["available"] },
+        {}
+      )
+      assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123?expand[]=available" do |req|
+        assert_nil(req.headers["Stripe-Account"])
+        true
+      end
+      assert transfer_reversal.is_a?(Stripe::Reversal)
+    end
+    should "warn you if you are attempting to pass only params" do
+      exception = assert_raises(ArgumentError) do
+        Stripe::Transfer.retrieve_reversal("tr_123", "trr_123", { expand: ["available"] })
+      end
+      assert_match(/Unrecognized request option/, exception.message)
+    end
   end
 end


### PR DESCRIPTION
Related: https://github.com/stripe/stripe-ruby/issues/1393

## Changelog
* Allow `Stripe::Transfer.retrieve_reversal()` to accept a params hash as the third argument, followed by opts. No changes to existing calls are necessary, but in a future major version this method will be updated to only accept params as the first argument.