### PR TITLE
Explicitly pass through custom headers in retrieve

### DIFF
--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -67,7 +67,8 @@ module Stripe
         values.delete(:id)
         opts = Util.normalize_opts(opts)
         APIRequestor.active_requestor.execute_request_initialize_from(:post, save_url, :api, self,
-                                                                      params: values, opts: RequestOptions.extract_opts_from_hash(opts),
+                                                                      params: values,
+                                                                      opts: RequestOptions.extract_opts_from_hash(opts),
                                                                       usage: ["save"])
       end
       extend Gem::Deprecate

--- a/lib/stripe/api_operations/save.rb
+++ b/lib/stripe/api_operations/save.rb
@@ -67,7 +67,7 @@ module Stripe
         values.delete(:id)
         opts = Util.normalize_opts(opts)
         APIRequestor.active_requestor.execute_request_initialize_from(:post, save_url, :api, self,
-                                                                      params: values, opts: opts,
+                                                                      params: values, opts: RequestOptions.extract_opts_from_hash(opts),
                                                                       usage: ["save"])
       end
       extend Gem::Deprecate

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -64,7 +64,8 @@ module Stripe
         opts = Util.normalize_opts(opts)
 
         APIRequestor.active_requestor.execute_request_initialize_from(:post, resource_url, :api, self,
-                                                                      params: values, opts: RequestOptions.extract_opts_from_hash(opts),
+                                                                      params: values,
+                                                                      opts: RequestOptions.extract_opts_from_hash(opts),
                                                                       usage: ["save"])
       end
       extend Gem::Deprecate

--- a/lib/stripe/api_operations/singleton_save.rb
+++ b/lib/stripe/api_operations/singleton_save.rb
@@ -64,7 +64,7 @@ module Stripe
         opts = Util.normalize_opts(opts)
 
         APIRequestor.active_requestor.execute_request_initialize_from(:post, resource_url, :api, self,
-                                                                      params: values, opts: opts,
+                                                                      params: values, opts: RequestOptions.extract_opts_from_hash(opts),
                                                                       usage: ["save"])
       end
       extend Gem::Deprecate

--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -220,9 +220,11 @@ module Stripe
     # with future non-major changes.
     def execute_request_initialize_from(method, path, base_address, object,
                                         params: {}, opts: {}, usage: [])
-      opts = RequestOptions.combine_opts(object.instance_variable_get(:@opts), opts)
+      opts = RequestOptions.combine_opts(object.instance_variable_get(:@opts) || {}, opts)
       opts = Util.normalize_opts(opts)
+
       params = params.to_h if params.is_a?(RequestParams)
+
       http_resp, req_opts = execute_request_internal(
         method, path, base_address, params, opts, usage
       )

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -119,7 +119,9 @@ module Stripe
 
       instance = new(id)
       # Explicitly send options for the retrieve call, to preserve custom headers
-      # This is ugly, we should clean this up with the rest of the RequestOptions
+      # This is so we can pass custom headers from this static function
+      # to the instance variable method call
+      # The custom headers will be cleaned up with the rest of the RequestOptions
       instance.instance_variable_set(:@retrieve_opts, Util.normalize_opts(opts))
       instance.refresh
     end

--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -98,7 +98,10 @@ module Stripe
               "It is not possible to refresh v2 objects. Please retrieve the object using the StripeClient instead."
       end
 
-      @obj = @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params)
+      opts = RequestOptions.extract_opts_from_hash(@retrieve_opts || {})
+      @retrieve_opts = {} # Make sure to clear the retrieve options
+      @obj = @requestor.execute_request_initialize_from(:get, resource_url, :api, self, params: @retrieve_params,
+                                                                                        opts: opts)
       initialize_from(
         @obj.last_response.data,
         @obj.instance_variable_get(:@opts),
@@ -114,8 +117,10 @@ module Stripe
               "It is not possible to retrieve v2 objects on the resource. Please use the StripeClient instead."
       end
 
-      opts = Util.normalize_opts(opts)
-      instance = new(id, opts)
+      instance = new(id)
+      # Explicitly send options for the retrieve call, to preserve custom headers
+      # This is ugly, we should clean this up with the rest of the RequestOptions
+      instance.instance_variable_set(:@retrieve_opts, Util.normalize_opts(opts))
       instance.refresh
     end
 

--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -64,11 +64,7 @@ module Stripe
         stripe_account: req_opts[:stripe_account] || object_opts[:stripe_account],
         stripe_context: req_opts[:stripe_context] || object_opts[:stripe_context],
         stripe_version: req_opts[:stripe_version] || object_opts[:stripe_version],
-        # We want this to be explicitly filtered out if it's not passed in per-request
-        # otherwise we end up calling extract_opts_from_hash on what is returned here
-        # in a few resource-based calls which causes it to pass a nested map to the API.
-        # NET::HTTP does not permit this.
-        headers: req_opts[:headers] || nil,
+        headers: req_opts[:headers] || {},
       }
 
       # Remove nil values from headers

