### PR TITLE
Remove public idempotent_replayed? method

### DIFF
--- a/lib/stripe/errors.rb
+++ b/lib/stripe/errors.rb
@@ -31,13 +31,6 @@ module Stripe
       ErrorObject.construct_from(@json_body[:error], {}, nil, :v1)
     end
 
-    # Whether the error was the result of an idempotent replay, meaning that it
-    # originally occurred on a previous request and is being replayed back
-    # because the user sent the same idempotency key for this one.
-    def idempotent_replayed?
-      @idempotent_replayed
-    end
-
     def to_s
       status_string = @http_status.nil? ? "" : "(Status #{@http_status}) "
       id_string = @request_id.nil? ? "" : "(Request #{@request_id}) "

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -17,12 +17,12 @@ module Stripe
       context "#idempotent_replayed?" do
         should "initialize from header" do
           e = StripeError.new("message", http_headers: { "idempotent-replayed" => "true" })
-          assert_equal true, e.idempotent_replayed?
+          assert_equal true, e.instance_variable_get(:@idempotent_replayed)
         end
 
         should "be 'falsey' by default" do
           e = StripeError.new("message")
-          refute_equal true, e.idempotent_replayed?
+          refute_equal true, e.instance_variable_get(:@idempotent_replayed)
         end
       end
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We don't provide this publicly for v2, removing for consistency.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Remove `idempotent_replayed` method

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://jira.corp.stripe.com/browse/DEVSDK-2040

## Changelog
* ⚠️ Remove the `idempotent_replayed?` method on `StripeError`
  * The information is accessible indirectly via the raw response headers, `StripeResponse.http_headers`. For example, use `resource.last_response.http_headers['Idempotent-Replayed']`