### PR TITLE
Updated rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -326,3 +326,73 @@ Style/SwapValues: # new in 1.1
   Enabled: true
 Style/YAMLFileRead: # new in 1.53
   Enabled: true
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
+Lint/ConstantReassignment: # new in 1.70
+  Enabled: true
+Lint/CopDirectiveSyntax: # new in 1.72
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
+Lint/RedundantTypeConversion: # new in 1.72
+  Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion: # new in 1.72
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessConstantScoping: # new in 1.72
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/ComparableBetween: # new in 1.74
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/HashFetchChain: # new in 1.75
+  Enabled: true
+Style/HashSlice: # new in 1.71
+  Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/ItBlockParameter: # new in 1.75
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/RedundantFormat: # new in 1.72
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
   # up-to-date, but it's not the end of the world if it's not.
   #
   # The latest version of rubocop is only compatible with Ruby 2.7+
-  gem "rubocop", "1.57.2" if RUBY_VERSION >= "2.7"
+  gem "rubocop", "1.75.2" if RUBY_VERSION >= "2.7"
 
   gem "sorbet"
   gem "tapioca"

--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -913,7 +913,7 @@ module Stripe
                   "with Stripe. Please let us know at support@stripe.com."
       end
 
-      message = message % base_url
+      message %= base_url
 
       message += " Request was retried #{num_retries} times." if num_retries > 0
 

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -36,9 +36,7 @@ module Stripe
     # clears them from internal tracking.
     def clear
       @mutex.synchronize do
-        @active_connections.each do |_, connection|
-          connection.finish
-        end
+        @active_connections.each_value(&:finish)
         @active_connections = {}
       end
     end

--- a/lib/stripe/oauth.rb
+++ b/lib/stripe/oauth.rb
@@ -8,7 +8,7 @@ module Stripe
       def self.execute_resource_request(method, url, base_address, params, opts)
         opts = Util.normalize_opts(opts)
 
-        super(method, url, base_address, params, opts)
+        super
       end
     end
 

--- a/lib/stripe/resources/account.rb
+++ b/lib/stripe/resources/account.rb
@@ -4804,7 +4804,7 @@ module Stripe
         opts = id
         id = nil
       end
-      super(id, opts)
+      super
     end
 
     # We are not adding a helper for capabilities here as the Account object
@@ -4844,7 +4844,7 @@ module Stripe
         entity_update[:additional_owners] =
           serialize_additional_owners(entity, owners)
       end
-      if (individual = @values[:individual]) && (individual.is_a?(Person) && !update_hash.key?(:individual))
+      if (individual = @values[:individual]) && individual.is_a?(Person) && !update_hash.key?(:individual)
         update_hash[:individual] = individual.serialize_params(options)
       end
       update_hash

--- a/lib/stripe/resources/funding_instructions.rb
+++ b/lib/stripe/resources/funding_instructions.rb
@@ -326,7 +326,7 @@ module Stripe
         raise NotImplementedError,
               "FundingInstructions cannot be accessed without a customer ID."
       end
-      "#{Customer.resource_url}/#{CGI.escape(customer)}/funding_instructions" "/#{CGI.escape(id)}"
+      "#{Customer.resource_url}/#{CGI.escape(customer)}/funding_instructions" + "/#{CGI.escape(id)}"
     end
   end
 end

--- a/lib/stripe/services/account_service.rb
+++ b/lib/stripe/services/account_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :capabilities, :external_accounts, :login_links, :persons
 
     def initialize(requestor)
-      super(requestor)
+      super
       @capabilities = Stripe::AccountCapabilityService.new(@requestor)
       @external_accounts = Stripe::AccountExternalAccountService.new(@requestor)
       @login_links = Stripe::AccountLoginLinkService.new(@requestor)

--- a/lib/stripe/services/application_fee_service.rb
+++ b/lib/stripe/services/application_fee_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :refunds
 
     def initialize(requestor)
-      super(requestor)
+      super
       @refunds = Stripe::ApplicationFeeRefundService.new(@requestor)
     end
 

--- a/lib/stripe/services/apps_service.rb
+++ b/lib/stripe/services/apps_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :secrets
 
     def initialize(requestor)