--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -65,7 +65,9 @@ module Stripe
         stripe_context: req_opts[:stripe_context] || object_opts[:stripe_context],
         stripe_version: req_opts[:stripe_version] || object_opts[:stripe_version],
         # We want this to be explicitly filtered out if it's not passed in per-request
-        # TODO: More details?
+        # otherwise we end up calling extract_opts_from_hash on what is returned here
+        # in a few resource-based calls which causes it to pass a nested map to the API.
+        # NET::HTTP does not permit this.
         headers: req_opts[:headers] || nil,
       }
 
@@ -76,7 +78,7 @@ module Stripe
     end
 
     # Extracts options from a user-provided hash, returning a new request options hash
-    # containing the recognized request options and a `headers` entry.
+    # containing the recognized request options and a `headers` entry for the remaining options.
     def self.extract_opts_from_hash(opts)
       req_opts = {}
       normalized_opts = Util.normalize_opts(opts.clone)

--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -56,7 +56,7 @@ module Stripe
     # Merges requestor options hash on a StripeObject
     # with a per-request options hash, giving precedence
     # to the per-request options. Returns the merged request options.
-    # Expects two hashes.
+    # Expects two hashes, expects extract_opts_from_hash to be called first!!!
     def self.combine_opts(object_opts, req_opts)
       merged_opts = {
         api_key: req_opts[:api_key] || object_opts[:api_key],

--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -64,6 +64,9 @@ module Stripe
         stripe_account: req_opts[:stripe_account] || object_opts[:stripe_account],
         stripe_context: req_opts[:stripe_context] || object_opts[:stripe_context],
         stripe_version: req_opts[:stripe_version] || object_opts[:stripe_version],
+        # We want this to be explicitly filtered out if it's not passed in per-request
+        # TODO: More details?
+        headers: req_opts[:headers] || nil,
       }
 
       # Remove nil values from headers
@@ -73,7 +76,7 @@ module Stripe
     end
 
     # Extracts options from a user-provided hash, returning a new request options hash
-    # containing the recognized request options and a `headers` entry for the remaining options.
+    # containing the recognized request options and a `headers` entry.
     def self.extract_opts_from_hash(opts)
       req_opts = {}
       normalized_opts = Util.normalize_opts(opts.clone)

--- a/lib/stripe/resources/source.rb
+++ b/lib/stripe/resources/source.rb
@@ -1270,7 +1270,7 @@ module Stripe
             "/#{CGI.escape(id)}"
       opts = Util.normalize_opts(opts)
       APIRequestor.active_requestor.execute_request_initialize_from(:delete, url, :api, self,
-                                                                    params: params, opts: opts)
+                                                                    params: params, opts: RequestOptions.extract_opts_from_hash(opts))
     end
 
     def source_transactions(params = {}, opts = {})

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -473,7 +473,8 @@ module Stripe
 
     # Should only be for v2 events and lists, for now.
     protected def _request(method:, path:, base_address:, params: {}, opts: {})
-      req_opts = RequestOptions.combine_opts(@opts, opts)
+      req_opts = RequestOptions.extract_opts_from_hash(opts)
+      req_opts = RequestOptions.combine_opts(@opts, req_opts)
       @requestor.execute_request(
         method,
         path,

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -480,7 +480,7 @@ module Stripe
         path,
         base_address,
         params: params,
-        opts: RequestOptions.extract_opts_from_hash(req_opts)
+        opts: req_opts
       )
     end
 

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -423,6 +423,16 @@ module Stripe
         c.save
       end
 
