### PR TITLE
build SDK w/ new spec

### DIFF
--- a/lib/stripe/services/v2/billing_service.rb
+++ b/lib/stripe/services/v2/billing_service.rb
@@ -4,14 +4,14 @@
 module Stripe
   module V2
     class BillingService < StripeService
-      attr_reader :meter_event_session, :meter_event_adjustments, :meter_event_stream, :meter_events
+      attr_reader :meter_events, :meter_event_adjustments, :meter_event_session, :meter_event_stream
 
       def initialize(requestor)
         super
-        @meter_event_session = Stripe::V2::Billing::MeterEventSessionService.new(@requestor)
-        @meter_event_adjustments = Stripe::V2::Billing::MeterEventAdjustmentService.new(@requestor)
-        @meter_event_stream = Stripe::V2::Billing::MeterEventStreamService.new(@requestor)
         @meter_events = Stripe::V2::Billing::MeterEventService.new(@requestor)
+        @meter_event_adjustments = Stripe::V2::Billing::MeterEventAdjustmentService.new(@requestor)
+        @meter_event_session = Stripe::V2::Billing::MeterEventSessionService.new(@requestor)
+        @meter_event_stream = Stripe::V2::Billing::MeterEventStreamService.new(@requestor)
       end
     end
   end

--- a/lib/stripe/services/v2/core/event_destination_service.rb
+++ b/lib/stripe/services/v2/core/event_destination_service.rb
@@ -5,6 +5,18 @@ module Stripe
   module V2
     module Core
       class EventDestinationService < StripeService
+        class ListParams < Stripe::RequestParams
+          # Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
+          attr_accessor :include
+          # The page size.
+          attr_accessor :limit
+
+          def initialize(include: nil, limit: nil)
+            @include = include
+            @limit = limit
+          end
+        end
+
         class CreateParams < Stripe::RequestParams
           class AmazonEventbridge < Stripe::RequestParams
             # The AWS account ID.
@@ -77,22 +89,6 @@ module Stripe
         end
 
         class DeleteParams < Stripe::RequestParams; end
-        class DisableParams < Stripe::RequestParams; end
-        class EnableParams < Stripe::RequestParams; end
-
-        class ListParams < Stripe::RequestParams
-          # Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
-          attr_accessor :include
-          # The page size.
-          attr_accessor :limit
-
-          def initialize(include: nil, limit: nil)
-            @include = include
-            @limit = limit
-          end
-        end
-
-        class PingParams < Stripe::RequestParams; end
 
         class RetrieveParams < Stripe::RequestParams
           # Additional fields to include in the response.
@@ -141,6 +137,10 @@ module Stripe
             @webhook_endpoint = webhook_endpoint
           end
         end
+
+        class DisableParams < Stripe::RequestParams; end
+        class EnableParams < Stripe::RequestParams; end
+        class PingParams < Stripe::RequestParams; end
 
         # Create a new event destination.
         def create(params = {}, opts = {})

--- a/lib/stripe/services/v2/core_service.rb
+++ b/lib/stripe/services/v2/core_service.rb
@@ -4,12 +4,12 @@
 module Stripe
   module V2
     class CoreService < StripeService
-      attr_reader :event_destinations, :events
+      attr_reader :events, :event_destinations
 
       def initialize(requestor)
         super
-        @event_destinations = Stripe::V2::Core::EventDestinationService.new(@requestor)
         @events = Stripe::V2::Core::EventService.new(@requestor)
+        @event_destinations = Stripe::V2::Core::EventDestinationService.new(@requestor)
       end
     end
   end

--- a/rbi/stripe/resources/v2/event.rbi
+++ b/rbi/stripe/resources/v2/event.rbi
@@ -19,11 +19,11 @@ module Stripe
         sig { returns(String) }
         attr_reader :type
         # Information on the API request that instigated the event.
-        sig { returns(T.nilable(Request)) }
+        sig { returns(Request) }
         attr_reader :request
       end
       # Authentication context needed to fetch the event or related object.
-      sig { returns(T.nilable(String)) }
+      sig { returns(String) }
       attr_reader :context
       # Time at which the object was created.
       sig { returns(String) }
