### PR TITLE
Add `StripeContext` object

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -51,6 +51,7 @@ require "stripe/api_resource_test_helpers"
 require "stripe/singleton_api_resource"
 require "stripe/webhook"
 require "stripe/stripe_configuration"
+require "stripe/stripe_context"
 require "stripe/thin_event"
 
 # Named API resources

--- a/lib/stripe/request_options.rb
+++ b/lib/stripe/request_options.rb
@@ -82,7 +82,16 @@ module Stripe
       RequestOptions.error_on_non_string_user_opts(normalized_opts)
 
       OPTS_USER_SPECIFIED.each do |opt|
-        req_opts[opt] = normalized_opts[opt] if normalized_opts.key?(opt)
+        if normalized_opts.key?(opt)
+          val = normalized_opts[opt]
+          # Convert StripeContext to string for stripe_context
+          if opt == :stripe_context && val.is_a?(StripeContext)
+            context_value = val.to_s
+            req_opts[opt] = context_value unless context_value.empty?
+          else
+            req_opts[opt] = val
+          end
+        end
         normalized_opts.delete(opt)
       end
 
@@ -100,6 +109,7 @@ module Stripe
         val = normalized_opts[opt]
         next if val.nil?
         next if val.is_a?(String)
+        next if opt == :stripe_context && val.is_a?(StripeContext)
 
         raise ArgumentError,
               "request option '#{opt}' should be a string value " \

--- a/lib/stripe/stripe_context.rb
+++ b/lib/stripe/stripe_context.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# typed: true
+
+module Stripe
+  # StripeContext represents a path-like context for Stripe API operations,
+  # allowing for hierarchical organization of API calls. The context is
+  # externally immutable, meaning all operations return new instances
+  # rather than modifying existing ones.
+  class StripeContext
+    attr_reader :segments
+
+    def initialize(segments = [])
+      @segments = segments ? segments.dup.freeze : [].freeze
+    end
+
+    # Parses a context string into a StripeContext instance.
+    def self.parse(context_string)
+      return new([]) if context_string.nil? || context_string.empty?
+
+      new(context_string.split("/"))
+    end
+
+    # Returns the parent context by removing the last segment.
+    # Raises an error if the context is empty.
+    def parent
+      raise ArgumentError, "Cannot get parent of empty context" if @segments.empty?
+
+      StripeContext.new(@segments[0...-1])
+    end
+
+    # Returns a new context with the given segment appended.
+    def child(segment)
+      StripeContext.new(@segments + [segment])
+    end
+
+    # Returns the string representation of the context.
+    def to_s
+      @segments.join("/")
+    end
+
+    # Enables conversion to string for JSON serialization
+    def as_json(*)
+      to_s
+    end
+
+    # For JSON serialization
+    def to_json(*args)
+      as_json.to_json(*args)
+    end
+  end
+end

--- a/lib/stripe/thin_event.rb
+++ b/lib/stripe/thin_event.rb
@@ -26,7 +26,7 @@ module Stripe
       @id = event_payload[:id]
       @type = event_payload[:type]
       @created = event_payload[:created]
-      @context = event_payload[:context]
+      @context = event_payload[:context].nil? ? nil : StripeContext.parse(event_payload[:context])
       @livemode = event_payload[:livemode]
       @related_object = event_payload[:related_object]
       return if event_payload[:reason].nil?

