### PR TITLE
Fix `raw_request` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ you can now use the `raw_request` method on `StripeClient`.
 
 ```ruby
 client = Stripe::StripeClient.new(...)
-resp = client.raw_request(:post, "/v1/beta_endpoint", {param: 123}, {stripe_version: "2022-11-15; feature_beta=v3"})
+resp = client.raw_request(:post, "/v1/beta_endpoint", params: {param: 123}, opts: {stripe_version: "2022-11-15; feature_beta=v3"})
 
 # (Optional) resp is a StripeResponse. You can use `Stripe.deserialize` to get a StripeObject.
 deserialized_resp = client.deserialize(resp.http_body)


### PR DESCRIPTION
### Why?
The README example for using `raw_request` is not valid.

### What?
Fixes the example usage of `raw_request` to pass `params` and `opts` as kwargs.
