### PR TITLE
Fix APIResource#retrieve not sending `stripe_version`

### DIFF
--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -63,7 +63,7 @@ module Stripe
         idempotency_key: req_opts[:idempotency_key],
         stripe_account: req_opts[:stripe_account] || object_opts[:stripe_account],
         stripe_context: req_opts[:stripe_context] || object_opts[:stripe_context],
-        stripe_version: req_opts[:stripe_version] || object_opts[:api_version],
+        stripe_version: req_opts[:stripe_version] || object_opts[:stripe_version],
       }
 
       # Remove nil values from headers

--- a/test/stripe/request_options_test.rb
+++ b/test/stripe/request_options_test.rb
@@ -79,14 +79,13 @@ module Stripe
     end
 
     context "combine_opts" do
-      should "correctly set stripe_version in retrieve" do
-        Stripe::Account.retrieve("acc_123", stripe_version: "2022-11-15")
-
-        assert_requested(
-          :get,
-          "#{Stripe.api_base}/v1/accounts/acc_123",
-          headers: { "Stripe-Version" => "2022-11-15" }
-        )
+      should "correctly combine user specified options" do
+        object_opts = { api_key: "sk_123", stripe_version: "2022-11-15" }
+        request_opts = { api_key: "sk_456", stripe_account: "acct_123" }
+        combined = RequestOptions.combine_opts(object_opts, request_opts)
+        assert_equal(combined[:stripe_version], "2022-11-15")
+        assert_equal(combined[:api_key], "sk_456")
+        assert_equal(combined[:stripe_account], "acct_123")
       end
     end
   end

--- a/test/stripe/request_options_test.rb
+++ b/test/stripe/request_options_test.rb
@@ -77,5 +77,17 @@ module Stripe
         assert_equal({ "A-Header" => "header", "B-Header" => "header" }, request_opts[:headers])
       end
     end
+
+    context "combine_opts" do
+      should "correctly set stripe_version in retrieve" do
+        Stripe::Account.retrieve("acc_123", stripe_version: "2022-11-15")
+
+        assert_requested(
+          :get,
+          "#{Stripe.api_base}/v1/accounts/acc_123",
+          headers: { "Stripe-Version" => "2022-11-15" }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why?

We stopped sending `stripe_version` parameter due to a refactor that missed this param. See https://github.com/stripe/stripe-ruby/issues/1482 for more context.