@@ -35,7 +35,7 @@ module Stripe
       sig { returns(String) }
       attr_reader :object
       # Reason for the event.
-      sig { returns(T.nilable(Reason)) }
+      sig { returns(Reason) }
       attr_reader :reason
       # The type of the event.
       sig { returns(String) }

--- a/rbi/stripe/resources/v2/event_destination.rbi
+++ b/rbi/stripe/resources/v2/event_destination.rbi
@@ -13,7 +13,7 @@ module Stripe
           attr_reader :reason
         end
         # Details about why the event destination has been disabled.
-        sig { returns(T.nilable(Disabled)) }
+        sig { returns(Disabled) }
         attr_reader :disabled
       end
       class AmazonEventbridge < Stripe::StripeObject
@@ -29,10 +29,10 @@ module Stripe
       end
       class WebhookEndpoint < Stripe::StripeObject
         # The signing secret of the webhook endpoint, only includable on creation.
-        sig { returns(T.nilable(String)) }
+        sig { returns(String) }
         attr_reader :signing_secret
         # The URL of the webhook endpoint, includable.
-        sig { returns(T.nilable(String)) }
+        sig { returns(String) }
         attr_reader :url
       end
       # Time at which the object was created.
@@ -48,13 +48,13 @@ module Stripe
       sig { returns(String) }
       attr_reader :event_payload
       # Where events should be routed from.
-      sig { returns(T.nilable(T::Array[String])) }
+      sig { returns(T::Array[String]) }
       attr_reader :events_from
       # Unique identifier for the object.
       sig { returns(String) }
       attr_reader :id
       # Metadata.
-      sig { returns(T.nilable(T::Hash[String, String])) }
+      sig { returns(T::Hash[String, String]) }
       attr_reader :metadata
       # Event destination name.
       sig { returns(String) }
@@ -63,13 +63,13 @@ module Stripe
       sig { returns(String) }
       attr_reader :object
       # If using the snapshot event payload, the API version events are rendered as.
-      sig { returns(T.nilable(String)) }
+      sig { returns(String) }
       attr_reader :snapshot_api_version
       # Status. It can be set to either enabled or disabled.
       sig { returns(String) }
       attr_reader :status
       # Additional information about event destination status.
-      sig { returns(T.nilable(StatusDetails)) }
+      sig { returns(StatusDetails) }
       attr_reader :status_details
       # Event destination type.
       sig { returns(String) }
@@ -81,10 +81,10 @@ module Stripe
       sig { returns(T::Boolean) }
       attr_reader :livemode
       # Amazon EventBridge configuration.
-      sig { returns(T.nilable(AmazonEventbridge)) }
+      sig { returns(AmazonEventbridge) }
       attr_reader :amazon_eventbridge
       # Webhook endpoint configuration.
-      sig { returns(T.nilable(WebhookEndpoint)) }
+      sig { returns(WebhookEndpoint) }
       attr_reader :webhook_endpoint
     end
   end

--- a/rbi/stripe/services/v2/billing_service.rbi
+++ b/rbi/stripe/services/v2/billing_service.rbi
@@ -5,10 +5,10 @@
 module Stripe
   module V2
     class BillingService < StripeService
-      attr_reader :meter_event_session
-      attr_reader :meter_event_adjustments
-      attr_reader :meter_event_stream
       attr_reader :meter_events
+      attr_reader :meter_event_adjustments
+      attr_reader :meter_event_session
+      attr_reader :meter_event_stream
     end
   end
 end

--- a/rbi/stripe/services/v2/core/event_destination_service.rbi
+++ b/rbi/stripe/services/v2/core/event_destination_service.rbi
@@ -6,6 +6,16 @@ module Stripe
   module V2
     module Core
       class EventDestinationService < StripeService
+        class ListParams < Stripe::RequestParams
+          # Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
+          sig { returns(T.nilable(T::Array[String])) }
+          attr_accessor :include
+          # The page size.
+          sig { returns(T.nilable(Integer)) }
+          attr_accessor :limit
+          sig { params(include: T.nilable(T::Array[String]), limit: T.nilable(Integer)).void }
+          def initialize(include: nil, limit: nil); end
+        end
         class CreateParams < Stripe::RequestParams
           class AmazonEventbridge < Stripe::RequestParams
             # The AWS account ID.
