### PR TITLE
Pin ubuntu version in Test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
 
   test:
     name: Test (${{ matrix.ruby-version }})
-    runs-on: ubuntu-latest
+    # this is needed because our JRuby test version isnt supported on ubuntu-24 (which is now ubuntu-latest)
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', jruby-9.4.0.0, truffleruby-head]


### PR DESCRIPTION
### Why?
Our test action ran on `ubuntu-latest` and tests against a range of ruby versions.  https://github.com/actions/runner-images/commit/976232da217887825e7541c2635bf39cbbf22654 updates `ubuntu-latest` to Ubuntu 24.04 which was causing stripe-ruby CI jobs to error out with `Error: Unavailable version 9.4.0.0 for jruby on ubuntu-24.04`.

### What?
- Changed runs-on value for Test job to `ubuntu-22.04`

