### PR TITLE
Add Ref type for typed v2 object references

### DIFF
--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -54,6 +54,7 @@ require "stripe/webhook"
 require "stripe/stripe_configuration"
 require "stripe/resources/v2/amount"
 require "stripe/resources/v2/deleted_object"
+require "stripe/resources/v2/ref"
 require "stripe/resources/v2/core/event_notification"
 
 # Named API resources

--- a/lib/stripe/resources/v2/ref.rb
+++ b/lib/stripe/resources/v2/ref.rb
@@ -17,6 +17,9 @@ module Stripe
       # Fetches the referenced object from the API. Makes an API request on every call.
       def fetch
         raise ArgumentError, "Cannot fetch a Ref without a client" if @client.nil?
+        unless url.is_a?(String) && url.start_with?("/")
+          raise ArgumentError, "Cannot fetch a Ref with an invalid url; expected a String starting with '/'"
+        end
 
         resp = @client.raw_request(:get, url, usage: ["ref_fetch"])
         @client.deserialize(resp.http_body, api_mode: Util.get_api_mode(url))

--- a/lib/stripe/resources/v2/ref.rb
+++ b/lib/stripe/resources/v2/ref.rb
@@ -7,22 +7,25 @@ module Stripe
     class Ref
       attr_reader :type, :id, :url
 
-      def initialize(data, client = nil)
+      def initialize(data, requestor = nil)
         @type = data[:type] || data["type"]
         @id = data[:id] || data["id"]
         @url = data[:url] || data["url"]
-        @client = client
+        @requestor = requestor
+      end
+
+      def self.construct_from(data, opts = {}, last_response = nil, api_mode = :v2, requestor = nil)
+        new(Stripe::Util.symbolize_names(data), requestor)
       end
 
       # Fetches the referenced object from the API. Makes an API request on every call.
       def fetch
-        raise ArgumentError, "Cannot fetch a Ref without a client" if @client.nil?
+        raise ArgumentError, "Cannot fetch a Ref without a requestor" if @requestor.nil?
         unless url.is_a?(String) && url.start_with?("/")
           raise ArgumentError, "Cannot fetch a Ref with an invalid url; expected a String starting with '/'"
         end
 
-        resp = @client.raw_request(:get, url, usage: ["ref_fetch"])
-        @client.deserialize(resp.http_body, api_mode: Util.get_api_mode(url))
+        @requestor.execute_request(:get, url, :api, usage: ["ref_fetch"])
       end
     end
   end

--- a/lib/stripe/resources/v2/ref.rb
+++ b/lib/stripe/resources/v2/ref.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Stripe
+  module V2
+    # A typed object reference with wire shape {type: string, id: string, url: string}.
+    # Call #fetch to retrieve the full object from the API.
+    class Ref
+      attr_reader :type, :id, :url
+
+      def initialize(data, client = nil)
+        @type = data[:type] || data["type"]
+        @id = data[:id] || data["id"]
+        @url = data[:url] || data["url"]
+        @client = client
+      end
+
+      # Fetches the referenced object from the API. Makes an API request on every call.
+      def fetch
+        raise ArgumentError, "Cannot fetch a Ref without a client" if @client.nil?
+
+        resp = @client.raw_request(:get, url, usage: ["ref_fetch"])
+        @client.deserialize(resp.http_body, api_mode: Util.get_api_mode(url))
+      end
+    end
+  end
+end

