### PR TITLE
Add deprecation warning for `APIResource.request`

### DIFF
--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -78,6 +78,8 @@ module Stripe
         # place for backwards compatibility. Consider removing it on the next
         # major.
         alias request execute_resource_request
+        extend Gem::Deprecate
+        deprecate :request, "Stripe.raw_request", 2024, 7
 
         private def error_on_non_string_user_opts(opts)
           Util::OPTS_USER_SPECIFIED.each do |opt|
@@ -134,6 +136,8 @@ module Stripe
 
       # See notes on `alias` above.
       alias request execute_resource_request
+      extend Gem::Deprecate
+      deprecate :request, "Stripe.raw_request", 2024, 7
     end
   end
 end


### PR DESCRIPTION
After releasing `raw_request`, this method should be deprecated. This TODO comment to remove in the next major has been here for ages, we should finally take action now that a more visible alternative exists. Doesn't change any behavior besides logging the message below.

Tested locally by calling the function, shows up with:

```
NOTE: Stripe::Account#request is deprecated; use Stripe.raw_request instead. It will be removed on or after 2024-07.
```