### PR TITLE
Rename `object_id` in V2::Core::EventService::ListParams to `object_id_`

### DIFF
--- a/lib/stripe/services/v2/core/event_service.rb
+++ b/lib/stripe/services/v2/core/event_service.rb
@@ -9,11 +9,13 @@ module Stripe
           # The page size.
           attr_accessor :limit
           # Primary object ID used to retrieve related events.
-          attr_accessor :object_id
+          #
+          # To avoid conflict with Ruby's ':object_id', this attribute has been renamed. If using a hash parameter map instead, please use the original name ':object_id' with NO trailing underscore as the provided param key.
+          attr_accessor :object_id_
 
-          def initialize(limit: nil, object_id: nil)
+          def initialize(limit: nil, object_id_: nil)
             @limit = limit
-            @object_id = object_id
+            @object_id_ = object_id_
           end
         end
 

--- a/rbi/stripe/services/v2/core/event_service.rbi
+++ b/rbi/stripe/services/v2/core/event_service.rbi
@@ -11,10 +11,12 @@ module Stripe
           sig { returns(T.nilable(Integer)) }
           attr_accessor :limit
           # Primary object ID used to retrieve related events.
+          #
+          # To avoid conflict with Ruby's ':object_id', this attribute has been renamed. If using a hash parameter map instead, please use the original name ':object_id' with NO trailing underscore as the provided param key.
           sig { returns(String) }
-          attr_accessor :object_id
-          sig { params(limit: T.nilable(Integer), object_id: String).void }
-          def initialize(limit: nil, object_id: nil); end
+          attr_accessor :object_id_
+          sig { params(limit: T.nilable(Integer), object_id_: String).void }
+          def initialize(limit: nil, object_id_: nil); end
         end
         class RetrieveParams < Stripe::RequestParams
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

As brought up in https://github.com/stripe/stripe-ruby/issues/1567, redefining attribute `object_id` is unsafe and triggers a warning. Rename the field to avoid this conflict.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Rename field `object_id` to `object_id_`

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* ⚠️ Change name of parameter from `object_id` to `object_id_` on `Stripe::V2::Core::EventService::ListParams` to avoid conflict with Ruby native attribute, as found in https://github.com/stripe/stripe-ruby/issues/1567