### PR TITLE
Fixed broken test caused by removing overrides for invoice/upcoming

### DIFF
--- a/test/stripe/invoice_test.rb
+++ b/test/stripe/invoice_test.rb
@@ -192,21 +192,21 @@ module Stripe
       end
     end
 
-    context ".list_upcoming_line_items" do
-      should "retrieve upcoming invoices" do
-        line_items = Stripe::Invoice.list_upcoming_line_items(
-          customer: "cus_123",
-          subscription: "sub_123"
-        )
-        assert_requested :get, "#{Stripe.api_base}/v1/invoices/upcoming/lines",
-                         query: {
-                           customer: "cus_123",
-                           subscription: "sub_123",
-                         }
-        assert line_items.data.is_a?(Array)
-        assert line_items.data[0].is_a?(Stripe::InvoiceLineItem)
-      end
-    end
+    # context ".list_upcoming_line_items" do
+    #   should "retrieve upcoming invoices" do
+    #     line_items = Stripe::Invoice.list_upcoming_line_items(
+    #       customer: "cus_123",
+    #       subscription: "sub_123"
+    #     )
+    #     assert_requested :get, "#{Stripe.api_base}/v1/invoices/upcoming/lines",
+    #                      query: {
+    #                        customer: "cus_123",
+    #                        subscription: "sub_123",
+    #                      }
+    #     assert line_items.data.is_a?(Array)
+    #     assert line_items.data[0].is_a?(Stripe::InvoiceLineItem)
+    #   end
+    # end
 
     context ".list_line_items" do
       should "retrieve invoice line items" do


### PR DESCRIPTION
### Why?
The `/v1/invoices/upcoming/lines` endpoint is being removed soon. As a result, this test is causing CI failures upstream. 

We don't need to change anything auto-generated; that'll get picked up when the spec is updated. These changes are purely for manual files.

### What?
- comment out test

### See Also
<!-- Include any links or additional information that help explain this change. -->
