### PR TITLE
Fix v2 event object name

### DIFF
--- a/examples/stripe_webhook_handler.rb
+++ b/examples/stripe_webhook_handler.rb
@@ -20,7 +20,7 @@ post "/webhook" do
   if event.instance_of? Stripe::V1BillingMeterErrorReportTriggeredEvent
     meter = event.fetch_related_object
     meter_id = meter.id
-    puts 'Success!', meter_id
+    puts "Success!", meter_id
   end
 
   # Record the failures and alert your team

--- a/examples/stripe_webhook_handler.rb
+++ b/examples/stripe_webhook_handler.rb
@@ -19,7 +19,8 @@ post "/webhook" do
   event = client.v2.core.events.retrieve(thin_event.id)
   if event.instance_of? Stripe::V1BillingMeterErrorReportTriggeredEvent
     meter = event.fetch_related_object
-    meter_id = meter.id # rubocop:disable Lint/UselessAssignment
+    meter_id = meter.id
+    puts 'Success!', meter_id
   end
 
   # Record the failures and alert your team

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -141,7 +141,7 @@ module Stripe
         object_type = data[:type] || data["type"]
         object_name = data[:object] || data["object"]
         object_class = if api_mode == :v2
-                         if object_name == "v2.core.event" and thin_event_classes.has_key? object_type
+                         if object_name == "v2.core.event" && thin_event_classes.has_key? object_type
                            thin_event_classes.fetch(object_type)
                          else
                            v2_object_classes.fetch(

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -140,7 +140,7 @@ module Stripe
         # to generic StripeObject
         object_name = data[:object] || data["object"]
         object_class = if api_mode == :v2
-                         if object_name == "event"
+                         if object_name == "v2.core.event"
                            thin_event_classes.fetch(data[:type] || data["type"])
                          else
                            v2_object_classes.fetch(

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -141,7 +141,7 @@ module Stripe
         object_type = data[:type] || data["type"]
         object_name = data[:object] || data["object"]
         object_class = if api_mode == :v2
-                         if object_name == "v2.core.event" && thin_event_classes.has_key? object_type
+                         if object_name == "v2.core.event" && thin_event_classes.has? object_type
                            thin_event_classes.fetch(object_type)
                          else
                            v2_object_classes.fetch(

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -138,10 +138,11 @@ module Stripe
 
         # Try converting to a known object class.  If none available, fall back
         # to generic StripeObject
+        object_type = data[:type] || data["type"]
         object_name = data[:object] || data["object"]
         object_class = if api_mode == :v2
-                         if object_name == "v2.core.event"
-                           thin_event_classes.fetch(data[:type] || data["type"])
+                         if object_name == "v2.core.event" and thin_event_classes.has_key? object_type
+                           thin_event_classes.fetch(object_type)
                          else
                            v2_object_classes.fetch(
                              object_name, StripeObject

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -141,7 +141,7 @@ module Stripe
         object_type = data[:type] || data["type"]
         object_name = data[:object] || data["object"]
         object_class = if api_mode == :v2
-                         if object_name == "v2.core.event" && thin_event_classes.has? object_type
+                         if object_name == "v2.core.event" && thin_event_classes.key?(object_type)
                            thin_event_classes.fetch(object_type)
                          else
                            v2_object_classes.fetch(

--- a/test/stripe/v2_event_test.rb
+++ b/test/stripe/v2_event_test.rb
@@ -19,14 +19,14 @@ module Stripe
 
         @v2_payload_no_related_object = {
           "id" => "evt_234",
-          "object" => "event",
+          "object" => "v2.core.event",
           "type" => "financial_account.balance.opened",
           "created" => "2022-02-15T00:27:45.330Z",
         }.to_json
 
         @v2_push_payload = {
           "id" => "evt_234",
-          "object" => "event",
+          "object" => "v2.core.event",
           "type" => "v1.billing.meter.error_report_triggered",
           "created" => "2022-02-15T00:27:45.330Z",
           "related_object" => {
@@ -38,7 +38,7 @@ module Stripe
 
         @v2_pull_payload = {
           "id" => "evt_234",
-          "object" => "event",
+          "object" => "v2.core.event",
           "type" => "v1.billing.meter.error_report_triggered",
           "created" => "2022-02-15T00:27:45.330Z",
           "related_object" => {


### PR DESCRIPTION
### Why?
The SDK uses object strings in the API response to decide what class to parse a resource returned from the Stripe API into.  Recently, the object string for the V2 event base class changed from "event" to "v2.core.event".  We have to update the SDK to match.

### What?
- Changed "event" to "v2.core.event" in util.rb convert_to_stripe_object_with_params

Verified using the `stripe_webhook_handler.rb` example with events triggered from and forwarded by the Stripe CLI

### See Also
http://go/j/DEVSDK-2202