### PR TITLE
Fix APIResource#retrieve bug not returning instance of custom resources

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -99,7 +99,13 @@ module Stripe
       end
 
       @obj = @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params)
-      initialize_from(@obj.last_response.data, {}, @obj.lat_response, api_mode: :v1, requestor: @requestor)
+      initialize_from(
+        @obj.last_response.data,
+        @obj.instance_variable_get(:@opts),
+        @obj.last_response,
+        api_mode: :v1,
+        requestor: @requestor
+      )
     end
 
     def self.retrieve(id, opts = {})

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -98,7 +98,8 @@ module Stripe
               "It is not possible to refresh v2 objects. Please retrieve the object using the StripeClient instead."
       end
 
-      @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params)
+      @obj = @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params)
+      initialize_from(@obj.last_response.data, {}, @obj.lat_response, api_mode: :v1, requestor: @requestor)
     end
 
     def self.retrieve(id, opts = {})

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -931,7 +931,7 @@ module Stripe
           .to_return(body: JSON.generate({ id: "id", object: "custom_stripe_object", result: "hello" }))
 
         custom_stripe_object = CustomStripeObject.retrieve("id")
-        assert_instance_of Stripe::StripeObject, custom_stripe_object
+        assert_instance_of CustomStripeObject, custom_stripe_object
         assert_equal "hello", custom_stripe_object.result
       end
     end


### PR DESCRIPTION
## Why?

A bug was introduced in v13.0.0 where we did not return the specific instance type if it wasn't available in our object mapping chart when a v1 resource was refreshed (custom resources). This addresses that.

## Changelog

* Fix bug in APIResource#refresh and APIResource#retrieve where they returned an instance of `StripeObject` for custom resources. They should now return the instance of the custom resource.