--- a/test/stripe/stripe_context_test.rb
+++ b/test/stripe/stripe_context_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Stripe
+  class StripeContextTest < Test::Unit::TestCase
+    def test_empty_context
+      context = StripeContext.new
+      assert_equal("", context.to_s)
+    end
+
+    def test_context_with_segments
+      context = StripeContext.new(["a", "b", "c"])
+      assert_equal("a/b/c", context.to_s)
+    end
+
+    def test_parse_empty_string
+      context = StripeContext.parse("")
+      assert_equal("", context.to_s)
+    end
+
+    def test_parse_nil
+      context = StripeContext.parse(nil)
+      assert_equal("", context.to_s)
+    end
+
+    def test_parse_single_segment
+      context = StripeContext.parse("a")
+      assert_equal("a", context.to_s)
+    end
+
+    def test_parse_multiple_segments
+      context = StripeContext.parse("a/b/c")
+      assert_equal("a/b/c", context.to_s)
+    end
+
+    def test_parent_returns_new_instance
+      context = StripeContext.parse("a/b/c")
+      parent = context.parent
+
+      # Original unchanged
+      assert_equal("a/b/c", context.to_s)
+      # New instance with removed segment
+      assert_equal("a/b", parent.to_s)
+    end
+
+    def test_parent_of_single_segment
+      context = StripeContext.parse("a")
+      parent = context.parent
+      assert_equal("", parent.to_s)
+    end
+
+    def test_parent_of_empty_context_raises_error
+      context = StripeContext.new
+
+      exception = assert_raise(ArgumentError) do
+        context.parent
+      end
+      assert_equal("Cannot get parent of empty context", exception.message)
+    end
+
+    def test_child_returns_new_instance
+      context = StripeContext.parse("a/b")
+      child = context.child("c")
+
+      # Original unchanged
+      assert_equal("a/b", context.to_s)
+      # New instance with added segment
+      assert_equal("a/b/c", child.to_s)
+    end
+
+    def test_child_on_empty_context
+      context = StripeContext.new
+      child = context.child("a")
+      assert_equal("a", child.to_s)
+    end
+
+    def test_method_chaining
+      context = StripeContext.parse("a")
+      result = context.child("b").child("c").parent
+      assert_equal("a/b", result.to_s)
+    end
+
+    def test_init_with_nil_segments
+      context = StripeContext.new(nil)
+      assert_equal("", context.to_s)
+    end
+
+    def test_init_with_empty_array
+      context = StripeContext.new([])
+      assert_equal("", context.to_s)
+    end
+
+    def test_as_json
+      context = StripeContext.parse("org_123/proj_456")
+      assert_equal("org_123/proj_456", context.as_json)
+    end
+
+    def test_to_json
+      context = StripeContext.parse("org_123/proj_456")
+      assert_equal("\"org_123/proj_456\"", context.to_json)
+    end
+
+    def test_request_options_with_stripe_context
+      context = StripeContext.parse("org_123/proj_456")
+
+      opts = RequestOptions.extract_opts_from_hash(stripe_context: context)
+
+      assert_equal("org_123/proj_456", opts[:stripe_context])
+    end
+
+    def test_request_options_with_stripe_context_string
+      opts = RequestOptions.extract_opts_from_hash(stripe_context: "org_123/proj_456")
+
+      assert_equal("org_123/proj_456", opts[:stripe_context])
+    end
+
+    def test_request_options_with_empty_stripe_context
+      context = StripeContext.new
+
+      opts = RequestOptions.extract_opts_from_hash(stripe_context: context)
+
+      assert_equal("", opts[:stripe_context])
+    end
+
+    def test_request_options_validation_allows_stripe_context
+      context = StripeContext.parse("org_123/proj_456")
+
+      # Should not raise an error
+      opts = { stripe_context: context }
+      normalized_opts = Util.normalize_opts(opts)
+
+      assert_nothing_raised do
+        RequestOptions.error_on_non_string_user_opts(normalized_opts)
+      end
+    end
+
+    def test_thin_event_with_context
+      event = ThinEvent.new(
+        id: "evt_123",
+        type: "test.event",
+        created: Time.now.to_i,
+        context: "org_123/proj_456"
+      )
+
+      assert_instance_of(StripeContext, event.context)
+      assert_equal("org_123/proj_456", event.context.to_s)
+    end
+
+    def test_thin_event_with_empty_context
+      event = ThinEvent.new(
+        id: "evt_123",
+        type: "test.event",
+        created: Time.now.to_i,
+        context: ""
+      )
+
+      assert_instance_of(StripeContext, event.context)
+      assert_equal("", event.context.to_s)
+    end
+
+    def test_thin_event_with_nil_context
+      event = ThinEvent.new(
+        id: "evt_123",
+        type: "test.event",
+        created: Time.now.to_i,
+        context: nil
+      )
+
+      assert_nil(event.context)
+    end
+
+    def test_thin_event_without_context
+      event = ThinEvent.new(
+        id: "evt_123",
+        type: "test.event",
+        created: Time.now.to_i
+      )
+
+      assert_nil(event.context)
+    end
+
+    def test_empty_context_does_not_set_header
+      empty_context = StripeContext.new
+
+      opts = RequestOptions.extract_opts_from_hash(stripe_context: empty_context)
+
+      # Empty context should not set stripe_context in options
+      assert_nil(opts[:stripe_context])
+    end
+
+    def test_non_empty_context_sets_header
+      context = StripeContext.parse("org_123/proj_456")
+
+      opts = RequestOptions.extract_opts_from_hash(stripe_context: context)
+
+      # Non-empty context should set the header
+      assert_equal("org_123/proj_456", opts[:stripe_context])
+    end
+  end
+end


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
