### PR TITLE
Fix mismatched indentations in `nested_resource`

### DIFF
--- a/lib/stripe/api_operations/nested_resource.rb
+++ b/lib/stripe/api_operations/nested_resource.rb
@@ -45,53 +45,53 @@ module Stripe
         when :create
           define_singleton_method(:"create_#{resource}") \
               do |id, params = {}, opts = {}|
-            request_stripe_object(
-              method: :post,
-              path: send(resource_url_method, id),
-              params: params,
-              opts: opts
-            )
-          end
+                request_stripe_object(
+                  method: :post,
+                  path: send(resource_url_method, id),
+                  params: params,
+                  opts: opts
+                )
+              end
         when :retrieve
           define_singleton_method(:"retrieve_#{resource}") \
               do |id, nested_id, params = {}, opts = {}|
-            request_stripe_object(
-              method: :get,
-              path: send(resource_url_method, id, nested_id),
-              params: params,
-              opts: opts
-            )
-          end
+                request_stripe_object(
+                  method: :get,
+                  path: send(resource_url_method, id, nested_id),
+                  params: params,
+                  opts: opts
+                )
+              end
         when :update
           define_singleton_method(:"update_#{resource}") \
               do |id, nested_id, params = {}, opts = {}|
-            request_stripe_object(
-              method: :post,
-              path: send(resource_url_method, id, nested_id),
-              params: params,
-              opts: opts
-            )
-          end
+                request_stripe_object(
+                  method: :post,
+                  path: send(resource_url_method, id, nested_id),
+                  params: params,
+                  opts: opts
+                )
+              end
         when :delete
           define_singleton_method(:"delete_#{resource}") \
               do |id, nested_id, params = {}, opts = {}|
-            request_stripe_object(
-              method: :delete,
-              path: send(resource_url_method, id, nested_id),
-              params: params,
-              opts: opts
-            )
-          end
+                request_stripe_object(
+                  method: :delete,
+                  path: send(resource_url_method, id, nested_id),
+                  params: params,
+                  opts: opts
+                )
+              end
         when :list
           define_singleton_method(:"list_#{resource_plural}") \
               do |id, params = {}, opts = {}|
-            request_stripe_object(
-              method: :get,
-              path: send(resource_url_method, id),
-              params: params,
-              opts: opts
-            )
-          end
+                request_stripe_object(
+                  method: :get,
+                  path: send(resource_url_method, id),
+                  params: params,
+                  opts: opts
+                )
+              end
         else
           raise ArgumentError, "Unknown operation: #{operation.inspect}"
         end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fix indentation when `end` doesn't match `do`, which raises a warning. Resolving https://github.com/stripe/stripe-ruby/pull/1403/files.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Overall no-op, just whitespace change

### See Also
<!-- Include any links or additional information that help explain this change. -->
