### PR TITLE
adjust lint rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,15 @@ Metrics/MethodLength:
   Max: 55
   Exclude:
     - "lib/stripe/services/v1_services.rb"
+    - "lib/stripe/event_types.rb"
+
+# TODO(xavdid): remove this once the first `basil` release is out
+Naming/MethodName:
+  # these endpoints are removed soon so we pulled their overrides, meaning their names are wrong
+  # that won't make it out to users, but it's breaking linting/formatting in the meantime
+  Exclude:
+    - "lib/stripe/services/invoice_service.rb"
+    - "lib/stripe/resources/invoice.rb"
 
 Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The `/v1/invoices/upcoming/lines` endpoint is being removed soon. As a result, we've been removing codegen overrides to unblock upstream PRs. This means generated ruby methods are no longer valid for lints, which is failing our formatter during codegen. I'm excluding those files for now.

Additionally, an increase in the number of events have made our big event mapping method too long. I fixed excluded that file from linting in a private repo, but should have done it here instead.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- exclude invoice-related code from naming conventions temporarily
- add `event_types` to the method line length exclusions (which duplicates a change made in the private ruby repo that I should have made here)

### See Also
<!-- Include any links or additional information that help explain this change. -->
