### PR TITLE
Updated Sorbet wiki link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Stripe.enable_telemetry = false
 ### Types
 
 In [v14.0.0](https://github.com/stripe/stripe-python/releases/tag/v7.1.0) and newer, the library provides RBI
-static type annotations. See [the wiki](https://github.com/stripe/stripe-ruby/wiki/Static-Type-Annotations)
+static type annotations. See [the wiki](https://github.com/stripe/stripe-ruby/wiki/Static-Type-Annotations-(with-Sorbet))
 for an detailed guide.
 
 Please note that these types are available only for static analysis and we only support RBIs at the moment.


### PR DESCRIPTION
### Why?
This PR fixes the broken sorbet wiki link in the README.md.

### What?
- Updated the wiki link in docs. 

### See Also
<!-- Include any links or additional information that help explain this change. -->