@@ -79,19 +89,6 @@ module Stripe
           ); end
         end
         class DeleteParams < Stripe::RequestParams; end
-        class DisableParams < Stripe::RequestParams; end
-        class EnableParams < Stripe::RequestParams; end
-        class ListParams < Stripe::RequestParams
-          # Additional fields to include in the response. Currently supports `webhook_endpoint.url`.
-          sig { returns(T.nilable(T::Array[String])) }
-          attr_accessor :include
-          # The page size.
-          sig { returns(T.nilable(Integer)) }
-          attr_accessor :limit
-          sig { params(include: T.nilable(T::Array[String]), limit: T.nilable(Integer)).void }
-          def initialize(include: nil, limit: nil); end
-        end
-        class PingParams < Stripe::RequestParams; end
         class RetrieveParams < Stripe::RequestParams
           # Additional fields to include in the response.
           sig { returns(T.nilable(T::Array[String])) }
@@ -117,7 +114,7 @@ module Stripe
           sig { returns(T.nilable(T::Array[String])) }
           attr_accessor :include
           # Metadata.
-          sig { returns(T.nilable(T::Hash[String, T.nilable(String)])) }
+          sig { returns(T.nilable(T::Hash[String, String])) }
           attr_accessor :metadata
           # Event destination name.
           sig { returns(T.nilable(String)) }
@@ -128,7 +125,7 @@ module Stripe
            }
           attr_accessor :webhook_endpoint
           sig {
-            params(description: T.nilable(String), enabled_events: T.nilable(T::Array[String]), include: T.nilable(T::Array[String]), metadata: T.nilable(T::Hash[String, T.nilable(String)]), name: T.nilable(String), webhook_endpoint: T.nilable(::Stripe::V2::Core::EventDestinationService::UpdateParams::WebhookEndpoint)).void
+            params(description: T.nilable(String), enabled_events: T.nilable(T::Array[String]), include: T.nilable(T::Array[String]), metadata: T.nilable(T::Hash[String, String]), name: T.nilable(String), webhook_endpoint: T.nilable(::Stripe::V2::Core::EventDestinationService::UpdateParams::WebhookEndpoint)).void
            }
           def initialize(
             description: nil,
@@ -139,6 +136,9 @@ module Stripe
             webhook_endpoint: nil
           ); end
         end
+        class DisableParams < Stripe::RequestParams; end
+        class EnableParams < Stripe::RequestParams; end
+        class PingParams < Stripe::RequestParams; end
         # Create a new event destination.
         sig {
           params(params: T.any(::Stripe::V2::Core::EventDestinationService::CreateParams, T::Hash[T.untyped, T.untyped]), opts: T.untyped).returns(Stripe::V2::EventDestination)
@@ -147,7 +147,7 @@ module Stripe
 
         # Delete an event destination.
         sig {
-          params(id: String, params: T.any(::Stripe::V2::Core::EventDestinationService::DeleteParams, T::Hash[T.untyped, T.untyped]), opts: T.untyped).returns(Stripe::V2::EventDestination)
+          params(id: String, params: T.any(::Stripe::V2::Core::EventDestinationService::DeleteParams, T::Hash[T.untyped, T.untyped]), opts: T.untyped).returns(Stripe::V2::DeletedObject)
          }
         def delete(id, params = {}, opts = {}); end
 

--- a/rbi/stripe/services/v2/core_service.rbi
+++ b/rbi/stripe/services/v2/core_service.rbi
@@ -5,8 +5,8 @@
 module Stripe
   module V2
     class CoreService < StripeService
-      attr_reader :event_destinations
       attr_reader :events
+      attr_reader :event_destinations
     end
   end
 end

--- a/test/stripe/generated_examples_test.rb
+++ b/test/stripe/generated_examples_test.rb
@@ -7512,15 +7512,18 @@ module Stripe
       )
       assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v1/webhook_endpoints/we_xxxxxxxxxxxxx"
     end
