### PR TITLE
Deprecate StripeClient#request

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -190,6 +190,7 @@ module Stripe
     #     client = StripeClient.new
     #     charge, resp = client.request { Charge.create }
     #
+
     def request
       @usage = ["stripe_client_request"]
       old_stripe_client = self.class.current_thread_context.active_client
@@ -211,6 +212,9 @@ module Stripe
         self.class.current_thread_context.last_responses.delete(object_id)
       end
     end
+    deprecate :request, "the `last_response` property on the returned resource (see " \
+                        "https://github.com/stripe/stripe-ruby?tab=readme-ov-file#accessing-a-response-object " \
+                        "for usage examples)", 2024, 6
 
     def execute_request(method, path,
                         api_base: nil, api_key: nil, headers: {}, params: {}, usage: [])

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1345,6 +1345,23 @@ module Stripe
                        e.message
         end
       end
+
+      should "warn that #request is deprecated" do
+        old_stderr = $stderr
+        $stderr = StringIO.new
+        stub_request(:post, "#{Stripe.api_base}/v1/charges")
+          .to_return(body: JSON.generate(object: "charge"))
+
+        begin
+          client = StripeClient.new
+          charge, resp = client.request { Charge.create }
+          message = "NOTE: Stripe::StripeClient#request is " \
+                    "deprecated"
+          assert_match Regexp.new(message), $stderr.string
+        ensure
+          $stderr = old_stderr
+        end
+      end
     end
 
     context "#proxy" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -1354,7 +1354,7 @@ module Stripe
 
         begin
           client = StripeClient.new
-          charge, resp = client.request { Charge.create }
+          client.request { Charge.create }
           message = "NOTE: Stripe::StripeClient#request is " \
                     "deprecated"
           assert_match Regexp.new(message), $stderr.string


### PR DESCRIPTION
Resulting deprecation message reads like this:
```
NOTE: Stripe::StripeClient#request is deprecated; use the `last_response` property on the returned
resource (see https://github.com/stripe/stripe-ruby?tab=readme-ov-file#accessing-a-response-object
for usage examples) instead. It will be removed on or after 2024-06.
```

## Changelog
* Add deprecation warning for `StripeClient#request`. This helper method will be removed in a future major version. To access response objects, use the `last_response` property on the returned resource instead. Refer to [Accessing a response object](https://github.com/stripe/stripe-ruby?tab=readme-ov-file#accessing-a-response-object) in the README for usage details.