### PR TITLE
throw more specific error when accessing Invoice.payment_intent

### DIFF
--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -171,7 +171,19 @@ module Stripe
     end
 
     def [](key)
-      @values[key.to_sym]
+      key_sym = key.to_sym
+      return @values[key_sym] if @values.key?(key_sym)
+
+      # super specific one-off case to help users debug this property disappearing
+      # see also: https://go/j/DEVSDK-2835
+      if is_a?(Invoice) && key_sym == :payment_intent
+        raise KeyError,
+              "The 'payment_intent' attribute is no longer available on Invoice objects. " \
+              "See the docs for more details: https://docs.stripe.com/changelog/basil/2025-03-31/" \
+              "add-support-for-multiple-partial-payments-on-invoices#why-is-this-a-breaking-change"
+      end
+
+      nil
     end
 
     def []=(key, value)
@@ -432,6 +444,15 @@ module Stripe
       begin
         super
       rescue NoMethodError => e
+        # super specific one-off case to help users debug this property disappearing
+        # see also: https://go/j/DEVSDK-2835
+        if is_a?(Invoice) && name == :payment_intent
+          raise NoMethodError,
+                "The 'payment_intent' attribute is no longer available on Invoice objects. " \
+                "See the docs for more details: https://docs.stripe.com/changelog/basil/2025-03-31/" \
+                "add-support-for-multiple-partial-payments-on-invoices#why-is-this-a-breaking-change"
+        end
+
         # If we notice the accessed name of our set of transient values we can
         # give the user a slightly more helpful error message. If not, just
         # raise right away.


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

After upgrading to API version [2025-03-31.basil](https://docs.stripe.com/changelog/basil#2025-03-31.basil), users have had a lot of trouble with `Invoice.payment_intent` disappearing. To make matters worse, the changelog isn't super descriptive, so it's hard to know how to find more information about this change.

To help, we're adding a one-off error message to point them at the docs to help ease their migration.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add more specific error when accessing a specific property
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2835](https://go/j/DEVSDK-2835)

## Changelog
* Throw a specific error when accessing `payment_intent` property on `Invoice` object to ease debugging. 