### PR TITLE
Suppress MethodLength on api_requestor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,13 +54,13 @@ Metrics/PerceivedComplexity:
     - "lib/stripe/util.rb"
 
 Metrics/MethodLength:
-  # There's ~2 long methods in `APIRequestor` and one in `NestedResource`. If
-  # we want to truncate those a little, we could move this to be closer to ~30
-  # (but the default of 10 is probably too short).
+  # There's one long method in `NestedResource`. If we want to truncate it a little,
+  # we could move this to be closer to ~30 (but the default of 10 is probably too short).
   Max: 55
   Exclude:
     - "lib/stripe/services/v1_services.rb"
     - "lib/stripe/event_types.rb"
+    - "lib/stripe/api_requestor.rb"
   AllowedMethods:
     - initialize
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The file `api_requestor.rb` has a method `specific_v2_api_error` that has an autogenerated `case` statement that will go grow arbitrarily long (and it has in dev). The linter won't let me preemptively suppress warnings on that one method, so I need to suppress `MethodLength` for the entire file.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Suppresses the `MethodLength` linter error for `api_requestor.rb`
### See Also
<!-- Include any links or additional information that help explain this change. -->
