### PR TITLE
Add section on private preview SDKs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ client = Stripe::StripeClient.new("sk_test_...")
 # list customers
 customers = client.v1.customers.list()
 
-# retrieve single customer 
+# retrieve single customer
 customer = client.v1.customers.retrieve('cus_123456789')
 ```
 
@@ -322,13 +322,11 @@ you see at runtime may not match the types.
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `11.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-ruby/releases/) and use it in the `gem install` command:
+To install, pick the latest version with the `beta` suffix by reviewing the [releases page](https://github.com/stripe/stripe-ruby/releases/) and use it in the `gem install` command:
 
 ```sh
 gem install stripe -v <replace-with-the-version-of-your-choice>
 ```
-
-You can find the latest version to use in this command from the [releases page](https://github.com/stripe/stripe-ruby/releases/)
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your Gemfile. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest version of the public preview SDK.
@@ -340,6 +338,10 @@ Some preview features require a name and version to be set in the `Stripe-Versio
 ```python
 Stripe.add_beta_version("feature_beta", "v3")
 ```
+
+### Private Preview SDKs
+
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `11.2.0-alpha.2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-ruby?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`.
 
 ### Custom requests
 


### PR DESCRIPTION
### Why?
Need a section on how to install the private preview SDKs

### What?
- Added a section on private preview SDKs
- Updated the note on public preview SDKs to nudge users to use the latest beta versions - these are guaranteed to have all the active previews and users do not need to go and find which version maps the feature they are interested in
- Removed the repeated line about releases page



