### PR TITLE
Fix 2D array parameter encoding

### DIFF
--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -276,7 +276,7 @@ module Stripe
         if elem.is_a?(Hash)
           result += flatten_params(elem, api_mode, "#{calculated_key}[#{i}]")
         elsif elem.is_a?(Array)
-          result += flatten_params_array(elem, api_mode, calculated_key)
+          result += flatten_params_array(elem, api_mode, "#{calculated_key}[#{i}]")
         else
           # Always use indexed format for arrays
           result << ["#{calculated_key}[#{i}]", elem]

--- a/test/stripe/util_test.rb
+++ b/test/stripe/util_test.rb
@@ -29,7 +29,15 @@ module Stripe
           a: [[foo: "bar", baz: "qux"]],
         }
         assert_equal(
-          "a[0][foo]=bar&a[0][baz]=qux",
+          "a[0][0][foo]=bar&a[0][0][baz]=qux",
+          Stripe::Util.encode_parameters(params, :v1)
+        )
+      end
+
+      should "correctly encode 2D arrays of scalars" do
+        params = { a: [[1, 2], [3, 4]] }
+        assert_equal(
+          "a[0][0]=1&a[0][1]=2&a[1][0]=3&a[1][1]=4",
           Stripe::Util.encode_parameters(params, :v1)
         )
       end
@@ -95,6 +103,14 @@ module Stripe
           [:e, [0, 1]],
         ]
         assert_equal([["d[a]", "a"], ["d[b]", "b"], ["e[0]", 0], ["e[1]", 1]], Stripe::Util.flatten_params(params, :v2))
+      end
+
+      should "flatten 2D arrays with correct indices" do
+        params = { a: [[1, 2], [3, 4]] }
+        assert_equal(
+          [["a[0][0]", 1], ["a[0][1]", 2], ["a[1][0]", 3], ["a[1][1]", 4]],
+          Stripe::Util.flatten_params(params, :v1)
+        )
       end
     end
 


### PR DESCRIPTION
### Why?

When encoding nested arrays (e.g. `[[1, 2], [3, 4]]`) as form parameters, the recursive call in `flatten_params_array` passed the parent key without the outer array index. This produced `a[0]=1&a[1]=2` instead of the correct `a[0][0]=1&a[0][1]=2`, silently sending wrong data to the API.

### What?

- Fix one-line bug in `lib/stripe/util.rb`: append `[#{i}]` to the key before recursing into nested arrays
- Update existing nested array test that was asserting the buggy behavior
- Add new regression tests for 2D scalar arrays in both `encode_parameters` and `flatten_params`

### See Also

- https://jira.corp.stripe.com/browse/RUN_DEVSDK-2304
- Parallel fixes in stripe-python and stripe-php (same bug pattern)
- Test-only PRs in stripe-go and stripe-dotnet (correct but untested)

## Changelog
- Fixes an issue encoding two-dimensional array request params where the SDK incorrectly flattens the array.