### PR TITLE
pipe rubocop output to devnull

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,8 +20,10 @@ alias lint-check := format-check
 # ⭐ check style & formatting for all files, fixing what we can
 lint: (format-check "--autocorrect")
 
+# NOTE: "-o /dev/null" is vital - rubocop has super noisy output and codegen will crash when formatting ruby if everything gets printed
+# so, we send all its output to the void
 # copy of `lint` with less output
-format: (format-check "--format quiet --autocorrect")
+format: (format-check "-o /dev/null --autocorrect")
 
 update-certs: install
     bundle exec rake update_certs


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Codegen for ruby was failing because `just format` for ruby was creating too much output. It turns out that even during "quiet" mode, `rubocop` prints outs the things it corrects (which there are a _ton_ of during generation).

So we need to pipe everything to `/dev/null` so there's no printing at all. I've confirmed this all works locally!

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- pipe formatting output to `/dev/null`

### See Also
<!-- Include any links or additional information that help explain this change. -->
