### PR TITLE
Singleton retrieve method now requires params to be passed as the first argument

### DIFF
--- a/examples/stripe_webhook_handler.rb
+++ b/examples/stripe_webhook_handler.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: true
+# typed: false
 
 require "stripe"
 require "sinatra"

--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -35,7 +35,6 @@ module Stripe
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       private def define_operation(
         resource,
         operation,
@@ -54,26 +53,8 @@ module Stripe
             )
           end
         when :retrieve
-          # TODO: (Major) Split params_or_opts to params and opts and get rid of the complicated way to add params
           define_singleton_method(:"retrieve_#{resource}") \
-              do |id, nested_id, params_or_opts = {}, definitely_opts = nil|
-            opts = nil
-            params = nil
-            if definitely_opts.nil?
-              unrecognized_key = params_or_opts.keys.find { |k| !RequestOptions::OPTS_USER_SPECIFIED.include?(k) }
-              if unrecognized_key
-                raise ArgumentError,
-                      "Unrecognized request option: #{unrecognized_key}. Did you mean to specify this as " \
-                      "retrieve params? " \
-                      "If so, you must explicitly pass an opts hash as a fourth argument. " \
-                      "For example: .retrieve(#{id}, #{nested_id}, {#{unrecognized_key}: 'foo'}, {})"
-              end
-
-              opts = params_or_opts
-            else
-              opts = definitely_opts
-              params = params_or_opts
-            end
+              do |id, nested_id, params = {}, opts = {}|
             request_stripe_object(
               method: :get,
               path: send(resource_url_method, id, nested_id),
@@ -115,7 +96,6 @@ module Stripe
           raise ArgumentError, "Unknown operation: #{operation.inspect}"
         end
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/stripe/singleton_api_resource.rb
+++ b/lib/stripe/singleton_api_resource.rb
@@ -17,24 +17,7 @@ module Stripe
       self.class.resource_url
     end
 
-    def self.retrieve(params_or_opts = {}, definitely_opts = nil)
-      opts = nil
-      params = nil
-      if definitely_opts.nil?
-        unrecognized_key = params_or_opts.keys.find { |k| !RequestOptions::OPTS_USER_SPECIFIED.include?(k) }
-        if unrecognized_key
-          raise ArgumentError,
-                "Unrecognized request option: #{unrecognized_key}. Did you mean to specify this as retrieve params? " \
-                "If so, you must explicitly pass an opts hash as a second argument. " \
-                "For example: .retrieve({#{unrecognized_key}: 'foo'}, {})"
-        end
-
-        opts = params_or_opts
-      else
-        opts = definitely_opts
-        params = params_or_opts
-      end
-
+    def self.retrieve(params = {}, opts = {})
       instance = new(params, Util.normalize_opts(opts))
       instance.refresh
       instance

--- a/test/stripe/api_operations_test.rb
+++ b/test/stripe/api_operations_test.rb
@@ -89,14 +89,6 @@ module Stripe
         assert_equal "bar", nested_resource.foo
       end
 
-      should "define a retrieve method with only opts" do
-        stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id")
-          .with(headers: { "Stripe-Account" => "acct_123" })
-          .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
-        nested_resource = MainResource.retrieve_nested("id", "nested_id", { stripe_account: "acct_123" })
-        assert_equal "bar", nested_resource.foo
-      end
-
       should "define a retrieve method with both opts and params" do
         stub_request(:get, "#{Stripe.api_base}/v1/mainresources/id/nesteds/nested_id?expand[]=reverse")
           .with(headers: { "Stripe-Account" => "acct_123" })
@@ -110,13 +102,6 @@ module Stripe
           .to_return(body: JSON.generate(id: "nested_id", object: "nested", foo: "bar"))
         nested_resource = MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] }, {})
         assert_equal "bar", nested_resource.foo
-      end
-
-      should "warns when attempting to retrieve and pass only params" do
-        exception = assert_raises(ArgumentError) do
-          MainResource.retrieve_nested("id", "nested_id", { expand: ["reverse"] })
-        end
-        assert_match(/Unrecognized request option/, exception.message)
       end
 
       should "define an update method" do

--- a/test/stripe/balance_test.rb
+++ b/test/stripe/balance_test.rb
@@ -9,14 +9,6 @@ module Stripe
       assert_requested :get, "#{Stripe.api_base}/v1/balance"
       assert balance.is_a?(Stripe::Balance)
     end
-    should "be retrievable with opts only" do
-      balance = Stripe::Balance.retrieve({ stripe_account: "acct_123" })
-      assert_requested :get, "#{Stripe.api_base}/v1/balance" do |req|
-        assert_equal("acct_123", req.headers["Stripe-Account"])
-        true
-      end
-      assert balance.is_a?(Stripe::Balance)
-    end
     should "be retrievable with opts and params" do
       balance = Stripe::Balance.retrieve({ expand: ["available"] }, { stripe_account: "acct_123" })
       assert_requested :get, "#{Stripe.api_base}/v1/balance?expand[]=available" do |req|
@@ -32,12 +24,6 @@ module Stripe
         true
       end
       assert balance.is_a?(Stripe::Balance)
-    end
-    should "warn you if you are attempting to pass only params" do
-      exception = assert_raises(ArgumentError) do
-        Stripe::Balance.retrieve({ expand: ["available"] })
-      end
-      assert_match(/Unrecognized request option/, exception.message)
     end
   end
 end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -306,7 +306,7 @@ module Stripe
       setup do
         @client = Stripe::StripeClient.new("sk_test_deserialize")
       end
-      
+
       should "deserializes string into known object" do
         expected_body = "{\"id\": \"acc_123\", \"object\": \"account\"}"
 

--- a/test/stripe/transfer_test.rb
+++ b/test/stripe/transfer_test.rb
@@ -96,18 +96,6 @@ module Stripe
       assert reversal.is_a?(Stripe::Reversal)
     end
 
-    should "be retrievable with opts only" do
-      transfer_reversal = Stripe::Transfer.retrieve_reversal(
-        "tr_123",
-        "trr_123",
-        { stripe_account: "acct_123" }
-      )
-      assert_requested :get, "#{Stripe.api_base}/v1/transfers/tr_123/reversals/trr_123" do |req|
-        assert_equal("acct_123", req.headers["Stripe-Account"])
-        true
-      end
-      assert transfer_reversal.is_a?(Stripe::Reversal)
-    end
     should "be retrievable with opts and params" do
       transfer_reversal = Stripe::Transfer.retrieve_reversal("tr_123",
                                                              "trr_123",
@@ -131,12 +119,6 @@ module Stripe
         true
       end
       assert transfer_reversal.is_a?(Stripe::Reversal)
-    end
-    should "warn you if you are attempting to pass only params" do
-      exception = assert_raises(ArgumentError) do
-        Stripe::Transfer.retrieve_reversal("tr_123", "trr_123", { expand: ["available"] })
-      end
-      assert_match(/Unrecognized request option/, exception.message)
     end
   end
 end


### PR DESCRIPTION
## Changelog
* Singleton `retrieve` method now requires `params` to be passed as the first argument. Existing calls to singleton `retrieve` method with only `opts` argument will have to be updated to account for the addition of `params` argument. 
```ruby
params = { expand: ["available"] }
opts = { stripe_account: "acct_123" }

# ❌ No longer works
Stripe::Balance.retrieve(opts)

# ✅ Correct way to call retrieve method
Stripe::Balance.retrieve(params, opts)
```