-    should "Test v2 billing meter event session post (service)" do
-      stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session").to_return(
-        body: '{"authentication_token":"authentication_token","created":"1970-01-12T21:42:34.472Z","expires_at":"1970-01-10T15:36:51.170Z","id":"obj_123","object":"v2.billing.meter_event_session","livemode":true}',
+    should "Test v2 billing meter event post (service)" do
+      stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_events").to_return(
+        body: '{"created":"1970-01-12T21:42:34.472Z","event_name":"event_name","identifier":"identifier","object":"v2.billing.meter_event","payload":{"undefined":"payload"},"timestamp":"1970-01-01T15:18:46.294Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
 
-      meter_event_session = client.v2.billing.meter_event_session.create
-      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session"
+      meter_event = client.v2.billing.meter_events.create({
+        event_name: "event_name",
+        payload: { undefined: "payload" },
+      })
+      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_events"
     end
     should "Test v2 billing meter event adjustment post (service)" do
       stub_request(
@@ -7538,6 +7541,16 @@ module Stripe
         type: "cancel",
       })
       assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_adjustments"
+    end
+    should "Test v2 billing meter event session post (service)" do
+      stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session").to_return(
+        body: '{"authentication_token":"authentication_token","created":"1970-01-12T21:42:34.472Z","expires_at":"1970-01-10T15:36:51.170Z","id":"obj_123","object":"v2.billing.meter_event_session","livemode":true}',
+        status: 200
+      )
+      client = Stripe::StripeClient.new("sk_test_123")
+
+      meter_event_session = client.v2.billing.meter_event_session.create
+      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_event_session"
     end
     should "Test v2 billing meter event stream post (service)" do
       stub_request(
@@ -7558,22 +7571,42 @@ module Stripe
       })
       assert_requested :post, "#{Stripe::DEFAULT_METER_EVENTS_BASE}/v2/billing/meter_event_stream"
     end
-    should "Test v2 billing meter event post (service)" do
-      stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_events").to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","event_name":"event_name","identifier":"identifier","object":"v2.billing.meter_event","payload":{"undefined":"payload"},"timestamp":"1970-01-01T15:18:46.294Z","livemode":true}',
+    should "Test v2 core event get (service)" do
+      stub_request(
+        :get,
+        "#{Stripe::DEFAULT_API_BASE}/v2/core/events?object_id=object_id"
+      ).to_return(
+        body: '{"data":[{"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","type":"type","livemode":true}],"next_page_url":null,"previous_page_url":null}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
 
-      meter_event = client.v2.billing.meter_events.create({
-        event_name: "event_name",
-        payload: { undefined: "payload" },
-      })
-      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/billing/meter_events"
+      events = client.v2.core.events.list({ object_id: "object_id" })
+      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events?object_id=object_id"
+    end
+    should "Test v2 core event get 2 (service)" do
+      stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events/id_123").to_return(
+        body: '{"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","type":"type","livemode":true}',
+        status: 200
+      )
+      client = Stripe::StripeClient.new("sk_test_123")
+
+      event = client.v2.core.events.retrieve("id_123")
+      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events/id_123"
+    end
+    should "Test v2 core event destination get (service)" do
+      stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations").to_return(
+        body: '{"data":[{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}],"next_page_url":null,"previous_page_url":null}',
+        status: 200
+      )
+      client = Stripe::StripeClient.new("sk_test_123")
+
+      event_destinations = client.v2.core.event_destinations.list
+      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations"
     end
     should "Test v2 core event destination post (service)" do
       stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations").to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
+        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
@@ -7590,67 +7623,15 @@ module Stripe
       stub_request(
         :delete,
         "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123"
-      ).to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
-        status: 200
-      )
+      ).to_return(body: "null", status: 200)
       client = Stripe::StripeClient.new("sk_test_123")
 
       deleted = client.v2.core.event_destinations.delete("id_123")
       assert_requested :delete, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123"
     end
