### PR TITLE
Pass requestor to all deserialized objects including lists

### DIFF
--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -76,7 +76,7 @@ module Stripe
 
     def deserialize(data, api_mode: :v1)
       data = JSON.parse(data) if data.is_a?(String)
-      Util.convert_to_stripe_object(data, {}, api_mode: api_mode)
+      Util.convert_to_stripe_object(data, {}, api_mode: api_mode, requestor: @requestor)
     end
   end
 end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -153,7 +153,7 @@ module Stripe
     def update_attributes(values, opts = {}, dirty: true)
       values.each do |k, v|
         add_accessors([k], values) unless metaclass.method_defined?(k.to_sym)
-        @values[k] = Util.convert_to_stripe_object(v, opts, api_mode: @api_mode)
+        @values[k] = Util.convert_to_stripe_object(v, opts, api_mode: @api_mode, requestor: @requestor)
         dirty_value!(@values[k]) if dirty
         @unsaved_values.add(k)
       end
@@ -361,7 +361,7 @@ module Stripe
                                    "We interpret empty strings as nil in requests. " \
                                    "You may set (object).#{k} = nil to delete the property."
             end
-            @values[k] = Util.convert_to_stripe_object(v, @opts, api_mode: @api_mode)
+            @values[k] = Util.convert_to_stripe_object(v, @opts, api_mode: @api_mode, requestor: @requestor)
             dirty_value!(@values[k])
             @unsaved_values.add(k)
           end
@@ -534,7 +534,7 @@ module Stripe
       # example by appending a new hash onto `additional_owners` for an
       # account.
       elsif value.is_a?(Hash)
-        Util.convert_to_stripe_object(value, @opts).serialize_params
+        Util.convert_to_stripe_object(value, @opts, api_mode: @api_mode, requestor: @requestor).serialize_params
 
       elsif value.is_a?(StripeObject)
         update = value.serialize_params(force: force)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -127,7 +127,7 @@ module Stripe
 
       case data
       when Array
-        data.map { |i| convert_to_stripe_object(i, opts, api_mode: api_mode) }
+        data.map { |i| convert_to_stripe_object(i, opts, api_mode: api_mode, requestor: requestor) }
       when Hash
         # TODO: This is a terrible hack.
         # Waiting on https://jira.corp.stripe.com/browse/API_SERVICES-3167 to add

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -14,6 +14,13 @@ module Stripe
       assert_equal 1, list.count
     end
 
+    should "be able to refresh objects in list" do
+      list = Stripe::Customer.list
+      assert_not_nil list.first.instance_variable_get(:@requestor)
+      cus = list.first.refresh
+      assert cus.is_a?(Stripe::Customer)
+    end
+
     should "provide #each" do
       arr = [
         { id: 1 },

--- a/test/stripe/search_result_object_test.rb
+++ b/test/stripe/search_result_object_test.rb
@@ -14,6 +14,13 @@ module Stripe
       assert_equal 1, list.count
     end
 
+    should "be able to refresh objects in search" do
+      list = Stripe::Customer.search({ query: "name:'fakename'" })
+      assert_not_nil list.first.instance_variable_get(:@requestor)
+      cus = list.first.refresh
+      assert cus.is_a?(Stripe::Customer)
+    end
+
     should "provide #each" do
       arr = [
         { id: 1 },

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -309,6 +309,19 @@ module Stripe
         assert_equal obj.id, "acc_123"
       end
 
+      should "allow refresh on deserialized object" do
+        expected_body = "{\"id\": \"acc_123\", \"object\": \"account\"}"
+
+        stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v1/accounts/acc_123")
+          .to_return(status: 200, body: expected_body)
+
+        obj = @client.deserialize(expected_body)
+        obj = obj.refresh
+
+        assert_equal obj.class, Stripe::Account
+        assert_equal obj.id, "acc_123"
+      end
+
       should "deserializes hash into unknown object" do
         expected_body = { "id" => "acc_123", "object" => "unknown" }
 


### PR DESCRIPTION
## Why?

Reported in https://github.com/stripe/stripe-ruby/issues/1506 where requestor is nil in deserialized lists. Before, we did not persist the requestor through lists in the response. This meant that requests couldn't be made on returned resources inside the list.

## What

This passes requestor through to all instances of convert_to_stripe_object where it was previously not, and adds some tests for this.