-      super(requestor)
+      super
       @secrets = Stripe::Apps::SecretService.new(@requestor)
     end
   end

--- a/lib/stripe/services/billing/meter_service.rb
+++ b/lib/stripe/services/billing/meter_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :event_summaries
 
       def initialize(requestor)
-        super(requestor)
+        super
         @event_summaries = Stripe::Billing::MeterEventSummaryService.new(@requestor)
       end
 

--- a/lib/stripe/services/billing_portal_service.rb
+++ b/lib/stripe/services/billing_portal_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :configurations, :sessions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @configurations = Stripe::BillingPortal::ConfigurationService.new(@requestor)
       @sessions = Stripe::BillingPortal::SessionService.new(@requestor)
     end

--- a/lib/stripe/services/billing_service.rb
+++ b/lib/stripe/services/billing_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :alerts, :credit_balance_summary, :credit_balance_transactions, :credit_grants, :meters, :meter_events, :meter_event_adjustments
 
     def initialize(requestor)
-      super(requestor)
+      super
       @alerts = Stripe::Billing::AlertService.new(@requestor)
       @credit_balance_summary = Stripe::Billing::CreditBalanceSummaryService.new(@requestor)
       @credit_balance_transactions = Stripe::Billing::CreditBalanceTransactionService

--- a/lib/stripe/services/checkout/session_service.rb
+++ b/lib/stripe/services/checkout/session_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :line_items
 
       def initialize(requestor)
-        super(requestor)
+        super
         @line_items = Stripe::Checkout::SessionLineItemService.new(@requestor)
       end
 

--- a/lib/stripe/services/checkout_service.rb
+++ b/lib/stripe/services/checkout_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :sessions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @sessions = Stripe::Checkout::SessionService.new(@requestor)
     end
   end

--- a/lib/stripe/services/climate_service.rb
+++ b/lib/stripe/services/climate_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :orders, :products, :suppliers
 
     def initialize(requestor)
-      super(requestor)
+      super
       @orders = Stripe::Climate::OrderService.new(@requestor)
       @products = Stripe::Climate::ProductService.new(@requestor)
       @suppliers = Stripe::Climate::SupplierService.new(@requestor)

--- a/lib/stripe/services/credit_note_service.rb
+++ b/lib/stripe/services/credit_note_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :line_items, :preview_lines
 
     def initialize(requestor)
-      super(requestor)
+      super
       @line_items = Stripe::CreditNoteLineItemService.new(@requestor)
       @preview_lines = Stripe::CreditNotePreviewLinesService.new(@requestor)
     end

--- a/lib/stripe/services/customer_service.rb
+++ b/lib/stripe/services/customer_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :cash_balance, :balance_transactions, :cash_balance_transactions, :payment_sources, :tax_ids, :payment_methods, :funding_instructions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @cash_balance = Stripe::CustomerCashBalanceService.new(@requestor)
       @balance_transactions = Stripe::CustomerBalanceTransactionService.new(@requestor)
       @cash_balance_transactions = Stripe::CustomerCashBalanceTransactionService.new(@requestor)

--- a/lib/stripe/services/entitlements_service.rb
+++ b/lib/stripe/services/entitlements_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :active_entitlements, :features
 
     def initialize(requestor)
-      super(requestor)
+      super
       @active_entitlements = Stripe::Entitlements::ActiveEntitlementService.new(@requestor)
       @features = Stripe::Entitlements::FeatureService.new(@requestor)
     end

--- a/lib/stripe/services/financial_connections/account_service.rb
+++ b/lib/stripe/services/financial_connections/account_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :owners
 
       def initialize(requestor)
-        super(requestor)
+        super
         @owners = Stripe::FinancialConnections::AccountOwnerService.new(@requestor)
       end
 

--- a/lib/stripe/services/financial_connections_service.rb
+++ b/lib/stripe/services/financial_connections_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :accounts, :sessions, :transactions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @accounts = Stripe::FinancialConnections::AccountService.new(@requestor)
       @sessions = Stripe::FinancialConnections::SessionService.new(@requestor)
       @transactions = Stripe::FinancialConnections::TransactionService.new(@requestor)

