### PR TITLE
Added rubocop exclusion for generated tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,6 +201,9 @@ Lint/UnexpectedBlockArity: # new in 1.5
   Enabled: true
 Lint/UnmodifiedReduceAccumulator: # new in 1.1
   Enabled: true
+Lint/UselessAssignment:
+  Exclude:
+    - "test/stripe/generated_examples_test.rb"
 Lint/UselessRescue: # new in 1.43
   Enabled: true
 Lint/UselessRuby2Keywords: # new in 1.23


### PR DESCRIPTION
### Why?
Generated tests will have a variable type after https://github.com/stripe/sdk-codegen/pull/2367 is merged.

### What?
Added an exception to excluded generated_examples_test.rb

### See Also
<!-- Include any links or additional information that help explain this change. -->
