### PR TITLE
Add comment on retrieve on how to pass parameters

### DIFF
--- a/lib/stripe/api_resource.rb
+++ b/lib/stripe/api_resource.rb
@@ -111,6 +111,9 @@ module Stripe
       )
     end
 
+    # Retrieve by passing id like `retrieve(id)`
+    # If passing parameters, pass a single map with parameters and the `id` as well.
+    # For example: retrieve({id: some_id, some_param: some_param_value})
     def self.retrieve(id, opts = {})
       if name.include?("Stripe::V2")
         raise NotImplementedError,


### PR DESCRIPTION
### Why?
https://github.com/stripe/stripe-ruby/issues/1628#issuecomment-3128003410

### What?
Add a comment on the retrieve() method explaining how to pass parameters

### See Also
<!-- Include any links or additional information that help explain this change. -->
