### PR TITLE
Fail resource-based methods for next resources

### DIFF
--- a/examples/meter_event_stream.rb
+++ b/examples/meter_event_stream.rb
@@ -1,9 +1,10 @@
-require 'stripe'
-require 'date'
+# frozen_string_literal: true
+
+require "stripe"
+require "date"
 
 class MeterEventManager
-  attr_accessor :api_key
-  attr_accessor :meter_event_session
+  attr_accessor :api_key, :meter_event_session
 
   def initialize(api_key)
     @api_key = api_key
@@ -11,17 +12,16 @@ class MeterEventManager
   end
 
   def refresh_meter_event_session
-    if @meter_event_session.nil? || DateTime.parse(@meter_event_session.expires_at) <= DateTime.now
-      # Create a new meter event session in case the existing session expired
-      client = Stripe::StripeClient.new(api_key)
-      @meter_event_session = client.v2.billing.meter_event_session.create
-    end
+    return unless @meter_event_session.nil? || DateTime.parse(@meter_event_session.expires_at) <= DateTime.now
+
+    # Create a new meter event session in case the existing session expired
+    client = Stripe::StripeClient.new(api_key)
+    @meter_event_session = client.v2.billing.meter_event_session.create
   end
 
   def send_meter_event(meter_event)
     # Refresh the meter event session if necessary
     refresh_meter_event_session
-
 
     # Create a meter event with the current session's authentication token
     client = Stripe::StripeClient.new(meter_event_session.authentication_token)
@@ -38,10 +38,10 @@ customer_id = "{{CUSTOMER_ID}}"
 manager = MeterEventManager.new(api_key)
 manager.send_meter_event(
   {
-    event_name: 'alpaca_ai_tokens',
+    event_name: "alpaca_ai_tokens",
     payload: {
       "stripe_customer_id" => customer_id,
-      "value" => '25'
-    }
+      "value" => "25",
+    },
   }
 )

--- a/examples/new_example.rb
+++ b/examples/new_example.rb
@@ -1,5 +1,7 @@
-require 'stripe'
-require 'date'
+# frozen_string_literal: true
+
+require "stripe"
+require "date"
 
 class NewExample
   attr_accessor :api_key
@@ -8,7 +10,7 @@ class NewExample
     @api_key = api_key
   end
 
-  def do_something_great()
+  def do_something_great
     puts "Hello World"
     # client = Stripe::StripeClient.new(api_key)
     # client.v1
@@ -17,7 +19,6 @@ end
 
 # Send meter events
 api_key = "{{API_KEY}}"
-customer_id = "{{CUSTOMER_ID}}"
 
 example = NewExample.new(api_key)
 example.do_something_great

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -27,8 +27,8 @@ module Stripe
     def self.resource_url
       if name.include?("Stripe::V2")
         raise NotImplementedError,
-          "V2 resources do not have a defined URL. Please use the StripeClient " \
-          "to make V2 requests"
+              "V2 resources do not have a defined URL. Please use the StripeClient " \
+              "to make V2 requests"
       end
 
       if self == APIResource
@@ -112,7 +112,6 @@ module Stripe
       instance.refresh
       instance
     end
-
 
     def request_stripe_object(method:, path:, params:, base_address: :api, opts: {})
       APIRequestor.active_requestor.execute_request_initialize_from(method, path, base_address, self,

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -25,6 +25,12 @@ module Stripe
     end
 
     def self.resource_url
+      if name.include?("Stripe::V2")
+        raise NotImplementedError,
+          "V2 resources do not have a defined URL. Please use the StripeClient " \
+          "to make V2 requests"
+      end
+
       if self == APIResource
         raise NotImplementedError,
               "APIResource is an abstract class. You should perform actions " \
@@ -86,17 +92,27 @@ module Stripe
       "#{self.class.resource_url}/#{CGI.escape(id)}"
     end
 
-    # TODO: v2 objects can be refreshed -- the api mode should depend on the object here.
     def refresh
+      if self.class.name.include?("Stripe::V2")
+        raise NotImplementedError,
+              "It is not possible to refresh v2 objects. Please retrieve the object using the StripeClient instead."
+      end
+
       @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params)
     end
 
     def self.retrieve(id, opts = {})
+      if name.include?("Stripe::V2")
+        raise NotImplementedError,
+              "It is not possible to retrieve v2 objects on the resource. Please use the StripeClient instead."
+      end
+
       opts = Util.normalize_opts(opts)
       instance = new(id, opts)
       instance.refresh
       instance
     end
+
 
     def request_stripe_object(method:, path:, params:, base_address: :api, opts: {})
       APIRequestor.active_requestor.execute_request_initialize_from(method, path, base_address, self,

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -894,6 +894,31 @@ module Stripe
       end
     end
 
+    context "v2 resources" do
+      should "raise an NotImplementedError on resource_url" do
+        assert_raises NotImplementedError do
+          Stripe::V2::Event.resource_url
+        end
+      end
+
+      should "raise an NotImplementedError on retrieve" do
+        assert_raises NotImplementedError do
+          Stripe::V2::Event.retrieve("acct_123")
+        end
+      end
+
+      should "raise an NotImplementedError on refresh" do
+        stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session")
+          .to_return(body: JSON.generate(object: "billing.meter_event_session"))
+
+        client = Stripe::StripeClient.new("sk_test_123")
+        session = client.v2.billing.meter_event_session.create
+        assert_raises NotImplementedError do
+          session.refresh
+        end
+      end
+    end
+
     @@fixtures = {} # rubocop:disable Style/ClassVars
     setup do
       if @@fixtures.empty?


### PR DESCRIPTION
These should not be available to these resources. We should consider generating them per-resource instead in the future.