### PR TITLE
Remove parseSnapshotEvent from StripeClient

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -65,19 +65,6 @@ module Stripe
       Stripe::ThinEvent.new(parsed)
     end
 
-    # Initializes an Event object from a JSON payload.
-    # This is the client-pattern equivalent of Webhook.construct_event
-    #
-    # This may raise JSON::ParserError if the payload is not valid JSON, or
-    # SignatureVerificationError if the signature verification fails.
-    def parse_snapshot_event(payload, sig_header, secret,
-                             tolerance: Webhook::DEFAULT_TOLERANCE)
-      Webhook::Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
-
-      event_data = JSON.parse(payload, symbolize_names: true)
-      Event.construct_from(event_data, {}, nil, :v1, @requestor)
-    end
-
     def raw_request(method, url, base_address: :api, params: {}, opts: {})
       opts = Util.normalize_opts(opts)
       req_opts = RequestOptions.extract_opts_from_hash(opts)

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -277,31 +277,6 @@ module Stripe
       end
     end
 
-    EVENT_PAYLOAD = <<~PAYLOAD
-      {
-        "id": "evt_test_webhook",
-        "data": {
-          "object": "account",
-          "id": "acct_123"
-        },
-        "object": "event"
-      }
-    PAYLOAD
-
-    context "#parse_snapshot_event" do
-      should "return the same as Webhook.construct_event" do
-        header = Test::WebhookHelpers.generate_header(payload: EVENT_PAYLOAD)
-        construct_event = Stripe::Webhook.construct_event(EVENT_PAYLOAD, header, Test::WebhookHelpers::SECRET)
-        client_event = StripeClient.new("sk_test_123").parse_snapshot_event(EVENT_PAYLOAD, header, Test::WebhookHelpers::SECRET)
-        assert construct_event.is_a?(Stripe::Event)
-        assert client_event.is_a?(Stripe::Event)
-        assert construct_event.id == client_event.id
-        assert construct_event.data.is_a?(Stripe::Account)
-        assert client_event.data.is_a?(Stripe::Account)
-        assert construct_event.data == client_event.data
-      end
-    end
-
     context "deserialize" do
       setup do
         @client = Stripe::StripeClient.new("sk_test_deserialize")


### PR DESCRIPTION
## Why?

We already have `Stripe::Webhook.construct_event` available, and we believe that we may want to unify thin and snapshot event processing on StripeClient eventually. Thus, `parseSnapshotEvent` is not actually useful to add for users.