### PR TITLE
Remove truffleruby head from CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - uses: stripe/openapi/actions/stripe-mock@master
     - name: test
-      run: |
-        just test typecheck
+      run: just test typecheck
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}
 


### PR DESCRIPTION
### Why?
See https://github.com/stripe/stripe-ruby/pull/1754 for more context.  We decided just to remove truffleruby-head from CI and test against a stable version.

### What?
- replaces truffleruby-head with truffleruby-25.0.0 in ruby-versions in test matrix

### See Also
