### PR TITLE
Require merge commit for merge PR (+ new rules.yml file) 

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,0 +1,21 @@
+
+name: rules
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types:
+      - auto_merge_enabled
+
+jobs:
+  require_merge_commit_on_merge_script_pr:
+    name: Merge script PRs must create merge commits
+    if: ${{ contains(github.head_ref, '/merge-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ github.event.pull_request.auto_merge.merge_method != 'merge' }}; then
+            echo "Auto-merge method must be 'merge' instead of '${{github.event.pull_request.auto_merge.merge_method}}'"
+            exit 1
+          fi
+


### PR DESCRIPTION
### Why?
Our merge script requires that PRs be merged with a merge commit to maintain git history and avoid conflicts in the future.  Our normal PR process is to squash before merging, usually with auto-merge enabled.  Since Github defaults to the last merge method selected, its very easy to accidentally enable auto-squash in this one situation where we really need a merge commit.

Neither Github's branch rulesets nor branch protection rules let us define rules in the context of the HEAD ref, so this PR adds a CI that can.

### What?
- add rules.yml to define PR/branch rules that we cannot define in the Github UI
- added Merge script PRs must create merge commits rule to run when auto merge is enabled and when the branch contains `/merge-`, and check that the auto merge method is 'merge'

#### Demo
When auto-merge is enabled on a merge PR like https://github.com/stripe/stripe-dotnet/pull/3106, it runs the rule as part of its checks.  If the auto-merge method is not 'merge', it fails:
![image](https://github.com/user-attachments/assets/7c5d3c91-1189-4e5f-94b1-e9c458f80e90)

The error provides a brief description about why it failed as a reminder to go fix the auto-merge method:
![image](https://github.com/user-attachments/assets/47173537-8833-4795-8ccd-31234fa531f0)

Once fixed, the merge PR check is green, and everything's good to go:
<img width="846" alt="image" src="https://github.com/user-attachments/assets/eef640ec-91df-4d8a-9b86-fad0834c3738" />

Note that this must exist in the repo and enabled as a blocking status check to get the full benefit!

### See Also
<!-- Include any links or additional information that help explain this change. -->
