### PR TITLE
Add usage to raw_request call

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -125,8 +125,8 @@ module Stripe
       @opts = {}
     end
 
-    def execute(method, url, params = {}, opts = {})
-      resp, = execute_resource_request(method, url, params, opts)
+    def execute(method, url, params = {}, opts = {}, usage = [])
+      resp, = execute_resource_request(method, url, params, opts, usage)
 
       resp
     end
@@ -135,7 +135,7 @@ module Stripe
   # Sends a request to Stripe REST API
   def self.raw_request(method, url, params = {}, opts = {})
     req = RawRequest.new
-    req.execute(method, url, params, opts)
+    req.execute(method, url, params, opts, ["raw_request"])
   end
 
   def self.deserialize(data)


### PR DESCRIPTION
Didn't add usage to the request when merging yesterday. This fixes that.