--- a/test/stripe/v2_ref_test.rb
+++ b/test/stripe/v2_ref_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", __dir__)
+require "json"
+
+module Stripe
+  class V2RefTest < Test::Unit::TestCase
+    context "Stripe::V2::Ref" do
+      setup do
+        @client = StripeClient.new("test_123")
+        @ref_data = { "type" => "billing.meter", "id" => "mtr_123", "url" => "/v1/billing/meters/mtr_123" }
+        @v2_ref_data = { "type" => "v2.core.account", "id" => "acct_123", "url" => "/v2/core/accounts/acct_123" }
+      end
+
+      context "construction" do
+        should "accept string-keyed hash" do
+          ref = Stripe::V2::Ref.new(@ref_data)
+          assert_equal "billing.meter", ref.type
+          assert_equal "mtr_123", ref.id
+          assert_equal "/v1/billing/meters/mtr_123", ref.url
+        end
+
+        should "accept symbol-keyed hash" do
+          ref = Stripe::V2::Ref.new(type: "billing.meter", id: "mtr_123", url: "/v1/billing/meters/mtr_123")
+          assert_equal "billing.meter", ref.type
+          assert_equal "mtr_123", ref.id
+          assert_equal "/v1/billing/meters/mtr_123", ref.url
+        end
+
+        should "accept a client" do
+          ref = Stripe::V2::Ref.new(@ref_data, @client)
+          assert_not_nil ref
+        end
+
+        should "accept no client" do
+          ref = Stripe::V2::Ref.new(@ref_data)
+          assert_not_nil ref
+        end
+      end
+
+      context "#fetch" do
+        should "raise ArgumentError when no client is present" do
+          ref = Stripe::V2::Ref.new(@ref_data)
+          assert_raises ArgumentError do
+            ref.fetch
+          end
+        end
+
+        should "make a GET request to the url and deserialize v1 response" do
+          stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v1/billing/meters/mtr_123")
+            .to_return(body: JSON.generate({ "id" => "mtr_123", "object" => "billing.meter" }))
+
+          ref = Stripe::V2::Ref.new(@ref_data, @client)
+          result = ref.fetch
+
+          assert_not_nil result
+          assert_requested(:get, "#{Stripe::DEFAULT_API_BASE}/v1/billing/meters/mtr_123")
+        end
+
+        should "make a GET request to the url and deserialize v2 response" do
+          stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/accounts/acct_123")
+            .to_return(body: JSON.generate({ "id" => "acct_123", "object" => "v2.core.account" }))
+
+          ref = Stripe::V2::Ref.new(@v2_ref_data, @client)
+          result = ref.fetch
+
+          assert_not_nil result
+          assert_requested(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/accounts/acct_123")
+        end
+      end
+    end
+  end
+end

--- a/test/stripe/v2_ref_test.rb
+++ b/test/stripe/v2_ref_test.rb
@@ -7,7 +7,7 @@ module Stripe
   class V2RefTest < Test::Unit::TestCase
     context "Stripe::V2::Ref" do
       setup do
-        @client = StripeClient.new("test_123")
+        @requestor = APIRequestor.new("test_123")
         @ref_data = { "type" => "billing.meter", "id" => "mtr_123", "url" => "/v1/billing/meters/mtr_123" }
         @v2_ref_data = { "type" => "v2.core.account", "id" => "acct_123", "url" => "/v2/core/accounts/acct_123" }
       end
@@ -27,19 +27,26 @@ module Stripe
           assert_equal "/v1/billing/meters/mtr_123", ref.url
         end
 
-        should "accept a client" do
-          ref = Stripe::V2::Ref.new(@ref_data, @client)
+        should "accept a requestor" do
+          ref = Stripe::V2::Ref.new(@ref_data, @requestor)
           assert_not_nil ref
         end
 
-        should "accept no client" do
+        should "accept no requestor" do
           ref = Stripe::V2::Ref.new(@ref_data)
           assert_not_nil ref
+        end
+
+        should "construct_from with requestor" do
+          ref = Stripe::V2::Ref.construct_from(@ref_data, {}, nil, :v2, @requestor)
+          assert_equal "billing.meter", ref.type
+          assert_equal "mtr_123", ref.id
+          assert_equal "/v1/billing/meters/mtr_123", ref.url
         end
       end
 
       context "#fetch" do
-        should "raise ArgumentError when no client is present" do
+        should "raise ArgumentError when no requestor is present" do
           ref = Stripe::V2::Ref.new(@ref_data)
           assert_raises ArgumentError do
             ref.fetch
@@ -50,7 +57,7 @@ module Stripe
           stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v1/billing/meters/mtr_123")
             .to_return(body: JSON.generate({ "id" => "mtr_123", "object" => "billing.meter" }))
 
-          ref = Stripe::V2::Ref.new(@ref_data, @client)
+          ref = Stripe::V2::Ref.new(@ref_data, @requestor)
           result = ref.fetch
 
           assert_not_nil result
@@ -63,7 +70,7 @@ module Stripe
           stub_request(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/accounts/acct_123")
             .to_return(body: JSON.generate({ "id" => "acct_123", "object" => "v2.core.account" }))
 
-          ref = Stripe::V2::Ref.new(@v2_ref_data, @client)
+          ref = Stripe::V2::Ref.new(@v2_ref_data, @requestor)
           result = ref.fetch
 
           assert_not_nil result

--- a/test/stripe/v2_ref_test.rb
+++ b/test/stripe/v2_ref_test.rb
@@ -54,6 +54,8 @@ module Stripe
           result = ref.fetch
 
           assert_not_nil result
+          assert_equal "mtr_123", result["id"]
+          assert_equal "billing.meter", result["object"]
           assert_requested(:get, "#{Stripe::DEFAULT_API_BASE}/v1/billing/meters/mtr_123")
         end
 
@@ -65,6 +67,8 @@ module Stripe
           result = ref.fetch
 
           assert_not_nil result
+          assert_equal "acct_123", result["id"]
+          assert_equal "v2.core.account", result["object"]
           assert_requested(:get, "#{Stripe::DEFAULT_API_BASE}/v2/core/accounts/acct_123")
         end
       end


### PR DESCRIPTION
### Why?

Custom objects need typed references to other Stripe objects. A reference has the wire shape `{type, id, url}` and in the SDK becomes `Ref` — a container that can fetch the referenced object.

### What?

- `Stripe::V2::Ref` class (standalone, not a StripeObject subclass)
- `type`, `id`, `url` attributes
- Stores `@requestor` (an `APIRequestor`, not StripeClient)
- `fetch` calls `@requestor.execute_request(:get, url, :api)` — same pattern as `Event.fetch_related_object` (the API pull path)
- `construct_from` classmethod matching StripeObject's 5-arg signature so the deserialization pipeline can instantiate Ref via `inner_class_types`
- Requestor is threaded through `convert_to_stripe_object_with_params` → `construct_from` automatically

### See Also


Generated with [Claude Code](https://claude.com/claude-code)