### PR TITLE
Include new Ruby 3.4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, '3.3', jruby-9.4.0.0, truffleruby-head]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4.0.0, truffleruby-head]
     steps:
     - uses: extractions/setup-just@v2
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Why?
In order to keep supporting new versions of Ruby we need to test against them.

### What?
Added Ruby version `3.4` to CI workflow. 

### See Also

