### PR TITLE
Fix `nil` requestor in `Webhook.construct_event` to allow for event data refresh

### DIFF
--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -18,7 +18,7 @@ module Stripe
       # doesn't GC symbols. It also decreases the likelihood that we receive a
       # bad payload that fails to parse and throws an exception.
       data = JSON.parse(payload, symbolize_names: true)
-      Event.construct_from(data, {}, nil, :v1)
+      Event.construct_from(data, {}, nil, :v1, APIRequestor.active_requestor)
     end
 
     module Signature

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -63,6 +63,26 @@ module Stripe
           Stripe::Webhook.construct_event(EVENT_PAYLOAD, header, Test::WebhookHelpers::SECRET)
         end
       end
+
+      should "can call refresh on Event data object" do
+        payload = {
+          "id": "evt_123",
+          "object": "event",
+          "data": {
+            "object": {
+              "id": "cus_123",
+              "object": "customer",
+            }
+          }
+        }.to_json
+
+        header = Test::WebhookHelpers.generate_header(payload: payload)
+        event = Stripe::Webhook.construct_event(payload, header, Test::WebhookHelpers::SECRET)
+        assert event.is_a?(Stripe::Event)
+
+        event.data.object.refresh
+        assert_equal("cus_123", event.data.object.id)
+      end
     end
 
     context ".verify_signature_header" do


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Raised in https://github.com/stripe/stripe-ruby/issues/1616 -- fix `nil` APIRequestor for Event constructed from `Webhook`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Global requestor is not passed into Webhook's `Event.construct_from`, fix that and also add test.

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Fix bug where `Event` constructed from `Webhook.construct_event` could not be refreshed due to a `nil` APIRequestor
  * Raised in https://github.com/stripe/stripe-ruby/issues/1616