### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/lib/stripe/resources/v2/billing/meter_event.rb
+++ b/lib/stripe/resources/v2/billing/meter_event.rb
@@ -6,9 +6,9 @@ module Stripe
     module Billing
       # Fix me empty_doc_string.
       class MeterEvent < APIResource
-        OBJECT_NAME = "billing.meter_event"
+        OBJECT_NAME = "v2.billing.meter_event"
         def self.object_name
-          "billing.meter_event"
+          "v2.billing.meter_event"
         end
       end
     end

--- a/lib/stripe/resources/v2/billing/meter_event_adjustment.rb
+++ b/lib/stripe/resources/v2/billing/meter_event_adjustment.rb
@@ -5,9 +5,9 @@ module Stripe
   module V2
     module Billing
       class MeterEventAdjustment < APIResource
-        OBJECT_NAME = "billing.meter_event_adjustment"
+        OBJECT_NAME = "v2.billing.meter_event_adjustment"
         def self.object_name
-          "billing.meter_event_adjustment"
+          "v2.billing.meter_event_adjustment"
         end
       end
     end

--- a/lib/stripe/resources/v2/billing/meter_event_session.rb
+++ b/lib/stripe/resources/v2/billing/meter_event_session.rb
@@ -5,9 +5,9 @@ module Stripe
   module V2
     module Billing
       class MeterEventSession < APIResource
-        OBJECT_NAME = "billing.meter_event_session"
+        OBJECT_NAME = "v2.billing.meter_event_session"
         def self.object_name
-          "billing.meter_event_session"
+          "v2.billing.meter_event_session"
         end
       end
     end

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -909,7 +909,7 @@ module Stripe
 
       should "raise an NotImplementedError on refresh" do
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session")
-          .to_return(body: JSON.generate(object: "billing.meter_event_session"))
+          .to_return(body: JSON.generate(object: "v2.billing.meter_event_session"))
 
         client = Stripe::StripeClient.new("sk_test_123")
         session = client.v2.billing.meter_event_session.create

--- a/test/stripe/stripe_service_test.rb
+++ b/test/stripe/stripe_service_test.rb
@@ -18,7 +18,7 @@ module Stripe
 
       should "correctly deserialize v2 account object" do
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session")
-          .to_return(body: JSON.generate(object: "billing.meter_event_session"))
+          .to_return(body: JSON.generate(object: "v2.billing.meter_event_session"))
 
         client = Stripe::StripeClient.new("sk_test_123")
 


### PR DESCRIPTION
CI failures are expected because stripe-mock doesn't yet have the changes these this PR is responding to

## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.