### PR TITLE
Validate all instance variable keys returned from the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Exclude:
     - "lib/stripe/api_requestor.rb"
+    - "lib/stripe/stripe_object.rb"
     - "lib/stripe/util.rb"
 
 Metrics/MethodLength:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ print(customer.last_response.http_status) # to retrieve status code
 print(customer.last_response.http_headers) # to retrieve headers
 ```
 
+If you are accessing a response field with custom hashes provided by you, such as `Customer.metadata`,
+please access your fields with the `[]` accessor.
+
 ### Configuring a proxy
 
 A proxy can be configured with `Stripe.proxy`:

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -372,7 +372,8 @@ module Stripe
       end
 
       keys.each do |k|
-        instance_variable_set(:"@#{k}", values[k])
+        key = Util.normalize_variable_name(k)
+        instance_variable_set(:"@#{key}", values[k])
       end
     end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -372,8 +372,11 @@ module Stripe
       end
 
       keys.each do |k|
-        key = Util.normalize_variable_name(k)
-        instance_variable_set(:"@#{key}", values[k])
+        if !Util.valid_variable_name?(k)
+          Util.log_info(`INFO: The variable name '#{k}' is not a valid Ruby variable name. Use ["#{k}"] to access this field, skipping instance variable instantiation...`)
+        else
+          instance_variable_set(:"@#{k}", values[k])
+        end
       end
     end
 

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -336,7 +336,7 @@ module Stripe
       end
     end
 
-    protected def add_accessors(keys, values)
+    protected def add_accessors(keys, values) # rubocop:todo Metrics/PerceivedComplexity
       # not available in the #instance_eval below
       protected_fields = self.class.protected_fields
 
@@ -372,10 +372,15 @@ module Stripe
       end
 
       keys.each do |k|
-        if !Util.valid_variable_name?(k)
-          Util.log_info(`INFO: The variable name '#{k}' is not a valid Ruby variable name. Use ["#{k}"] to access this field, skipping instance variable instantiation...`)
-        else
+        if Util.valid_variable_name?(k)
           instance_variable_set(:"@#{k}", values[k])
+        else
+          Util.log_info(<<~LOG
+            The variable name '#{k}' is not a valid Ruby variable name.
+            Use ["#{k}"] to access this field, skipping instance variable instantiation...
+          LOG
+                       )
+
         end
       end
     end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -4,6 +4,9 @@ require "cgi"
 
 module Stripe
   module Util
+    LEGAL_FIRST_CHARACTER = /[a-zA-Z_]/.freeze
+    LEGAL_VARIABLE_CHARACTER = /[a-zA-Z0-9_]/.freeze
+
     def self.objects_to_ids(obj)
       case obj
       when APIResource
@@ -312,9 +315,9 @@ module Stripe
     # Return false for strings that are invalid variable names
     # Does NOT expect there to be a preceding '@' for instance variables
     def self.valid_variable_name?(key)
-      return false if key.empty? || key[0] !~ /[a-zA-Z_]/
+      return false if key.empty? || key[0] !~ LEGAL_FIRST_CHARACTER
 
-      key[1..-1].chars.all? { |char| char =~ /[a-zA-Z0-9_]/ }
+      key[1..-1].chars.all? { |char| char =~ LEGAL_VARIABLE_CHARACTER }
     end
 
     def self.check_string_argument!(key)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -309,14 +309,12 @@ module Stripe
       end
     end
 
-    # This will normalize variable names the following way:
-    #   * Downcase the variable name
-    #   * Prepend _ if first character is a number (identifiers cannot begin with an integer)
-    #   * Replace all invalid characters with _, and condense multiple _ to single
-    def self.normalize_variable_name(key)
-      key = key.to_s.downcase
-      key = '_' + key if key.match?(/^\d/)
-      key.gsub(/[^a-z0-9_]/, '_').gsub(/_+/, '_')
+    # Return false for strings that are invalid variable names
+    # Does NOT expect there to be a preceding '@' for instance variables
+    def self.valid_variable_name?(key)
+      return false if key.empty? || key[0] !~ /[a-zA-Z_]/
+
+      key[1..-1].chars.all? { |char| char =~ /[a-zA-Z0-9_]/ }
     end
 
     def self.check_string_argument!(key)

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -309,6 +309,16 @@ module Stripe
       end
     end
 
+    # This will normalize variable names the following way:
+    #   * Downcase the variable name
+    #   * Prepend _ if first character is a number (identifiers cannot begin with an integer)
+    #   * Replace all invalid characters with _, and condense multiple _ to single
+    def self.normalize_variable_name(key)
+      key = key.to_s.downcase
+      key = '_' + key if key.match?(/^\d/)
+      key.gsub(/[^a-z0-9_]/, '_').gsub(/_+/, '_')
+    end
+
     def self.check_string_argument!(key)
       raise TypeError, "argument must be a string" unless key.is_a?(String)
 

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -238,6 +238,13 @@ module Stripe
       assert_equal true, obj.send(:metaclass).method_defined?(:foo)
     end
 
+    should "allow nonstandard keys in response hashes" do
+      stub_request(:post, "#{Stripe.api_base}/v1/customers")
+        .to_return(body: JSON.generate(object: "customer", email: "test@example.com", metadata: { 'this-is?a.test' => "foo"}))
+      c = Stripe::Customer.create({email: 'test@example.com', metadata: { 'this-is?a.test' => "foo"} })
+      assert_equal "foo", c.metadata["this-is?a.test"]
+    end
+
     should "pass opts down to children when initializing" do
       opts = { custom: "opts" }
 

--- a/test/stripe/stripe_object_test.rb
+++ b/test/stripe/stripe_object_test.rb
@@ -238,10 +238,10 @@ module Stripe
       assert_equal true, obj.send(:metaclass).method_defined?(:foo)
     end
 
-    should "allow nonstandard keys in response hashes" do
+    should "nonstandard keys in response hashes work" do
       stub_request(:post, "#{Stripe.api_base}/v1/customers")
-        .to_return(body: JSON.generate(object: "customer", email: "test@example.com", metadata: { 'this-is?a.test' => "foo"}))
-      c = Stripe::Customer.create({email: 'test@example.com', metadata: { 'this-is?a.test' => "foo"} })
+        .to_return(body: JSON.generate(object: "customer", email: "test@example.com", metadata: { "this-is?a.test" => "foo" }))
+      c = Stripe::Customer.create({ email: "test@example.com", metadata: { "this-is?a.test" => "foo" } })
       assert_equal "foo", c.metadata["this-is?a.test"]
     end
 

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -325,27 +325,18 @@ module Stripe
       end
     end
 
-    context ".normalize_variable_name" do
-      should "downcase the variable name" do
-        assert_equal "foo", Util.normalize_variable_name("FOO")
-      end
-
-      should "prepend an underscore if first char is numeric" do
-        assert_equal "_1foo1", Util.normalize_variable_name("1foo1")
-      end
-
-      should "replace non-alphanumeric characters with underscores" do
-        assert_equal "foo_bar", Util.normalize_variable_name("foo-bar")
-        assert_equal "foo_bar", Util.normalize_variable_name("foo?bar")
-        assert_equal "foo_bar", Util.normalize_variable_name("foo!bar")
-      end
-
-      should "replace multiple non-alphanumeric characters with a single underscore" do
-        assert_equal "foo_bar", Util.normalize_variable_name("foo-?!_bar")
-      end
-
-      should "normalize the entire variable name" do
-        assert_equal "_1foo_bar_", Util.normalize_variable_name("1FOO-.><bar?")
+    context ".valid_variable_name?" do
+      should "reject invalid variable name" do
+        assert Util.valid_variable_name?("FOOfoo")
+        assert Util.valid_variable_name?("foo123")
+        assert Util.valid_variable_name?("foo_123_")
+        assert Util.valid_variable_name?("_123_foo")
+        refute Util.valid_variable_name?("123foo")
+        refute Util.valid_variable_name?("foo-bar")
+        refute Util.valid_variable_name?("foo?bar")
+        refute Util.valid_variable_name?("foo!bar")
+        refute Util.valid_variable_name?("foo-?!_bar")
+        refute Util.valid_variable_name?("1FOO-.><bar?")
       end
     end
 

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -325,6 +325,30 @@ module Stripe
       end
     end
 
+    context ".normalize_variable_name" do
+      should "downcase the variable name" do
+        assert_equal "foo", Util.normalize_variable_name("FOO")
+      end
+
+      should "prepend an underscore if first char is numeric" do
+        assert_equal "_1foo1", Util.normalize_variable_name("1foo1")
+      end
+
+      should "replace non-alphanumeric characters with underscores" do
+        assert_equal "foo_bar", Util.normalize_variable_name("foo-bar")
+        assert_equal "foo_bar", Util.normalize_variable_name("foo?bar")
+        assert_equal "foo_bar", Util.normalize_variable_name("foo!bar")
+      end
+
+      should "replace multiple non-alphanumeric characters with a single underscore" do
+        assert_equal "foo_bar", Util.normalize_variable_name("foo-?!_bar")
+      end
+
+      should "normalize the entire variable name" do
+        assert_equal "_1foo_bar_", Util.normalize_variable_name("1FOO-.><bar?")
+      end
+    end
+
     #
     # private
     #


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The Ruby SDK has some weird behaviors where it turns all objects returned by the API into methods, including metadata which can contain keys that are nonstandard. This was causing issues once I added more explicit attributes, defining instance variables to keep our attribute accessors happy dynamically with keys that are nonstandard. Reported in https://github.com/stripe/stripe-ruby/issues/1564

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Validate all keys are invalid and log+reject the ones that are not

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Validate all keys returned from the API, including custom response fields, to make sure they can be set in an instance variable
  * We do not set instance variables for invalid field names (as defined by the [Ruby spec](https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/syntax.html#ident)). We recommend for custom hash map response fields, use the `[]` accessor.
     ```ruby
     c = client.v1.customers.retrieve("cus_123")
     c.metadata["invalid-variable-name!"]
     c.metadata["valid_key_name_works_too"]
    ```