### PR TITLE
[connection_manager] use unix socket if flag is set

### DIFF
--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -466,7 +466,7 @@ module Stripe
       raise ArgumentError, "path should be a string" \
       unless path.is_a?(String)
 
-      base_url ||= config.base_addresses[base_address]
+      base_url = Stripe.api_base
 
       raise ArgumentError, "api_base cannot be empty" if base_url.nil? || base_url.empty?
 

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -140,9 +140,16 @@ module Stripe
       # These all come back as `nil` if no proxy is configured.
       proxy_host, proxy_port, proxy_user, proxy_pass = proxy_parts
 
+      unix_socket = UNIXSocket.new("/home/clrxy/.stripeproxy")
       connection = Net::HTTP.new(uri.host, uri.port,
                                  proxy_host, proxy_port,
                                  proxy_user, proxy_pass)
+
+      def connection.connect
+        @socket = Net::BufferedIO.new(@unix_socket)
+        on_connect
+      end
+      connection.instance_variable_set(:@unix_socket, unix_socket)
 
       # Time in seconds within which Net::HTTP will try to reuse an already
       # open connection when issuing a new operation. Outside this window, Ruby


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
[DEVE-6416](https://jira.corp.stripe.com/browse/DEVE-6416)

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
This should not affect any environment except for the devbox.

### See Also
<!-- Include any links or additional information that help explain this change. -->
Testing:

l created a Gemfile at `/Users/clrxy/stripe/Gemfile`
```
source 'https://rubygems.org'

ruby '3.2.3'

gem 'stripe', path: '/pay/src/stripe-ruby'
```

then a short Ruby script `/Users/clrxy/stripe/script.rb`
