### PR TITLE
Fix incorrect key in param encoding

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -259,7 +259,7 @@ module Stripe
         if elem.is_a?(Hash)
           result += flatten_params(elem, api_mode, "#{calculated_key}[#{i}]")
         elsif elem.is_a?(Array)
-          result += flatten_params_array(elem, calculated_key, api_mode)
+          result += flatten_params_array(elem, api_mode, calculated_key)
         else
           result << if api_mode == :v2
                       [calculated_key, elem]

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -16,9 +16,20 @@ module Stripe
 
           # NOTE: the empty hash won't even show up in the request
           g: [],
+
         }
         assert_equal(
           "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[0]=0&e[1]=1&f=",
+          Stripe::Util.encode_parameters(params, :v1)
+        )
+      end
+
+      should "correctly represent nested arrays" do
+        params = {
+          a: [[foo: "bar", baz: "qux"]],
+        }
+        assert_equal(
+          "a[0][foo]=bar&a[0][baz]=qux",
           Stripe::Util.encode_parameters(params, :v1)
         )
       end


### PR DESCRIPTION
## Why?

https://github.com/stripe/stripe-ruby/issues/1485 revealed a bug with our nested array param encoding.

Confirmed the test failed before the fix, included `v1` in the test instead of the correct param name `a`.