+      should "pass custom headers to the call on calls that use initialize_from" do
+        req = nil
+        stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
+          .with { |request| req = request }
+          .to_return(body: JSON.generate(customer_fixture))
+
+        Stripe::Customer.retrieve("cus_123", { "A-Header": "foo" })
+        assert_equal "foo", req.headers["A-Header"]
+      end
+
       should "add key to nested objects on save" do
         acct = Stripe::Account.construct_from(id: "myid",
                                               legal_entity: {

--- a/test/stripe/api_resource_test.rb
+++ b/test/stripe/api_resource_test.rb
@@ -423,14 +423,21 @@ module Stripe
         c.save
       end
 
-      should "pass custom headers to the call on calls that use initialize_from" do
-        req = nil
+      should "pass custom headers to execute_request_initialize_from and don't carry through" do
+        req1 = nil
+        req2 = nil
         stub_request(:get, "#{Stripe.api_base}/v1/customers/cus_123")
-          .with { |request| req = request }
+          .with { |request| req1 = request }
           .to_return(body: JSON.generate(customer_fixture))
+        stub_request(:delete, "#{Stripe.api_base}/v1/customers/cus_123")
+          .with { |request| req2 = request }
+          .to_return(body: JSON.generate(object: "customer"))
 
-        Stripe::Customer.retrieve("cus_123", { "A-Header": "foo" })
-        assert_equal "foo", req.headers["A-Header"]
+        c = Stripe::Customer.retrieve("cus_123", { "A-Header": "foo" })
+        assert_equal "foo", req1.headers["A-Header"]
+
+        c.delete
+        assert_nil req2.headers["A-Header"]
       end
 
       should "add key to nested objects on save" do

--- a/test/stripe/request_options_test.rb
+++ b/test/stripe/request_options_test.rb
@@ -87,6 +87,17 @@ module Stripe
         assert_equal(combined[:api_key], "sk_456")
         assert_equal(combined[:stripe_account], "acct_123")
       end
+
+      should "correctly only retain per-request custom keys" do
+        object_opts = { api_key: "sk_123", stripe_version: "2022-11-15" , headers: {"Test-Header": "foo"}}
+        request_opts = { api_key: "sk_456", stripe_account: "acct_123" , headers: {"Cool-Header": "bar"}}
+        combined = RequestOptions.combine_opts(object_opts, request_opts)
+        assert_equal("2022-11-15", combined[:stripe_version])
+        assert_equal("sk_456", combined[:api_key])
+        assert_equal( "acct_123", combined[:stripe_account])
+        assert !combined.key?(:test_header)
+        assert_equal({ :"Cool-Header" => "bar" }, combined[:headers])
+      end
     end
   end
 end

--- a/test/stripe/request_options_test.rb
+++ b/test/stripe/request_options_test.rb
@@ -89,14 +89,14 @@ module Stripe
       end
 
       should "correctly only retain per-request custom keys" do
-        object_opts = { api_key: "sk_123", stripe_version: "2022-11-15" , headers: {"Test-Header": "foo"}}
-        request_opts = { api_key: "sk_456", stripe_account: "acct_123" , headers: {"Cool-Header": "bar"}}
+        object_opts = { api_key: "sk_123", stripe_version: "2022-11-15", headers: { "Test-Header": "foo" } }
+        request_opts = { api_key: "sk_456", stripe_account: "acct_123", headers: { "Cool-Header": "bar" } }
         combined = RequestOptions.combine_opts(object_opts, request_opts)
         assert_equal("2022-11-15", combined[:stripe_version])
         assert_equal("sk_456", combined[:api_key])
-        assert_equal( "acct_123", combined[:stripe_account])
+        assert_equal("acct_123", combined[:stripe_account])
         assert !combined.key?(:test_header)
-        assert_equal({ :"Cool-Header" => "bar" }, combined[:headers])
+        assert_equal({ "Cool-Header": "bar" }, combined[:headers])
       end
     end
   end

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -248,7 +248,7 @@ module Stripe
         assert_equal "idemp_123", req.headers["Idempotency-Key"]
       end
 
-      should "allow a request with custom headers but not carry through" do
+      should "allow a request with custom headers but not persist to subsequent requests" do
         req1 = nil
         req2 = nil
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/customers")

--- a/test/stripe/stripe_client_test.rb
+++ b/test/stripe/stripe_client_test.rb
@@ -254,16 +254,16 @@ module Stripe
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/customers")
           .with { |request| req1 = request }
           .to_return(body: JSON.generate(object: "customer", id: "cus_123"))
-        stub_request(:delete, "#{Stripe.api_base}/v1/customers/cus_123")
+        stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v1/customers/cus_123")
           .with { |request| req2 = request }
-          .to_return(body: "{}")
+          .to_return(body: JSON.generate(object: "customer", id: "cus_123"))
 
         client = StripeClient.new("sk_test_123")
         Stripe.api_key = "sk_test_123"
 
         cus = client.v1.customers.create({}, { "A-Header": "foo" })
         assert_equal "foo", req1.headers["A-Header"]
-        cus.delete
+        cus.refresh
         assert_nil req2.headers["A-Header"]
       end
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

After v13, custom options passing was not working in retrieve as it was pre-v13. This flows the options through in this and other requests that use the `execute_request_initialize_from` method.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

This sets a new variable that is sent to refresh, then @opts is set by our normal request-sending which then sets the correct options on the object for future requests made on that object. We do NOT want to continue sending custom headers, so it still does not persist these custom options on the object after the request is sent.

Some important notes:
* Net::HTTP does NOT allow nested maps, so I've explicitly added comments to make it more clear how to flow options using these requests
* I've also fixed some other cases where we don't process the headers before making our `execute_request_intialize_from` call

I've also filed a future ticket to make all of this cleaner, this is all very ugly and hard to understand. We need this in the short-term as a band-aid. More context in Jira.

I've also tested locally calling retrieve with custom headers and it does log/reach the API (checked the latter with request logs):
```
> c = Stripe::Customer.retrieve("cus_Q11bcaSRwSQRAM", {"Test-Header": "foo", "Header2": "bar"})
#<Stripe::Instrumentation::RequestEndEvent:0x000000011d2dadc0>
{"User-Agent"=>"Stripe/v1 RubyBindings/14.0.0", "Authorization"=>"Bearer ...", ..., "Test-Header"=>"foo", "Header2"=>"bar"}
```

### See Also
<!-- Include any links or additional information that help explain this change. -->
* Sending custom options fix [JIRA](https://jira.corp.stripe.com/browse/DEVSDK-2459)
* RequestOptions cleanup [JIRA](https://jira.corp.stripe.com/browse/DEVSDK-2492)

## Changelog
* Fix custom options passing for resource-based retrieve