### PR TITLE
Lock `rbi` gem version in jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,8 @@ group :development do
     gem "pry"
     gem "pry-byebug"
   end
+
+  platforms :jruby do
+    gem "rbi", "0.2.4" # jruby does not support rbs, a new dependency in 0.3.0
+  end
 end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`jruby` does not support the `rbs` gem right now (https://github.com/ruby/rbs/issues/2067), and the newest release of `rbi` adds a dependency to the rbs gem. This locks the dependency for jruby only.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