--- a/lib/stripe/services/forwarding_service.rb
+++ b/lib/stripe/services/forwarding_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :requests
 
     def initialize(requestor)
-      super(requestor)
+      super
       @requests = Stripe::Forwarding::RequestService.new(@requestor)
     end
   end

--- a/lib/stripe/services/identity_service.rb
+++ b/lib/stripe/services/identity_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :verification_reports, :verification_sessions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @verification_reports = Stripe::Identity::VerificationReportService.new(@requestor)
       @verification_sessions = Stripe::Identity::VerificationSessionService.new(@requestor)
     end

--- a/lib/stripe/services/invoice_service.rb
+++ b/lib/stripe/services/invoice_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :line_items
 
     def initialize(requestor)
-      super(requestor)
+      super
       @line_items = Stripe::InvoiceLineItemService.new(@requestor)
     end
 

--- a/lib/stripe/services/issuing_service.rb
+++ b/lib/stripe/services/issuing_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :authorizations, :cards, :cardholders, :disputes, :personalization_designs, :physical_bundles, :tokens, :transactions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @authorizations = Stripe::Issuing::AuthorizationService.new(@requestor)
       @cards = Stripe::Issuing::CardService.new(@requestor)
       @cardholders = Stripe::Issuing::CardholderService.new(@requestor)

--- a/lib/stripe/services/payment_link_service.rb
+++ b/lib/stripe/services/payment_link_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :line_items
 
     def initialize(requestor)
-      super(requestor)
+      super
       @line_items = Stripe::PaymentLinkLineItemService.new(@requestor)
     end
 

--- a/lib/stripe/services/product_service.rb
+++ b/lib/stripe/services/product_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :features
 
     def initialize(requestor)
-      super(requestor)
+      super
       @features = Stripe::ProductFeatureService.new(@requestor)
     end
 

--- a/lib/stripe/services/quote_service.rb
+++ b/lib/stripe/services/quote_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :line_items, :computed_upfront_line_items
 
     def initialize(requestor)
-      super(requestor)
+      super
       @line_items = Stripe::QuoteLineItemService.new(@requestor)
       @computed_upfront_line_items = Stripe::QuoteComputedUpfrontLineItemsService.new(@requestor)
     end

--- a/lib/stripe/services/radar_service.rb
+++ b/lib/stripe/services/radar_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :early_fraud_warnings, :value_lists, :value_list_items
 
     def initialize(requestor)
-      super(requestor)
+      super
       @early_fraud_warnings = Stripe::Radar::EarlyFraudWarningService.new(@requestor)
       @value_lists = Stripe::Radar::ValueListService.new(@requestor)
       @value_list_items = Stripe::Radar::ValueListItemService.new(@requestor)

--- a/lib/stripe/services/reporting_service.rb
+++ b/lib/stripe/services/reporting_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :report_runs, :report_types
 
     def initialize(requestor)
-      super(requestor)
+      super
       @report_runs = Stripe::Reporting::ReportRunService.new(@requestor)
       @report_types = Stripe::Reporting::ReportTypeService.new(@requestor)
     end

--- a/lib/stripe/services/sigma_service.rb
+++ b/lib/stripe/services/sigma_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :scheduled_query_runs
 
     def initialize(requestor)
-      super(requestor)
+      super
       @scheduled_query_runs = Stripe::Sigma::ScheduledQueryRunService.new(@requestor)
     end
   end

--- a/lib/stripe/services/source_service.rb
+++ b/lib/stripe/services/source_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :transactions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @transactions = Stripe::SourceTransactionService.new(@requestor)
     end
 

--- a/lib/stripe/services/tax/calculation_service.rb
+++ b/lib/stripe/services/tax/calculation_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :line_items
 
       def initialize(requestor)
-        super(requestor)
+        super
         @line_items = Stripe::Tax::CalculationLineItemService.new(@requestor)
       end
 

--- a/lib/stripe/services/tax/transaction_service.rb
+++ b/lib/stripe/services/tax/transaction_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :line_items
 
       def initialize(requestor)
-        super(requestor)
+        super
         @line_items = Stripe::Tax::TransactionLineItemService.new(@requestor)
       end
 

