### PR TITLE
Use updated rubocop vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "rebornix.ruby",
-    "misogi.ruby-rubocop",
+    "LoranKloeze.ruby-rubocop-revived",
     "EditorConfig.editorconfig"
   ]
 }


### PR DESCRIPTION
This PR updates the vscode extension recommendation to be `LoranKloeze.ruby-rubocop-revived`. The new extension supports auto-fixes.