### PR TITLE
Add lambda/proc support for api_key

### DIFF
--- a/lib/stripe/stripe_configuration.rb
+++ b/lib/stripe/stripe_configuration.rb
@@ -3,6 +3,11 @@
 module Stripe
   # Configurable options:
   #
+  # =api_key=
+  # The API key used to authenticate requests. Can be set to a string or a callable
+  # (lambda/proc) that returns the API key, allowing the key to be resolved
+  # at request time for multi-region or dynamic configuration scenarios.
+  #
   # =ca_bundle_path=
   # The location of a file containing a bundle of CA certificates. By default
   # the library will use an included bundle that can successfully validate
@@ -30,6 +35,13 @@ module Stripe
     attr_reader :api_base, :uploads_base, :connect_base, :meter_events_base, :base_addresses, :ca_bundle_path,
                 :log_level, :initial_network_retry_delay, :max_network_retries, :max_network_retry_delay,
                 :open_timeout, :read_timeout, :write_timeout, :proxy, :verify_ssl_certs
+
+    # Returns the API key, resolving it if it's a callable (lambda/proc).
+    # This enables multi-region or dynamic configuration where the key
+    # may vary per request.
+    def api_key
+      @api_key.respond_to?(:call) ? @api_key.call : @api_key
+    end
 
     def self.setup
       new.tap do |instance|

--- a/test/stripe/stripe_configuration_test.rb
+++ b/test/stripe/stripe_configuration_test.rb
@@ -254,5 +254,41 @@ module Stripe
         refute_equal StripeConfiguration.setup.key, custom_config.key
       end
     end
+
+    context "callable configuration values" do
+      context "#api_key" do
+        should "return the value directly when it's a string" do
+          config = Stripe::StripeConfiguration.setup do |c|
+            c.api_key = "sk_test_123"
+          end
+
+          assert_equal "sk_test_123", config.api_key
+        end
+
+        should "resolve the value when it's a lambda" do
+          config = Stripe::StripeConfiguration.setup do |c|
+            c.api_key = -> { "sk_test_from_lambda" }
+          end
+
+          assert_equal "sk_test_from_lambda", config.api_key
+        end
+
+        should "resolve the value when it's a proc" do
+          config = Stripe::StripeConfiguration.setup do |c|
+            c.api_key = proc { "sk_test_from_proc" }
+          end
+
+          assert_equal "sk_test_from_proc", config.api_key
+        end
+
+        should "return nil when the value is nil" do
+          config = Stripe::StripeConfiguration.setup do |c|
+            c.api_key = nil
+          end
+
+          assert_nil config.api_key
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Multi-tenant Rails applications often need to use different Stripe API keys for different tenants/regions. Currently, api_key must be set to a static string at boot time, which doesn't work well for applications where the correct API key is only known at request time.
This change allows api_key to accept a callable (lambda/proc) that is evaluated on each access, enabling dynamic resolution of the API key based on the current request context.

After this change, applications can configure Stripe like this:

```
Stripe.api_key = -> { CurrentTenant.stripe_api_key }
```

### What?

-  Added a custom getter for `api_key` that resolves callable values (lambdas/procs) before returning
-  Added documentation explaining the callable support
-  Added tests for callable api_key configuration

### See Also

[activerecord-tenanted ](https://github.com/basecamp/activerecord-tenanted)- This is the gem I am using that enables multi-tenant Rails applications, which is an example use case for this feature.