### PR TITLE
Add livemode and reason to thin_event

### DIFF
--- a/lib/stripe/thin_event.rb
+++ b/lib/stripe/thin_event.rb
@@ -9,7 +9,9 @@ module Stripe
       @type = event_payload[:type]
       @created = event_payload[:created]
       @context = event_payload[:context]
+      @livemode = event_payload[:livemode]
       @related_object = event_payload[:related_object]
+      @reason = event_payload[:reason]
     end
   end
 end


### PR DESCRIPTION
## Why?

I missed these when I added thin_event.