### PR TITLE
Helenye meb

### DIFF
--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -191,6 +191,8 @@ module Stripe
         self.class.current_thread_context.last_responses.delete(object_id)
       end
     end
+    extend Gem::Deprecate
+    deprecate :request, "StripeClient#raw_request", 2024, 9
 
     def execute_request(method, path, base_address,
                         params: {}, opts: {}, usage: [])
@@ -212,6 +214,9 @@ module Stripe
     end
 
     # Execute request without instantiating a new object if the relevant object's name matches the class
+    #
+    # For internal use only. Does not provide a stable API and may be broken
+    # with future non-major changes.
     def execute_request_initialize_from(method, path, base_address, object,
                                         params: {}, opts: {}, usage: [])
       opts = RequestOptions.combine_opts(object.instance_variable_get(:@opts), opts)

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -19,6 +19,7 @@ module Stripe
                    api_base: nil,
                    uploads_base: nil,
                    connect_base: nil,
+                   meter_events_base: nil,
                    client_id: nil)
       unless api_key
         raise AuthenticationError, "No API key provided. " \
@@ -36,6 +37,7 @@ module Stripe
         api_base: api_base,
         uploads_base: uploads_base,
         connect_base: connect_base,
+        meter_events_base: meter_events_base,
         client_id: client_id,
       }.reject { |_k, v| v.nil? }
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -49,10 +49,11 @@ module Stripe
       # top-level services: The end of the section generated from our OpenAPI spec
     end
 
-    # TODO: thread safety investigate
     def request(&block)
       @requestor.request(&block)
     end
+    extend Gem::Deprecate
+    deprecate :request, :raw_request, 2024, 9
 
     def parse_thin_event(payload, sig_header, secret, tolerance: Webhook::DEFAULT_TOLERANCE)
       payload = payload.force_encoding("UTF-8") if payload.respond_to?(:force_encoding)


### PR DESCRIPTION
## Why?

We should be able to modify meter_events_base on creation, add that capability.

It also marks a new method introduced in this version as internal only, since it is mostly intended as an internal helper.

Marks `APIRequestor.request` and `StripeClient.request` as deprecated as alternatives now exist.