### PR TITLE
Exclude event types from rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,12 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/CollectionLiteralLength:
+  Enabled: true
+  Exclude:
+    # We have thin event types that are automatically generated from the OpenAPI spec
+    - "lib/stripe/event_types.rb"
+
 # There are several methods with many branches in api_requestor due to
 # request logic.
 Metrics/CyclomaticComplexity:
@@ -208,8 +214,6 @@ Lint/UselessAssignment:
 Lint/UselessRescue: # new in 1.43
   Enabled: true
 Lint/UselessRuby2Keywords: # new in 1.23
-  Enabled: true
-Metrics/CollectionLiteralLength: # new in 1.47
   Enabled: true
 Naming/BlockForwarding: # new in 1.24
   Enabled: true


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Rubocop is unhappy with how many private preview events we have. We codegen this from a spec, so we don't care about this rule for this file. (it's concerned about hardcoding large amounts of data, but this is coming from an external source already).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Exclude `event_types.rb` from the collection rule in rubocop.

### See Also
<!-- Include any links or additional information that help explain this change. -->
