### PR TITLE
Import global configuration for options not available on StripeClient options

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -75,25 +75,25 @@ module Stripe
   DEFAULT_METER_EVENTS_BASE = "https://meter-events.stripe.com"
 
   # Options that can be configured globally by users
-  USER_CONFIGURABLE_GLOBAL_OPTIONS = Set.new([
-    :api_key,
-    :api_version,
-    :stripe_account,
-    :api_base,
-    :uploads_base,
-    :connect_base,
-    :meter_events_base,
-    :open_timeout,
-    :read_timeout,
-    :write_timeout,
-    :proxy,
-    :verify_ssl_certs,
-    :ca_bundle_path,
-    :log_level,
-    :logger,
-    :max_network_retries,
-    :enable_telemetry,
-    :client_id
+  USER_CONFIGURABLE_GLOBAL_OPTIONS = Set.new(%i[
+    api_key
+    api_version
+    stripe_account
+    api_base
+    uploads_base
+    connect_base
+    meter_events_base
+    open_timeout
+    read_timeout
+    write_timeout
+    proxy
+    verify_ssl_certs
+    ca_bundle_path
+    log_level
+    logger
+    max_network_retries
+    enable_telemetry
+    client_id
   ])
 
   @app_info = nil

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -74,6 +74,28 @@ module Stripe
   DEFAULT_UPLOAD_BASE = "https://files.stripe.com"
   DEFAULT_METER_EVENTS_BASE = "https://meter-events.stripe.com"
 
+  # Options that can be configured globally by users
+  USER_CONFIGURABLE_GLOBAL_OPTIONS = Set.new([
+    :api_key,
+    :api_version,
+    :stripe_account,
+    :api_base,
+    :uploads_base,
+    :connect_base,
+    :meter_events_base,
+    :open_timeout,
+    :read_timeout,
+    :write_timeout,
+    :proxy,
+    :verify_ssl_certs,
+    :ca_bundle_path,
+    :log_level,
+    :logger,
+    :max_network_retries,
+    :enable_telemetry,
+    :client_id
+  ])
+
   @app_info = nil
 
   @config = Stripe::StripeConfiguration.setup

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -12,7 +12,7 @@ module Stripe
 
     # For internal use only. Does not provide a stable API and may be broken
     # with future non-major changes.
-    CLIENT_OPTIONS = Set.new([:api_key, :stripe_account, :stripe_context, :api_version, :api_base, :uploads_base, :connect_base, :meter_events_base, :client_id])
+    CLIENT_OPTIONS = Set.new(%i[api_key stripe_account stripe_context api_version api_base uploads_base connect_base meter_events_base client_id])
 
     # Initializes a new StripeClient
     def initialize(api_key, # rubocop:todo Metrics/ParameterLists

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -10,6 +10,10 @@ module Stripe
 
     # attr_readers: The end of the section generated from our OpenAPI spec
 
+    # For internal use only. Does not provide a stable API and may be broken
+    # with future non-major changes.
+    CLIENT_OPTIONS = Set.new([:api_key, :stripe_account, :stripe_context, :api_version, :api_base, :uploads_base, :connect_base, :meter_events_base, :client_id])
+
     # Initializes a new StripeClient
     def initialize(api_key, # rubocop:todo Metrics/ParameterLists
                    stripe_account: nil,
@@ -40,7 +44,8 @@ module Stripe
         client_id: client_id,
       }.reject { |_k, v| v.nil? }
 
-      @requestor = APIRequestor.new(config_opts)
+      config = StripeConfiguration.client_init(config_opts)
+      @requestor = APIRequestor.new(config)
 
       # top-level services: The beginning of the section generated from our OpenAPI spec
       @v1 = Stripe::V1Services.new(@requestor)

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -45,7 +45,12 @@ module Stripe
       imported_options = USER_CONFIGURABLE_GLOBAL_OPTIONS - StripeClient::CLIENT_OPTIONS
       client_config = StripeConfiguration.setup do |instance|
         imported_options.each do |key|
-          instance.public_send("#{key}=", global_config.public_send(key)) if global_config.respond_to?(key)
+          begin
+            instance.public_send("#{key}=", global_config.public_send(key)) if global_config.respond_to?(key)
+          rescue NotImplementedError => e
+            # In Ruby <= 2.5, we can't set write_timeout on Net::HTTP, log an error and continue
+            Util.log_error("Failed to set #{key} on client configuration: #{e}")
+          end
         end
       end
       client_config.reverse_duplicate_merge(config_opts)

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -41,20 +41,16 @@ module Stripe
     # Otherwise, for user configurable global options, set them to the global configuration
     # For all other options, set them to the StripeConfiguration default value
     def self.client_init(config_opts)
-      global = Stripe.config
-      imported_options = Stripe::USER_CONFIGURABLE_GLOBAL_OPTIONS - StripeClient::CLIENT_OPTIONS
-      StripeConfiguration.setup do |instance|
+      global_config = Stripe.config
+      imported_options = USER_CONFIGURABLE_GLOBAL_OPTIONS - StripeClient::CLIENT_OPTIONS
+      client_config = StripeConfiguration.setup do |instance|
         imported_options.each do |key|
-          if global.respond_to?(key)
-            instance.public_send("#{key}=", global.public_send(key))
-          end
-        end
-        StripeClient::CLIENT_OPTIONS.each do |key|
-          if config_opts.include?(key)
-            instance.public_send("#{key}=", config_opts[key])
+          if global_config.respond_to?(key)
+            instance.public_send("#{key}=", global_config.public_send(key))
           end
         end
       end
+      client_config.reverse_duplicate_merge(config_opts)
     end
 
     # Create a new config based off an existing one. This is useful when the
@@ -88,7 +84,7 @@ module Stripe
       @connect_base = DEFAULT_CONNECT_BASE
       @uploads_base = DEFAULT_UPLOAD_BASE
       @meter_events_base = DEFAULT_METER_EVENTS_BASE
-      @base_addresses = { api: @api_base, connect: @connect_base, files: @uploads_base, events: @meter_events_base }
+      @base_addresses = { api: @api_base, connect: @connect_base, files: @uploads_base, meter_events: @meter_events_base }
     end
 
     def log_level=(val)

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -37,6 +37,26 @@ module Stripe
       end
     end
 
+    # Set options to the StripeClient configured options, if valid as a client option and provided
+    # Otherwise, for user configurable global options, set them to the global configuration
+    # For all other options, set them to the StripeConfiguration default value
+    def self.client_init(config_opts)
+      global = Stripe.config
+      imported_options = Stripe::USER_CONFIGURABLE_GLOBAL_OPTIONS - StripeClient::CLIENT_OPTIONS
+      StripeConfiguration.setup do |instance|
+        imported_options.each do |key|
+          if global.respond_to?(key)
+            instance.public_send("#{key}=", global.public_send(key))
+          end
+        end
+        StripeClient::CLIENT_OPTIONS.each do |key|
+          if config_opts.include?(key)
+            instance.public_send("#{key}=", config_opts[key])
+          end
+        end
+      end
+    end
+
     # Create a new config based off an existing one. This is useful when the
     # caller wants to override the global configuration
     def reverse_duplicate_merge(hash)

--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -45,9 +45,7 @@ module Stripe
       imported_options = USER_CONFIGURABLE_GLOBAL_OPTIONS - StripeClient::CLIENT_OPTIONS
       client_config = StripeConfiguration.setup do |instance|
         imported_options.each do |key|
-          if global_config.respond_to?(key)
-            instance.public_send("#{key}=", global_config.public_send(key))
-          end
+          instance.public_send("#{key}=", global_config.public_send(key)) if global_config.respond_to?(key)
         end
       end
       client_config.reverse_duplicate_merge(config_opts)
@@ -84,7 +82,8 @@ module Stripe
       @connect_base = DEFAULT_CONNECT_BASE
       @uploads_base = DEFAULT_UPLOAD_BASE
       @meter_events_base = DEFAULT_METER_EVENTS_BASE
-      @base_addresses = { api: @api_base, connect: @connect_base, files: @uploads_base, meter_events: @meter_events_base }
+      @base_addresses = { api: @api_base, connect: @connect_base, files: @uploads_base,
+                          meter_events: @meter_events_base, }
     end
 
     def log_level=(val)

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -47,7 +47,6 @@ module Stripe
         client = StripeClient.new("test_123")
         assert_equal "test_123", client.instance_variable_get(:@requestor).config.api_key
         assert_nil client.instance_variable_get(:@requestor).config.stripe_account
-        assert_equal 30, client.instance_variable_get(:@requestor).config.open_timeout
       end
 
       should "use client config options" do

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -20,6 +20,7 @@ module Stripe
         @orig_api_key = Stripe.api_key
         @orig_stripe_account = Stripe.stripe_account
         @orig_open_timeout = Stripe.open_timeout
+        @orig_api_version = Stripe.api_version
 
         Stripe.api_key = "DONT_USE_THIS_KEY"
         Stripe.stripe_account = "DONT_USE_THIS_ACCOUNT"
@@ -30,6 +31,7 @@ module Stripe
         Stripe.api_key = @orig_api_key
         Stripe.stripe_account = @orig_stripe_account
         Stripe.open_timeout = @orig_open_timeout
+        Stripe.api_version = @orig_api_version
       end
 
       should "use default config options" do
@@ -65,6 +67,30 @@ module Stripe
         assert_equal "acct_123", req.headers["Stripe-Account"]
         assert_equal "wksp_123", req.headers["Stripe-Context"]
         assert_equal "2022-11-15", req.headers["Stripe-Version"]
+      end
+
+      should "use global config options for options unavailable in client" do
+        Stripe.api_key = "NOT_THIS_KEY"
+        Stripe.stripe_account = "NOT_THIS_ACCOUNT"
+        Stripe.api_version = "2022-11-15"
+        client = StripeClient.new("test_123", stripe_account: "acct_123")
+        # Imported from global options
+        assert_equal 30_000, client.instance_variable_get(:@requestor).config.open_timeout
+        # Not set in client options, not imported from global
+        assert_equal client.instance_variable_get(:@requestor).config.api_base, Stripe::DEFAULT_API_BASE
+        assert_equal client.instance_variable_get(:@requestor).config.api_version, Stripe::ApiVersion::CURRENT
+
+        req = nil
+        stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v1/customers/cus_123")
+          .with { |request| req = request }
+          .to_return(body: JSON.generate(object: "customer"))
+
+        client.v1.customers.retrieve("cus_123")
+
+        # Set in client options
+        assert_equal "Bearer test_123", req.headers["Authorization"]
+        assert_equal "acct_123", req.headers["Stripe-Account"]
+        assert_requested(:get, "#{Stripe::DEFAULT_API_BASE}/v1/customers/cus_123")
       end
 
       should "request options overrides client config options" do

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -99,7 +99,7 @@ module Stripe
 
     context "client_init" do
       setup do
-        @client_opts = StripeClient::CLIENT_OPTIONS.to_h { |k| [k, nil] }
+        @client_opts = Hash[StripeClient::CLIENT_OPTIONS.map { |k| [k, nil] }]
         @old_api_key = Stripe.api_key
         @old_stripe_account = Stripe.stripe_account
         @old_enable_telemetry = Stripe.instance_variable_get(:@enable_telemetry)

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -99,7 +99,7 @@ module Stripe
 
     context "client_init" do
       setup do
-        @client_opts = Hash[StripeClient::CLIENT_OPTIONS.map { |k| [k, nil] }]
+        @client_opts = Hash[StripeClient::CLIENT_OPTIONS.map { |k| [k, nil] }] # rubocop:todo Style/HashConversion - necessary for Ruby <= 2.5
         @old_api_key = Stripe.api_key
         @old_stripe_account = Stripe.stripe_account
         @old_enable_telemetry = Stripe.instance_variable_get(:@enable_telemetry)

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -120,20 +120,20 @@ module Stripe
         Stripe.api_key = "global_test_123"
         Stripe.stripe_account = "global_acct_123"
         Stripe.enable_telemetry = false
-        Stripe.open_timeout = 30000
+        Stripe.open_timeout = 30_000
         Stripe.uploads_base = "global_uploads_base.stripe.com"
 
         @client_opts[:api_key] = "client_test_123"
         @client_opts[:stripe_account] = "client_acct_123"
         @client_opts[:uploads_base] = "client_uploads_base.stripe.com"
-        @client_opts.reject! { |k, v| v.nil? }
+        @client_opts.reject! { |_k, v| v.nil? }
 
         client_config = Stripe::StripeConfiguration.client_init(@client_opts)
 
         assert_equal("client_test_123", client_config.api_key) # client api key
         assert_equal("client_acct_123", client_config.stripe_account) # client stripe account
         assert_equal(false, client_config.enable_telemetry) # global telemetry
-        assert_equal(30000, client_config.open_timeout) # global timeout
+        assert_equal(30_000, client_config.open_timeout) # global timeout
         assert_equal("client_uploads_base.stripe.com", client_config.base_addresses[:files]) # client uploads base
         assert_equal(Stripe::DEFAULT_API_BASE, client_config.base_addresses[:api]) # default api base
         assert_equal(ApiVersion::CURRENT, client_config.api_version) # default api version


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Raised in https://github.com/stripe/stripe-ruby/issues/1511 - In our v13 migration guide, we mention that we use global configuration for options that are not available per StripeClient. This was not implemented for that release, this remedies that.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Adds a new fxn and tests to StripeConfiguration to initialize a client configuration with given options, with each option following the priority:
- If available as a client option:
  - If provided, set as provided option
  - Use StripeConfiguration default
- If not available as a client option (e.g.`enable_telemetry`, `open_timeout`)
  - Use global configuration value

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Fixes bug where `StripeClient` was not falling back to global options for options that are not available to be set per-client