### PR TITLE
Fix event names and related objects

### DIFF
--- a/lib/stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event.rb
@@ -9,5 +9,15 @@ module Stripe
     end
     # There is additional data present for this event, accessible with the `data` property.
     # See the Stripe API docs for more information.
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_configuration_customer_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_customer_updated_event.rb
@@ -7,5 +7,15 @@ module Stripe
     def self.lookup_type
       "v2.core.account[configuration.customer].updated"
     end
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event.rb
@@ -9,5 +9,15 @@ module Stripe
     end
     # There is additional data present for this event, accessible with the `data` property.
     # See the Stripe API docs for more information.
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_configuration_merchant_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_merchant_updated_event.rb
@@ -7,5 +7,15 @@ module Stripe
     def self.lookup_type
       "v2.core.account[configuration.merchant].updated"
     end
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event.rb
@@ -9,5 +9,15 @@ module Stripe
     end
     # There is additional data present for this event, accessible with the `data` property.
     # See the Stripe API docs for more information.
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_configuration_recipient_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_configuration_recipient_updated_event.rb
@@ -7,5 +7,15 @@ module Stripe
     def self.lookup_type
       "v2.core.account[configuration.recipient].updated"
     end
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_identity_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_identity_updated_event.rb
@@ -7,5 +7,15 @@ module Stripe
     def self.lookup_type
       "v2.core.account[identity].updated"
     end
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_including_requirements_updated_event.rb
+++ b/lib/stripe/events/v2_core_account_including_requirements_updated_event.rb
@@ -7,5 +7,15 @@ module Stripe
     def self.lookup_type
       "v2.core.account[requirements].updated"
     end
+
+    # Retrieves the related object from the API. Make an API request on every call.
+    def fetch_related_object
+      _request(
+        method: :get,
+        path: related_object.url,
+        base_address: :api,
+        opts: { stripe_account: context }
+      )
+    end
   end
 end

--- a/lib/stripe/events/v2_core_account_link_completed_event.rb
+++ b/lib/stripe/events/v2_core_account_link_completed_event.rb
@@ -9,15 +9,5 @@ module Stripe
     end
     # There is additional data present for this event, accessible with the `data` property.
     # See the Stripe API docs for more information.
-
-    # Retrieves the related object from the API. Make an API request on every call.
-    def fetch_related_object
-      _request(
-        method: :get,
-        path: related_object.url,
-        base_address: :api,
-        opts: { stripe_account: context }
-      )
-    end
   end
 end


### PR DESCRIPTION
### Why?
Manually creating PRs as automation is currently failing
Re-generating after the latest set of fixes in the codegen around fixing event names and related objects

### What?
Re-run code gen

