### PR TITLE
Add method to list invoice line items

### DIFF
--- a/lib/stripe/resources/invoice.rb
+++ b/lib/stripe/resources/invoice.rb
@@ -38,6 +38,7 @@ module Stripe
     extend Stripe::APIOperations::Create
     include Stripe::APIOperations::Delete
     extend Stripe::APIOperations::List
+    extend Stripe::APIOperations::NestedResource
     extend Stripe::APIOperations::Search
     include Stripe::APIOperations::Save
 
@@ -45,6 +46,8 @@ module Stripe
     def self.object_name
       "invoice"
     end
+
+    nested_resource_class_methods :line, operations: %i[list]
 
     # This endpoint creates a draft invoice for a given customer. The invoice remains a draft until you [finalize the invoice, which allows you to [pay](#pay_invoice) or <a href="#send_invoice">send](https://stripe.com/docs/api#finalize_invoice) the invoice to your customers.
     def self.create(params = {}, opts = {})

--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -208,6 +208,15 @@ module Stripe
       end
     end
 
+    context ".list_line_items" do
+      should "retrieve invoice line items" do
+        line_items = Stripe::Invoice.list_lines("in_123")
+        assert_requested :get, "#{Stripe.api_base}/v1/invoices/in_123/lines"
+        assert line_items.data.is_a?(Array)
+        assert line_items.data[0].is_a?(Stripe::InvoiceLineItem)
+      end
+    end
+
     context "#void_invoice" do
       should "void invoice" do
         invoice = Stripe::Invoice.retrieve("in_123")


### PR DESCRIPTION
This PR adds the method to list invoice line items which was missing in stripe-ruby but is present in our other libraries

## Changelog 

* Add methods `list_lines()` on the class `Invoice` to list the invoice line items