--- a/lib/stripe/services/tax_service.rb
+++ b/lib/stripe/services/tax_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :calculations, :registrations, :settings, :transactions
 
     def initialize(requestor)
-      super(requestor)
+      super
       @calculations = Stripe::Tax::CalculationService.new(@requestor)
       @registrations = Stripe::Tax::RegistrationService.new(@requestor)
       @settings = Stripe::Tax::SettingsService.new(@requestor)

--- a/lib/stripe/services/terminal_service.rb
+++ b/lib/stripe/services/terminal_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :configurations, :connection_tokens, :locations, :readers
 
     def initialize(requestor)
-      super(requestor)
+      super
       @configurations = Stripe::Terminal::ConfigurationService.new(@requestor)
       @connection_tokens = Stripe::Terminal::ConnectionTokenService.new(@requestor)
       @locations = Stripe::Terminal::LocationService.new(@requestor)

--- a/lib/stripe/services/test_helpers/issuing_service.rb
+++ b/lib/stripe/services/test_helpers/issuing_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :authorizations, :cards, :personalization_designs, :transactions
 
       def initialize(requestor)
-        super(requestor)
+        super
         @authorizations = Stripe::TestHelpers::Issuing::AuthorizationService.new(@requestor)
         @cards = Stripe::TestHelpers::Issuing::CardService.new(@requestor)
         @personalization_designs = Stripe::TestHelpers::Issuing::PersonalizationDesignService

--- a/lib/stripe/services/test_helpers/terminal_service.rb
+++ b/lib/stripe/services/test_helpers/terminal_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :readers
 
       def initialize(requestor)
-        super(requestor)
+        super
         @readers = Stripe::TestHelpers::Terminal::ReaderService.new(@requestor)
       end
     end

--- a/lib/stripe/services/test_helpers/treasury_service.rb
+++ b/lib/stripe/services/test_helpers/treasury_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :inbound_transfers, :outbound_payments, :outbound_transfers, :received_credits, :received_debits
 
       def initialize(requestor)
-        super(requestor)
+        super
         @inbound_transfers = Stripe::TestHelpers::Treasury::InboundTransferService.new(@requestor)
         @outbound_payments = Stripe::TestHelpers::Treasury::OutboundPaymentService.new(@requestor)
         @outbound_transfers = Stripe::TestHelpers::Treasury::OutboundTransferService.new(@requestor)

--- a/lib/stripe/services/test_helpers_service.rb
+++ b/lib/stripe/services/test_helpers_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :confirmation_tokens, :customers, :issuing, :refunds, :terminal, :test_clocks, :treasury
 
     def initialize(requestor)
-      super(requestor)
+      super
       @confirmation_tokens = Stripe::TestHelpers::ConfirmationTokenService.new(@requestor)
       @customers = Stripe::TestHelpers::CustomerService.new(@requestor)
       @issuing = Stripe::TestHelpers::IssuingService.new(@requestor)

--- a/lib/stripe/services/transfer_service.rb
+++ b/lib/stripe/services/transfer_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :reversals
 
     def initialize(requestor)
-      super(requestor)
+      super
       @reversals = Stripe::TransferReversalService.new(@requestor)
     end
 

--- a/lib/stripe/services/treasury/financial_account_service.rb
+++ b/lib/stripe/services/treasury/financial_account_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :features
 
       def initialize(requestor)
-        super(requestor)
+        super
         @features = Stripe::Treasury::FinancialAccountFeaturesService.new(@requestor)
       end
 

--- a/lib/stripe/services/treasury_service.rb
+++ b/lib/stripe/services/treasury_service.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :credit_reversals, :debit_reversals, :financial_accounts, :inbound_transfers, :outbound_payments, :outbound_transfers, :received_credits, :received_debits, :transactions, :transaction_entries
 
     def initialize(requestor)
-      super(requestor)
+      super
       @credit_reversals = Stripe::Treasury::CreditReversalService.new(@requestor)
       @debit_reversals = Stripe::Treasury::DebitReversalService.new(@requestor)
       @financial_accounts = Stripe::Treasury::FinancialAccountService.new(@requestor)

