### PR TITLE
Add `stripe_client` usage tracking for StripeClient

### DIFF
--- a/lib/stripe/stripe_service.rb
+++ b/lib/stripe/stripe_service.rb
@@ -14,7 +14,8 @@ module Stripe
         path,
         base_address,
         params: params,
-        opts: RequestOptions.extract_opts_from_hash(opts)
+        opts: RequestOptions.extract_opts_from_hash(opts),
+        usage: ['stripe_client']
       )
     end
 
@@ -24,7 +25,8 @@ module Stripe
         path,
         base_address,
         params: params,
-        opts: RequestOptions.extract_opts_from_hash(opts),
+        # opts: RequestOptions.extract_opts_from_hash(opts),
+        usage: ['stripe_client'],
         &read_body_chunk_block
       )
     end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Add a usage telemetry string to track `StripeClient` adoption.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Add `stripe_client` usage to any service calls, which is how all standard StripeClient calls are made.

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://jira.corp.stripe.com/browse/DEVSDK-2730