### PR TITLE
fix ruby merge conflict for beta

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,6 @@ Layout/LineLength:
     - "lib/stripe/services/**/*.rb"
     - "test/**/*.rb"
 
-
 Lint/MissingSuper:
   Exclude:
     - "lib/stripe/resources/**/*.rb"
@@ -60,8 +59,17 @@ Metrics/MethodLength:
   Max: 55
   Exclude:
     - "lib/stripe/services/v1_services.rb"
+    - "lib/stripe/event_types.rb"
   AllowedMethods:
     - initialize
+
+# TODO(xavdid): remove this once the first `basil` release is out
+Naming/MethodName:
+  # these endpoints are removed soon so we pulled their overrides, meaning their names are wrong
+  # that won't make it out to users, but it's breaking linting/formatting in the meantime
+  Exclude:
+    - "lib/stripe/services/invoice_service.rb"
+    - "lib/stripe/resources/invoice.rb"
 
 Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

I edited the rubocop config in https://github.com/stripe/stripe-ruby/pull/1542, causing a merge conflict here

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- merge; no other changes

### See Also
<!-- Include any links or additional information that help explain this change. -->
