### PR TITLE
Update Stripe.add_beta_version

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -160,16 +160,18 @@ module Stripe
   end
 
   def self.add_beta_version(beta_name, version)
-    unless version.match?(/\Av\d+\z/)
+    unless version.start_with?("v") && version[1..-1].to_i.to_s == version[1..-1]
       raise ArgumentError, "Version must be in the format 'v' followed by a number (e.g., 'v3')"
     end
 
-    if api_version.include?("; #{beta_name}=")
-      current_version = api_version.match(/; #{beta_name}=v(\d+)/)[1].to_i
+    if (index = api_version.index("; #{beta_name}="))
+      start_index = index + "; #{beta_name}=".length
+      end_index = api_version.index(";", start_index) || api_version.length
+      current_version = api_version[start_index...end_index][1..-1].to_i
       new_version = version[1..-1].to_i
       return if new_version <= current_version # Keep the higher version, no update needed
 
-      self.api_version = api_version.sub(/; #{beta_name}=v\d+/, "; #{beta_name}=#{version}")
+      self.api_version = api_version[0...index] + "; #{beta_name}=#{version}" + api_version[end_index..-1]
     else
       self.api_version = "#{api_version}; #{beta_name}=#{version}"
     end

--- a/test/stripe/generated_examples_test.rb
+++ b/test/stripe/generated_examples_test.rb
@@ -3851,20 +3851,6 @@ module Stripe
       client.v1.quotes.update("qt_xxxxxxxxxxxxx", { metadata: { order_id: "6735" } })
       assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v1/quotes/qt_xxxxxxxxxxxxx"
     end
-    should "Test quotes preview invoices lines get" do
-      Stripe::Quote.list_preview_invoice_lines("qt_xyz", "in_xyz")
-      assert_requested :get, "#{Stripe.api_base}/v1/quotes/qt_xyz/preview_invoices/in_xyz/lines"
-    end
-    should "Test quotes preview invoices lines get (service)" do
-      stub_request(
-        :get,
-        "#{Stripe::DEFAULT_API_BASE}/v1/quotes/qt_xyz/preview_invoices/in_xyz/lines"
-      ).to_return(body: "{}")
-      client = StripeClient.new("sk_test_123")
-
-      client.v1.quotes.list_preview_invoice_lines("qt_xyz", "in_xyz")
-      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v1/quotes/qt_xyz/preview_invoices/in_xyz/lines"
-    end
     should "Test radar early fraud warnings get" do
       Stripe::Radar::EarlyFraudWarning.list({ limit: 3 })
       assert_requested :get, "#{Stripe.api_base}/v1/radar/early_fraud_warnings?limit=3"
@@ -4869,22 +4855,6 @@ module Stripe
 
       client.v1.tax_codes.retrieve("txcd_xxxxxxxxxxxxx")
       assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v1/tax_codes/txcd_xxxxxxxxxxxxx"
-    end
-    should "Test tax forms pdf get" do
-      block_handler = {}
-      Stripe::Tax::Form.pdf("form_xxxxxxxxxxxxx", &block_handler)
-      assert_requested :get, "#{Stripe.api_base}/v1/tax/forms/form_xxxxxxxxxxxxx/pdf"
-    end
-    should "Test tax forms pdf get (service)" do
-      block_handler = {}
-      stub_request(
-        :get,
-        "#{Stripe::DEFAULT_UPLOAD_BASE}/v1/tax/forms/form_xxxxxxxxxxxxx/pdf"
-      ).to_return(body: "{}")
-      client = StripeClient.new("sk_test_123")
-
-      client.v1.tax.forms.pdf("form_xxxxxxxxxxxxx", &block_handler)
-      assert_requested :get, "#{Stripe::DEFAULT_UPLOAD_BASE}/v1/tax/forms/form_xxxxxxxxxxxxx/pdf"
     end
     should "Test tax ids delete" do
       Stripe::TaxId.delete("taxid_123")

--- a/test/stripe_test.rb
+++ b/test/stripe_test.rb
@@ -129,16 +129,33 @@ class StripeTest < Test::Unit::TestCase
       assert_equal "https://other.stripe.com", Stripe.meter_events_base
     end
 
-    should "allow beta versions to be added once only" do
+    should "allow beta versions to be added multiple times" do
       Stripe.api_version = "2018-02-28"
 
       Stripe.add_beta_version("my_beta", "v2")
       assert_equal "2018-02-28; my_beta=v2", Stripe.api_version
 
-      err = assert_raises do
-        Stripe.add_beta_version("my_beta", "v1")
-        assert_equal(err, "Stripe version header 2018-02-28; my_beta=v2 already contains entry for beta my_beta")
-      end
+      # same version should be a no-op
+      Stripe.add_beta_version("my_beta", "v2")
+      assert_equal "2018-02-28; my_beta=v2", Stripe.api_version
+
+      # higher version should use higher version
+      Stripe.add_beta_version("my_beta", "v5")
+      assert_equal "2018-02-28; my_beta=v5", Stripe.api_version
+
+      # lower version should be a no-op
+      Stripe.add_beta_version("my_beta", "v4")
+      assert_equal "2018-02-28; my_beta=v5", Stripe.api_version
+    end
+
+    should "allow append multiple beta names" do
+      Stripe.api_version = "2018-02-28"
+
+      Stripe.add_beta_version("my_beta", "v2")
+      assert_equal "2018-02-28; my_beta=v2", Stripe.api_version
+
+      Stripe.add_beta_version("my_beta_two", "v4")
+      assert_equal "2018-02-28; my_beta=v2; my_beta_two=v4", Stripe.api_version
     end
 
     should "allow verify_ssl_certs to be configured" do


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We decided to allow `Stripe.add_beta_version` to overwrite an existing beta version

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Validates that `version` is of the form "v" + a number
- Allows overwriting existing `beta_name`. The new behavior is that the higher `version` is accepted instead of throwing.
- Removes two failing tests for removed API methods

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
- `stripe.add_beta_version` will use the highest version number used for a beta feature instead of raising an `Error` on a conflict as it had done previously.