### PR TITLE
Remove coveralls and re-added JRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', truffleruby-head]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', jruby-9.4.0.0, truffleruby-head]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
@@ -55,8 +55,6 @@ jobs:
       run: make ci-test
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_SERVICE_NAME: github-action
 
   publish:
     name: Publish

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 /.bundle/
 coverage/
 .idea/
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "coveralls_reborn", "~> 0.25.0" if RUBY_VERSION >= "3.1"
   gem "mocha", "~> 1.16.0"
   gem "rack", ">= 2.0.6"
   gem "rake"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/stripe.svg)](https://badge.fury.io/rb/stripe)
 [![Build Status](https://github.com/stripe/stripe-ruby/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-ruby/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-ruby/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-ruby?branch=master)
 
 The Stripe Ruby library provides convenient access to the Stripe API from
 applications written in the Ruby language. It includes a pre-defined set of

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-# Report test coverage to coveralls for only one Ruby version to avoid
-# repeated builds. This also accounts for coveralls_reborn requiring
-# RUBY_VERSION >= 2.5.
-if ENV.key?("COVERALLS_REPO_TOKEN") && RUBY_VERSION.start_with?("3.1.")
-  require "coveralls"
-  Coveralls.wear!
-end
-
 require "stripe"
 require "test/unit"
 require "mocha/setup"


### PR DESCRIPTION
Fixes CI failures caused in JRuby. 
JRuby was removed temporarily in this [PR](https://github.com/stripe/stripe-ruby/pull/1424).