### PR TITLE
Temporarily remove jruby from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', jruby-9.4.0.0, truffleruby-head]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', truffleruby-head]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
Unblocking major release by removing jrubby from the test matrix due to the error in [CI](https://github.com/stripe/stripe-ruby/actions/runs/9651358562/job/26619031291).

Error message:

```
LoadError: load error: mize/cache_protocol -- java.lang.NoSuchMethodError: 'org.joni.Region org.joni.Region.newRegion(int, int)'
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/mize-0.4.1/lib/mize/cache_methods.rb:1
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/mize-0.4.1/lib/mize/memoize.rb:1
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/mize-0.4.1/lib/mize.rb:13
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/term-ansicolor-1.10.2/lib/term/ansicolor.rb:2
  require at org/jruby/RubyKernel.java:1057
   format at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/coveralls_reborn-0.25.0/lib/coveralls/output.rb:68
     puts at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/coveralls_reborn-0.25.0/lib/coveralls/output.rb:94
   setup! at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/coveralls_reborn-0.25.0/lib/coveralls.rb:56
    wear! at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/coveralls_reborn-0.25.0/lib/coveralls.rb:21
   <main> at /home/runner/work/stripe-ruby/stripe-ruby/test/test_helper.rb:8
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/work/stripe-ruby/stripe-ruby/test/stripe/account_link_test.rb:3
  require at org/jruby/RubyKernel.java:1057
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21
   select at org/jruby/RubyArray.java:2891
   <main> at /home/runner/.rubies/jruby-9.4.0.0/lib/ruby/gems/shared/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6
... 21 levels...
rake aborted!
Command failed with status (1)
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
/home/runner/.rubies/jruby-9.4.0.0/bin/bundle:23:in `<main>'
```