### PR TITLE
Fix InvoiceLineItem parent class

### DIFF
--- a/lib/stripe/resources/invoice_line_item.rb
+++ b/lib/stripe/resources/invoice_line_item.rb
@@ -5,7 +5,7 @@ module Stripe
   # Invoice Line Items represent the individual lines within an [invoice](https://stripe.com/docs/api/invoices) and only exist within the context of an invoice.
   #
   # Each line item is backed by either an [invoice item](https://stripe.com/docs/api/invoiceitems) or a [subscription item](https://stripe.com/docs/api/subscription_items).
-  class InvoiceLineItem < StripeObject
+  class InvoiceLineItem < APIResource
     include Stripe::APIOperations::Save
 
     OBJECT_NAME = "line_item"

--- a/test/stripe/invoice_line_item_test.rb
+++ b/test/stripe/invoice_line_item_test.rb
@@ -4,5 +4,10 @@ require File.expand_path("../test_helper", __dir__)
 
 module Stripe
   class InvoiceLineItemTest < Test::Unit::TestCase
+    should "be updateable" do
+      item = Stripe::InvoiceLineItem.update("in_123", "il_tmp_123")
+      assert_requested :post, "#{Stripe.api_base}/v1/invoices/in_123/lines/il_tmp_123"
+      assert item.is_a?(Stripe::InvoiceLineItem)
+    end
   end
 end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The `request_stripe_object` is undefined, fix parent class. Issue raised in https://github.com/stripe/stripe-ruby/issues/1535

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Change parent class from `StripeObject` to `APIResource`, and add a test for invoice line item update

### See Also
<!-- Include any links or additional information that help explain this change. -->
