### PR TITLE
Always return the result of APIResource#refresh in APIResource.retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ background terminal ([stripe-mock's README][stripe-mock] also contains
 instructions for installing via Homebrew and other methods):
 
 ```sh
-go get -u github.com/stripe/stripe-mock
+go install github.com/stripe/stripe-mock@latest
 stripe-mock
 ```
 

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -110,7 +110,6 @@ module Stripe
       opts = Util.normalize_opts(opts)
       instance = new(id, opts)
       instance.refresh
-      instance
     end
 
     def request_stripe_object(method:, path:, params:, base_address: :api, opts: {})

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -919,6 +919,23 @@ module Stripe
       end
     end
 
+    class CustomStripeObject < APIResource
+      def self.resource_url
+        "/v1/custom_stripe_object"
+      end
+    end
+
+    context "custom class extending APIResource" do
+      should "return StripeObject instance when calling retrieve" do
+        stub_request(:get, "#{Stripe.api_base}/v1/custom_stripe_object/id")
+          .to_return(body: JSON.generate({ id: "id", object: "custom_stripe_object", result: "hello" }))
+
+        custom_stripe_object = CustomStripeObject.retrieve("id")
+        assert_instance_of Stripe::StripeObject, custom_stripe_object
+        assert_equal "hello", custom_stripe_object.result
+      end
+    end
+
     @@fixtures = {} # rubocop:disable Style/ClassVars
     setup do
       if @@fixtures.empty?


### PR DESCRIPTION
This is somewhat of a bug report masked as a PR, since I'm not sure what I suggested is the desired solution based on the API design of `ApiResource.refresh`. If we think this is the best solution for now, I'm happy to add tests as well.

With the refactor of v13, there are now cases where `self` is not mutated in the call to refresh and instead a new object is returned. This change ensures that the new object is always returned by returning the result of refresh instead. 

This case happens when the else branch of this method is triggered.

https://github.com/stripe/stripe-ruby/blob/a2e2881c7cad5ebe5ad03c013521d01384ab77d9/lib/stripe/api_requestor.rb#L236-L244

This happens if you defined a custom object that extends APIResource. For example, at Shopify we have an object like so:

```ruby
module Stripe
  class ReservePlan < APIResource

  class << self
    def retrieve(id, opts = {})
      super
    end
  end
end
```

The retrieve method no longer works with the method for v13, since it doesn't return the result of the API call, since `instance` is not mutated in this case.

However even after the change in this PR, there is still a regression since calling `super` now returns a generic StripeObject. To be able to return an instance of our custom class, I had to change the code of retrieve to something like this:

```ruby
def retrieve(id, opts = {})
  result = super
  construct_from(result.to_h, opts, result.last_response)
end
```

This is obviously not as clean as it was before. It's also a bit unintuitive to have a method called `#refresh` which returns a new `StripeObject` instance instead of mutating the existing instance, which seems like the intent of that method.