### PR TITLE
Update VSCode default extensions to use solargraph instead of ruby lsp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "EditorConfig.editorconfig", // default
-    "shopify.ruby-lsp", // intellisense-like support (if you get it working)
+    "castwide.solargraph", // intellisense
     "sorbet.sorbet-vscode-extension", // typechecking, where applicable
     "LoranKloeze.ruby-rubocop-revived", // linting
     "SarahRidge.vscode-ruby-syntax" // Semantic syntax highlighting


### PR DESCRIPTION
## Why?

Solargraph works much better OOTB in VSCode and I've had much less trouble with it. I think it works better as a default suggestion.