### PR TITLE
Turn off rubocop format on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
 
   // Rubocop settings
   "ruby.rubocop.configFilePath": ".rubocop.yml",
-  "ruby.rubocop.onSave": true
+  "ruby.rubocop.onSave": false
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

This is very slow, I run `just format` before pushing instead (which is still slow but at least doesn't ruin your dev flow)

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
Update recommended settings.

### See Also
<!-- Include any links or additional information that help explain this change. -->
