### PR TITLE
Remove deprecated methods and update raw_request README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,11 @@ If you:
 - prefer to bypass the method definitions in the library and specify your request details directly,
 - used the method `Stripe::APIResource.request(...)` to specify your own requests, which will soon be broken
 
-you can now use the `raw_request` method on `Stripe`.
+you can now use the `raw_request` method on `StripeClient`.
 
 ```ruby
-resp = Stripe.raw_request(:post, "/v1/beta_endpoint", {param: 123}, {stripe_version: "2022-11-15; feature_beta=v3"})
+client = Stripe::StripeClient.new(...)
+resp = client.raw_request(:post, "/v1/beta_endpoint", {param: 123}, {stripe_version: "2022-11-15; feature_beta=v3"})
 
 # (Optional) resp is a StripeResponse. You can use `Stripe.deserialize` to get a StripeObject.
 deserialized_resp = Stripe.deserialize(resp.http_body)

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ client = Stripe::StripeClient.new(...)
 resp = client.raw_request(:post, "/v1/beta_endpoint", {param: 123}, {stripe_version: "2022-11-15; feature_beta=v3"})
 
 # (Optional) resp is a StripeResponse. You can use `Stripe.deserialize` to get a StripeObject.
-deserialized_resp = Stripe.deserialize(resp.http_body)
+deserialized_resp = client.deserialize(resp.http_body)
 ```
 
 ## Support

--- a/lib/stripe/api_operations/request.rb
+++ b/lib/stripe/api_operations/request.rb
@@ -51,20 +51,6 @@ module Stripe
           )
         end
 
-        # TODO: (major)
-        # This method used to be called `request`, but it's such a short name
-        # that it eventually conflicted with the name of a field on an API
-        # resource (specifically, `Event#request`), so it was renamed to
-        # something more unique.
-        #
-        # The former name had been around for just about forever though, and
-        # although all internal uses have been renamed, I've left this alias in
-        # place for backwards compatibility. Consider removing it on the next
-        # major.
-        alias request execute_resource_request
-        extend Gem::Deprecate
-        deprecate :request, "StripeClient.raw_request", 2024, 7
-
         private def error_on_invalid_params(params)
           return if params.nil? || params.is_a?(Hash)
 
@@ -102,11 +88,6 @@ module Stripe
       private def request_stripe_object(method:, path:, params:, base_address: :api, opts: {}, usage: [])
         execute_resource_request(method, path, base_address, params, opts, usage)
       end
-
-      # See notes on `alias` above.
-      alias request execute_resource_request
-      extend Gem::Deprecate
-      deprecate :request, "StripeClient.raw_request", 2024, 7
     end
   end
 end

--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -167,15 +167,6 @@ module Stripe
       [config.initial_network_retry_delay, sleep_seconds].max
     end
 
-    # Gets the connection manager in use for the current `APIRequestor`.
-    #
-    # This method is DEPRECATED and for backwards compatibility only.
-    def connection_manager
-      self.class.default_connection_manager
-    end
-    extend Gem::Deprecate
-    deprecate :connection_manager, :none, 2020, 9
-
     # Executes the API call within the given block. Usage looks like:
     #
     #     client = APIRequestor.new

--- a/test/stripe/api_requestor_test.rb
+++ b/test/stripe/api_requestor_test.rb
@@ -1327,22 +1327,6 @@ module Stripe
       end
     end
 
-    context "#connection_manager" do
-      should "warn that #connection_manager is deprecated" do
-        old_stderr = $stderr
-        $stderr = StringIO.new
-        begin
-          client = APIRequestor.new("sk_test_123")
-          client.connection_manager
-          message = "NOTE: Stripe::APIRequestor#connection_manager is " \
-                    "deprecated"
-          assert_match Regexp.new(message), $stderr.string
-        ensure
-          $stderr = old_stderr
-        end
-      end
-    end
-
     context "#request" do
       should "return a result and response object" do
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/charges")

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -306,7 +306,7 @@ module Stripe
       setup do
         @client = Stripe::StripeClient.new("sk_test_deserialize")
       end
-      
+
       should "deserializes string into known object" do
         expected_body = "{\"id\": \"acc_123\", \"object\": \"account\"}"
 


### PR DESCRIPTION
## Why?

These methods were deprecated years ago, and still remained in the API. We'd like to discourage their use as alternatives exist and we are changing requestor patterns.

Also updates the README for correct raw_request snippets.

## Changelog
* ⚠️ Remove `APIResource.request`. Instead, use `StripeClient.raw_request` now.
```ruby
# Instead of
Stripe::APIResource.request(:get, "/v1/endpoint", params, opts)

# do
client = Stripe::StripeClient.new(...)
resp = client.raw_request(:get, "/v1/endpoint", params: params, opts: opts)
```
* ⚠️ Remove `StripeClient.connection_manager` (now `APIRequestor.connection_manager`). This was a legacy method from years ago.