-    should "Test v2 core event destination post 2 (service)" do
-      stub_request(
-        :post,
-        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/disable"
-      ).to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
-        status: 200
-      )
-      client = Stripe::StripeClient.new("sk_test_123")
-
-      event_destination = client.v2.core.event_destinations.disable("id_123")
-      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/disable"
-    end
-    should "Test v2 core event destination post 3 (service)" do
-      stub_request(
-        :post,
-        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/enable"
-      ).to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
-        status: 200
-      )
-      client = Stripe::StripeClient.new("sk_test_123")
-
-      event_destination = client.v2.core.event_destinations.enable("id_123")
-      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/enable"
-    end
-    should "Test v2 core event destination get (service)" do
-      stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations").to_return(
-        body: '{"data":[{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}],"next_page_url":null,"previous_page_url":null}',
-        status: 200
-      )
-      client = Stripe::StripeClient.new("sk_test_123")
-
-      event_destinations = client.v2.core.event_destinations.list
-      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations"
-    end
-    should "Test v2 core event destination post 4 (service)" do
-      stub_request(
-        :post,
-        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/ping"
-      ).to_return(
-        body: '{"context":null,"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","reason":null,"type":"type","livemode":true}',
-        status: 200
-      )
-      client = Stripe::StripeClient.new("sk_test_123")
-
-      event = client.v2.core.event_destinations.ping("id_123")
-      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/ping"
-    end
     should "Test v2 core event destination get 2 (service)" do
       stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123").to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
+        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
@@ -7658,12 +7639,12 @@ module Stripe
       event_destination = client.v2.core.event_destinations.retrieve("id_123")
       assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123"
     end
-    should "Test v2 core event destination post 5 (service)" do
+    should "Test v2 core event destination post 2 (service)" do
       stub_request(
         :post,
         "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123"
       ).to_return(
-        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","events_from":null,"id":"obj_123","metadata":null,"name":"name","object":"v2.core.event_destination","snapshot_api_version":null,"status":"disabled","status_details":null,"type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true,"amazon_eventbridge":null,"webhook_endpoint":null}',
+        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
@@ -7671,28 +7652,44 @@ module Stripe
       event_destination = client.v2.core.event_destinations.update("id_123")
       assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123"
     end
-    should "Test v2 core event get (service)" do
+    should "Test v2 core event destination post 3 (service)" do
       stub_request(
-        :get,
-        "#{Stripe::DEFAULT_API_BASE}/v2/core/events?object_id=object_id"
+        :post,
+        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/disable"
       ).to_return(
-        body: '{"data":[{"context":null,"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","reason":null,"type":"type","livemode":true}],"next_page_url":null,"previous_page_url":null}',
+        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
 
-      events = client.v2.core.events.list({ object_id: "object_id" })
-      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events?object_id=object_id"
+      event_destination = client.v2.core.event_destinations.disable("id_123")
+      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/disable"
     end
-    should "Test v2 core event get 2 (service)" do
-      stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events/id_123").to_return(
-        body: '{"context":null,"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","reason":null,"type":"type","livemode":true}',
+    should "Test v2 core event destination post 4 (service)" do
+      stub_request(
+        :post,
+        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/enable"
+      ).to_return(
+        body: '{"created":"1970-01-12T21:42:34.472Z","description":"description","enabled_events":["enabled_events"],"event_payload":"thin","id":"obj_123","name":"name","object":"v2.core.event_destination","status":"disabled","type":"amazon_eventbridge","updated":"1970-01-03T17:07:10.277Z","livemode":true}',
         status: 200
       )
       client = Stripe::StripeClient.new("sk_test_123")
 
-      event = client.v2.core.events.retrieve("id_123")
-      assert_requested :get, "#{Stripe::DEFAULT_API_BASE}/v2/core/events/id_123"
+      event_destination = client.v2.core.event_destinations.enable("id_123")
+      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/enable"
+    end
+    should "Test v2 core event destination post 5 (service)" do
+      stub_request(
+        :post,
+        "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/ping"
+      ).to_return(
+        body: '{"created":"1970-01-12T21:42:34.472Z","id":"obj_123","object":"v2.core.event","type":"type","livemode":true}',
+        status: 200
+      )
+      client = Stripe::StripeClient.new("sk_test_123")
+
+      event = client.v2.core.event_destinations.ping("id_123")
+      assert_requested :post, "#{Stripe::DEFAULT_API_BASE}/v2/core/event_destinations/id_123/ping"
     end
     should "Test temporary session expired error (service)" do
       stub_request(


### PR DESCRIPTION
DON'T MERGE. This is just to see the output of snapshots built w/ openapi v2.

CI may fail because of changes to `DeletedObject`, which is expected