### PR TITLE
Update param in deprecation docs link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # following https://docs.stripe.com/sdks/versioning?server=ruby#stripe-sdk-language-version-support-policy
+        # following https://docs.stripe.com/sdks/versioning?lang=ruby#stripe-sdk-language-version-support-policy
         ruby-version: [2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4.0.0, truffleruby-head]
     steps:
     - uses: extractions/setup-just@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
   - Add the `StripeContext` class. Previously you could set the stripe_context to only a string value. Now you can use the new class as well
   - ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
 * [#1684](https://github.com/stripe/stripe-ruby/pull/1684) ⚠️ Drop support for Ruby < 2.6 & clarify version policy
-  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=ruby#stripe-sdk-language-version-support-policy)
+  - Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?lang=ruby#stripe-sdk-language-version-support-policy)
       - ⚠️ In this release, we drop support for Ruby 2.3, 2.4, and 2.5
       -  Ruby 2.6 support is deprecated and will be removed in the next scheduled major release (March 2026)
 * [#1651](https://github.com/stripe/stripe-ruby/pull/1651) ⚠️ Build SDK w/ V2 OpenAPI spec

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ gem build stripe.gemspec
 
 ### Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=ruby#stripe-sdk-language-version-support-policy), we currently support **Ruby 2.6+**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=ruby#stripe-sdk-language-version-support-policy), we currently support **Ruby 2.6+**.
 
-Support for Ruby 2.6 and 2.7 is deprecated and will be removed in upcoming major versions. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=ruby#stripe-sdk-language-version-support-policy
+Support for Ruby 2.6 and 2.7 is deprecated and will be removed in upcoming major versions. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=ruby#stripe-sdk-language-version-support-policy
 
 ### Bundler
 


### PR DESCRIPTION
### Why?

We're using a different `pref` name in the docs for the version deprecation policy, so these links need to be updated.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- replace `?server=` with `?lang=` in links