--- a/lib/stripe/services/v1_services.rb
+++ b/lib/stripe/services/v1_services.rb
@@ -11,7 +11,7 @@ module Stripe
     attr_reader :oauth
 
     def initialize(requestor)
-      super(requestor)
+      super
       # v1 services: The beginning of the section generated from our OpenAPI spec
       @accounts = Stripe::AccountService.new(@requestor)
       @account_links = Stripe::AccountLinkService.new(@requestor)

--- a/lib/stripe/services/v2/billing_service.rb
+++ b/lib/stripe/services/v2/billing_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :meter_event_session, :meter_event_adjustments, :meter_event_stream, :meter_events
 
       def initialize(requestor)
-        super(requestor)
+        super
         @meter_event_session = Stripe::V2::Billing::MeterEventSessionService.new(@requestor)
         @meter_event_adjustments = Stripe::V2::Billing::MeterEventAdjustmentService.new(@requestor)
         @meter_event_stream = Stripe::V2::Billing::MeterEventStreamService.new(@requestor)

--- a/lib/stripe/services/v2/core_service.rb
+++ b/lib/stripe/services/v2/core_service.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_reader :event_destinations, :events
 
       def initialize(requestor)
-        super(requestor)
+        super
         @event_destinations = Stripe::V2::Core::EventDestinationService.new(@requestor)
         @events = Stripe::V2::Core::EventService.new(@requestor)
       end

--- a/lib/stripe/services/v2_services.rb
+++ b/lib/stripe/services/v2_services.rb
@@ -6,7 +6,7 @@ module Stripe
     attr_reader :billing, :core
 
     def initialize(requestor)
-      super(requestor)
+      super
       @billing = Stripe::V2::BillingService.new(@requestor)
       @core = Stripe::V2::CoreService.new(@requestor)
     end

--- a/test/stripe/api_requestor_test.rb
+++ b/test/stripe/api_requestor_test.rb
@@ -492,7 +492,7 @@ module Stripe
                 data[:thread_object_id] == Thread.current.object_id &&
                 (data[:connection_manager_object_id].is_a? Numeric) &&
                 (data[:connection_object_id].is_a? Numeric) &&
-                data[:log_timestamp] == 0.0 # rubocop:todo Lint/FloatComparison
+                data[:log_timestamp] == 0.0
             end
 
             response_object_id = nil
@@ -506,7 +506,7 @@ module Stripe
                  data[:connection_manager_object_id] == connection_manager_data[:connection_manager_object_id] &&
                  data[:connection_object_id] == connection_manager_data[:connection_object_id] &&
                  (data[:response_object_id].is_a? Numeric) &&
-                 data[:log_timestamp] == 0.0 # rubocop:todo Lint/FloatComparison
+                 data[:log_timestamp] == 0.0
                 response_object_id = data[:response_object_id]
               end
             end
@@ -547,7 +547,7 @@ module Stripe
                  data[:process_id] == Process.pid &&
                  data[:thread_object_id] == Thread.current.object_id &&
                  data[:response_object_id] == response_object_id &&
-                 data[:log_timestamp] == 0.0 # rubocop:todo Lint/FloatComparison
+                 data[:log_timestamp] == 0.0
                 # Streaming requests have a different body.
                 if request_method == "execute_request_stream"
                   data[:body].is_a? Net::ReadAdapter

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -99,7 +99,7 @@ module Stripe
 
     context "client_init" do
       setup do
-        @client_opts = Hash[StripeClient::CLIENT_OPTIONS.map { |k| [k, nil] }] # rubocop:todo Style/HashConversion - necessary for Ruby <= 2.5
+        @client_opts = Hash[StripeClient::CLIENT_OPTIONS.map { |k| [k, nil] }] # rubocop:todo Style/HashConversion -- necessary for Ruby <= 2.5
         @old_api_key = Stripe.api_key
         @old_stripe_account = Stripe.stripe_account
         @old_enable_telemetry = Stripe.instance_variable_get(:@enable_telemetry)


### PR DESCRIPTION
### Why?
Codegen is currently failing format check because of a warning. 

### What?
Updated rubocop to `1.75.2` and applied all the formatting changes. 

### See Also

