### PR TITLE
Use autoload instead of eager require for generated resource, service, and param files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,8 +47,6 @@ Metrics/CollectionLiteralLength:
   Exclude:
     # We have thin event types that are automatically generated from the OpenAPI spec
     - "lib/stripe/event_types.rb"
-    # Generated list of param files for eager loading
-    - "lib/stripe/params.rb"
 
 # There are several methods with many branches in api_requestor due to
 # request logic.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,8 @@ Metrics/CollectionLiteralLength:
   Exclude:
     # We have thin event types that are automatically generated from the OpenAPI spec
     - "lib/stripe/event_types.rb"
+    # Generated list of param files for eager loading
+    - "lib/stripe/params.rb"
 
 # There are several methods with many branches in api_requestor due to
 # request logic.

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -52,11 +52,11 @@ require "stripe/api_resource_test_helpers"
 require "stripe/singleton_api_resource"
 require "stripe/webhook"
 require "stripe/stripe_configuration"
-require "stripe/resources/v2/amount"
-require "stripe/resources/v2/deleted_object"
-require "stripe/resources/v2/core/event_notification"
 
-# Named API resources
+# Named API resources — autoloaded on first use to reduce boot time.
+# Call Stripe.eager_load! to load everything upfront (recommended
+# before forking in production). In Rails, this happens automatically
+# when config.eager_load is true.
 require "stripe/resources"
 require "stripe/services"
 require "stripe/params"
@@ -64,6 +64,10 @@ require "stripe/params"
 # OAuth
 require "stripe/oauth"
 require "stripe/services/oauth_service"
+
+# Rails integration — registers Stripe in config.eager_load_namespaces
+# so Stripe.eager_load! is called automatically when config.eager_load is true.
+require "stripe/railtie" if defined?(::Rails::Railtie)
 
 module Stripe
   DEFAULT_CA_BUNDLE_PATH = __dir__ + "/data/ca-certificates.crt"
@@ -134,6 +138,23 @@ module Stripe
     def_delegators :@config, :max_network_retry_delay
     def_delegators :@config, :initial_network_retry_delay
     def_delegators :@config, :ca_store
+  end
+
+  # Eagerly loads all autoloaded Stripe constants (resources, services,
+  # params) using the same file list and load order as previous versions
+  # of this gem that used eager require.
+  #
+  # Call this before forking in production (Puma, Unicorn, etc.) to
+  # avoid autoload in multi-threaded request handling. In Rails apps
+  # this is called automatically when config.eager_load is true.
+  #
+  #   # Non-Rails production / pre-fork hook:
+  #   Stripe.eager_load!
+  #
+  def self.eager_load!
+    (RESOURCE_FILES + SERVICE_FILES + PARAM_FILES).each do |path|
+      require path
+    end
   end
 
   # Gets the application for a plugin that's identified some. See

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -67,7 +67,7 @@ require "stripe/services/oauth_service"
 
 # Rails integration — registers Stripe in config.eager_load_namespaces
 # so Stripe.eager_load! is called automatically when config.eager_load is true.
-require "stripe/railtie" if defined?(::Rails::Railtie)
+require "stripe/railtie" if defined?(Rails::Railtie)
 
 module Stripe
   DEFAULT_CA_BUNDLE_PATH = __dir__ + "/data/ca-certificates.crt"

--- a/lib/stripe/params.rb
+++ b/lib/stripe/params.rb
@@ -1,617 +1,1310 @@
 # File generated from our OpenAPI spec
 # frozen_string_literal: true
 
-require "stripe/params/account_capability_list_params"
-require "stripe/params/account_capability_retrieve_params"
-require "stripe/params/account_capability_update_params"
-require "stripe/params/account_create_params"
-require "stripe/params/account_delete_params"
-require "stripe/params/account_external_account_create_params"
-require "stripe/params/account_external_account_delete_params"
-require "stripe/params/account_external_account_list_params"
-require "stripe/params/account_external_account_retrieve_params"
-require "stripe/params/account_external_account_update_params"
-require "stripe/params/account_link_create_params"
-require "stripe/params/account_list_params"
-require "stripe/params/account_login_link_create_params"
-require "stripe/params/account_person_create_params"
-require "stripe/params/account_person_delete_params"
-require "stripe/params/account_person_list_params"
-require "stripe/params/account_person_retrieve_params"
-require "stripe/params/account_person_update_params"
-require "stripe/params/account_persons_params"
-require "stripe/params/account_reject_params"
-require "stripe/params/account_retrieve_current_params"
-require "stripe/params/account_retrieve_params"
-require "stripe/params/account_session_create_params"
-require "stripe/params/account_update_params"
-require "stripe/params/apple_pay_domain_create_params"
-require "stripe/params/apple_pay_domain_delete_params"
-require "stripe/params/apple_pay_domain_list_params"
-require "stripe/params/apple_pay_domain_retrieve_params"
-require "stripe/params/application_fee_list_params"
-require "stripe/params/application_fee_refund_create_params"
-require "stripe/params/application_fee_refund_list_params"
-require "stripe/params/application_fee_refund_retrieve_params"
-require "stripe/params/application_fee_refund_update_params"
-require "stripe/params/application_fee_retrieve_params"
-require "stripe/params/apps/secret_create_params"
-require "stripe/params/apps/secret_delete_where_params"
-require "stripe/params/apps/secret_find_params"
-require "stripe/params/apps/secret_list_params"
-require "stripe/params/balance_retrieve_params"
-require "stripe/params/balance_settings_retrieve_params"
-require "stripe/params/balance_settings_update_params"
-require "stripe/params/balance_transaction_list_params"
-require "stripe/params/balance_transaction_retrieve_params"
-require "stripe/params/billing/alert_activate_params"
-require "stripe/params/billing/alert_archive_params"
-require "stripe/params/billing/alert_create_params"
-require "stripe/params/billing/alert_deactivate_params"
-require "stripe/params/billing/alert_list_params"
-require "stripe/params/billing/alert_retrieve_params"
-require "stripe/params/billing/credit_balance_summary_retrieve_params"
-require "stripe/params/billing/credit_balance_transaction_list_params"
-require "stripe/params/billing/credit_balance_transaction_retrieve_params"
-require "stripe/params/billing/credit_grant_create_params"
-require "stripe/params/billing/credit_grant_expire_params"
-require "stripe/params/billing/credit_grant_list_params"
-require "stripe/params/billing/credit_grant_retrieve_params"
-require "stripe/params/billing/credit_grant_update_params"
-require "stripe/params/billing/credit_grant_void_grant_params"
-require "stripe/params/billing/meter_create_params"
-require "stripe/params/billing/meter_deactivate_params"
-require "stripe/params/billing/meter_event_adjustment_create_params"
-require "stripe/params/billing/meter_event_create_params"
-require "stripe/params/billing/meter_event_summary_list_params"
-require "stripe/params/billing/meter_list_params"
-require "stripe/params/billing/meter_reactivate_params"
-require "stripe/params/billing/meter_retrieve_params"
-require "stripe/params/billing/meter_update_params"
-require "stripe/params/billing_portal/configuration_create_params"
-require "stripe/params/billing_portal/configuration_list_params"
-require "stripe/params/billing_portal/configuration_retrieve_params"
-require "stripe/params/billing_portal/configuration_update_params"
-require "stripe/params/billing_portal/session_create_params"
-require "stripe/params/charge_capture_params"
-require "stripe/params/charge_create_params"
-require "stripe/params/charge_list_params"
-require "stripe/params/charge_retrieve_params"
-require "stripe/params/charge_search_params"
-require "stripe/params/charge_update_params"
-require "stripe/params/checkout/session_create_params"
-require "stripe/params/checkout/session_expire_params"
-require "stripe/params/checkout/session_line_item_list_params"
-require "stripe/params/checkout/session_list_line_items_params"
-require "stripe/params/checkout/session_list_params"
-require "stripe/params/checkout/session_retrieve_params"
-require "stripe/params/checkout/session_update_params"
-require "stripe/params/climate/order_cancel_params"
-require "stripe/params/climate/order_create_params"
-require "stripe/params/climate/order_list_params"
-require "stripe/params/climate/order_retrieve_params"
-require "stripe/params/climate/order_update_params"
-require "stripe/params/climate/product_list_params"
-require "stripe/params/climate/product_retrieve_params"
-require "stripe/params/climate/supplier_list_params"
-require "stripe/params/climate/supplier_retrieve_params"
-require "stripe/params/confirmation_token_create_params"
-require "stripe/params/confirmation_token_retrieve_params"
-require "stripe/params/country_spec_list_params"
-require "stripe/params/country_spec_retrieve_params"
-require "stripe/params/coupon_create_params"
-require "stripe/params/coupon_delete_params"
-require "stripe/params/coupon_list_params"
-require "stripe/params/coupon_retrieve_params"
-require "stripe/params/coupon_update_params"
-require "stripe/params/credit_note_create_params"
-require "stripe/params/credit_note_line_item_list_params"
-require "stripe/params/credit_note_list_params"
-require "stripe/params/credit_note_list_preview_line_items_params"
-require "stripe/params/credit_note_preview_lines_list_params"
-require "stripe/params/credit_note_preview_params"
-require "stripe/params/credit_note_retrieve_params"
-require "stripe/params/credit_note_update_params"
-require "stripe/params/credit_note_void_credit_note_params"
-require "stripe/params/customer_balance_transaction_create_params"
-require "stripe/params/customer_balance_transaction_list_params"
-require "stripe/params/customer_balance_transaction_retrieve_params"
-require "stripe/params/customer_balance_transaction_update_params"
-require "stripe/params/customer_cash_balance_retrieve_params"
-require "stripe/params/customer_cash_balance_transaction_list_params"
-require "stripe/params/customer_cash_balance_transaction_retrieve_params"
-require "stripe/params/customer_cash_balance_update_params"
-require "stripe/params/customer_create_funding_instructions_params"
-require "stripe/params/customer_create_params"
-require "stripe/params/customer_delete_discount_params"
-require "stripe/params/customer_delete_params"
-require "stripe/params/customer_fund_cash_balance_params"
-require "stripe/params/customer_funding_instructions_create_params"
-require "stripe/params/customer_list_params"
-require "stripe/params/customer_list_payment_methods_params"
-require "stripe/params/customer_payment_method_list_params"
-require "stripe/params/customer_payment_method_retrieve_params"
-require "stripe/params/customer_payment_source_create_params"
-require "stripe/params/customer_payment_source_delete_params"
-require "stripe/params/customer_payment_source_list_params"
-require "stripe/params/customer_payment_source_retrieve_params"
-require "stripe/params/customer_payment_source_update_params"
-require "stripe/params/customer_payment_source_verify_params"
-require "stripe/params/customer_retrieve_params"
-require "stripe/params/customer_retrieve_payment_method_params"
-require "stripe/params/customer_search_params"
-require "stripe/params/customer_session_create_params"
-require "stripe/params/customer_tax_id_create_params"
-require "stripe/params/customer_tax_id_delete_params"
-require "stripe/params/customer_tax_id_list_params"
-require "stripe/params/customer_tax_id_retrieve_params"
-require "stripe/params/customer_update_params"
-require "stripe/params/dispute_close_params"
-require "stripe/params/dispute_list_params"
-require "stripe/params/dispute_retrieve_params"
-require "stripe/params/dispute_update_params"
-require "stripe/params/entitlements/active_entitlement_list_params"
-require "stripe/params/entitlements/active_entitlement_retrieve_params"
-require "stripe/params/entitlements/feature_create_params"
-require "stripe/params/entitlements/feature_list_params"
-require "stripe/params/entitlements/feature_retrieve_params"
-require "stripe/params/entitlements/feature_update_params"
-require "stripe/params/ephemeral_key_create_params"
-require "stripe/params/ephemeral_key_delete_params"
-require "stripe/params/event_list_params"
-require "stripe/params/event_retrieve_params"
-require "stripe/params/exchange_rate_list_params"
-require "stripe/params/exchange_rate_retrieve_params"
-require "stripe/params/file_create_params"
-require "stripe/params/file_link_create_params"
-require "stripe/params/file_link_list_params"
-require "stripe/params/file_link_retrieve_params"
-require "stripe/params/file_link_update_params"
-require "stripe/params/file_list_params"
-require "stripe/params/file_retrieve_params"
-require "stripe/params/financial_connections/account_disconnect_params"
-require "stripe/params/financial_connections/account_list_owners_params"
-require "stripe/params/financial_connections/account_list_params"
-require "stripe/params/financial_connections/account_owner_list_params"
-require "stripe/params/financial_connections/account_refresh_account_params"
-require "stripe/params/financial_connections/account_refresh_params"
-require "stripe/params/financial_connections/account_retrieve_params"
-require "stripe/params/financial_connections/account_subscribe_params"
-require "stripe/params/financial_connections/account_unsubscribe_params"
-require "stripe/params/financial_connections/session_create_params"
-require "stripe/params/financial_connections/session_retrieve_params"
-require "stripe/params/financial_connections/transaction_list_params"
-require "stripe/params/financial_connections/transaction_retrieve_params"
-require "stripe/params/forwarding/request_create_params"
-require "stripe/params/forwarding/request_list_params"
-require "stripe/params/forwarding/request_retrieve_params"
-require "stripe/params/identity/verification_report_list_params"
-require "stripe/params/identity/verification_report_retrieve_params"
-require "stripe/params/identity/verification_session_cancel_params"
-require "stripe/params/identity/verification_session_create_params"
-require "stripe/params/identity/verification_session_list_params"
-require "stripe/params/identity/verification_session_redact_params"
-require "stripe/params/identity/verification_session_retrieve_params"
-require "stripe/params/identity/verification_session_update_params"
-require "stripe/params/invoice_add_lines_params"
-require "stripe/params/invoice_attach_payment_params"
-require "stripe/params/invoice_create_params"
-require "stripe/params/invoice_create_preview_params"
-require "stripe/params/invoice_delete_params"
-require "stripe/params/invoice_finalize_invoice_params"
-require "stripe/params/invoice_item_create_params"
-require "stripe/params/invoice_item_delete_params"
-require "stripe/params/invoice_item_list_params"
-require "stripe/params/invoice_item_retrieve_params"
-require "stripe/params/invoice_item_update_params"
-require "stripe/params/invoice_line_item_list_params"
-require "stripe/params/invoice_line_item_update_params"
-require "stripe/params/invoice_list_params"
-require "stripe/params/invoice_mark_uncollectible_params"
-require "stripe/params/invoice_pay_params"
-require "stripe/params/invoice_payment_list_params"
-require "stripe/params/invoice_payment_retrieve_params"
-require "stripe/params/invoice_remove_lines_params"
-require "stripe/params/invoice_rendering_template_archive_params"
-require "stripe/params/invoice_rendering_template_list_params"
-require "stripe/params/invoice_rendering_template_retrieve_params"
-require "stripe/params/invoice_rendering_template_unarchive_params"
-require "stripe/params/invoice_retrieve_params"
-require "stripe/params/invoice_search_params"
-require "stripe/params/invoice_send_invoice_params"
-require "stripe/params/invoice_update_lines_params"
-require "stripe/params/invoice_update_params"
-require "stripe/params/invoice_void_invoice_params"
-require "stripe/params/issuing/authorization_approve_params"
-require "stripe/params/issuing/authorization_capture_params"
-require "stripe/params/issuing/authorization_create_params"
-require "stripe/params/issuing/authorization_decline_params"
-require "stripe/params/issuing/authorization_expire_params"
-require "stripe/params/issuing/authorization_finalize_amount_params"
-require "stripe/params/issuing/authorization_increment_params"
-require "stripe/params/issuing/authorization_list_params"
-require "stripe/params/issuing/authorization_respond_params"
-require "stripe/params/issuing/authorization_retrieve_params"
-require "stripe/params/issuing/authorization_reverse_params"
-require "stripe/params/issuing/authorization_update_params"
-require "stripe/params/issuing/card_create_params"
-require "stripe/params/issuing/card_deliver_card_params"
-require "stripe/params/issuing/card_fail_card_params"
-require "stripe/params/issuing/card_list_params"
-require "stripe/params/issuing/card_retrieve_params"
-require "stripe/params/issuing/card_return_card_params"
-require "stripe/params/issuing/card_ship_card_params"
-require "stripe/params/issuing/card_submit_card_params"
-require "stripe/params/issuing/card_update_params"
-require "stripe/params/issuing/cardholder_create_params"
-require "stripe/params/issuing/cardholder_list_params"
-require "stripe/params/issuing/cardholder_retrieve_params"
-require "stripe/params/issuing/cardholder_update_params"
-require "stripe/params/issuing/dispute_create_params"
-require "stripe/params/issuing/dispute_list_params"
-require "stripe/params/issuing/dispute_retrieve_params"
-require "stripe/params/issuing/dispute_submit_params"
-require "stripe/params/issuing/dispute_update_params"
-require "stripe/params/issuing/personalization_design_activate_params"
-require "stripe/params/issuing/personalization_design_create_params"
-require "stripe/params/issuing/personalization_design_deactivate_params"
-require "stripe/params/issuing/personalization_design_list_params"
-require "stripe/params/issuing/personalization_design_reject_params"
-require "stripe/params/issuing/personalization_design_retrieve_params"
-require "stripe/params/issuing/personalization_design_update_params"
-require "stripe/params/issuing/physical_bundle_list_params"
-require "stripe/params/issuing/physical_bundle_retrieve_params"
-require "stripe/params/issuing/token_list_params"
-require "stripe/params/issuing/token_retrieve_params"
-require "stripe/params/issuing/token_update_params"
-require "stripe/params/issuing/transaction_create_force_capture_params"
-require "stripe/params/issuing/transaction_create_unlinked_refund_params"
-require "stripe/params/issuing/transaction_list_params"
-require "stripe/params/issuing/transaction_refund_params"
-require "stripe/params/issuing/transaction_retrieve_params"
-require "stripe/params/issuing/transaction_update_params"
-require "stripe/params/mandate_retrieve_params"
-require "stripe/params/payment_attempt_record_list_params"
-require "stripe/params/payment_attempt_record_retrieve_params"
-require "stripe/params/payment_intent_amount_details_line_item_list_params"
-require "stripe/params/payment_intent_apply_customer_balance_params"
-require "stripe/params/payment_intent_cancel_params"
-require "stripe/params/payment_intent_capture_params"
-require "stripe/params/payment_intent_confirm_params"
-require "stripe/params/payment_intent_create_params"
-require "stripe/params/payment_intent_increment_authorization_params"
-require "stripe/params/payment_intent_list_params"
-require "stripe/params/payment_intent_retrieve_params"
-require "stripe/params/payment_intent_search_params"
-require "stripe/params/payment_intent_update_params"
-require "stripe/params/payment_intent_verify_microdeposits_params"
-require "stripe/params/payment_link_create_params"
-require "stripe/params/payment_link_line_item_list_params"
-require "stripe/params/payment_link_list_line_items_params"
-require "stripe/params/payment_link_list_params"
-require "stripe/params/payment_link_retrieve_params"
-require "stripe/params/payment_link_update_params"
-require "stripe/params/payment_method_attach_params"
-require "stripe/params/payment_method_configuration_create_params"
-require "stripe/params/payment_method_configuration_list_params"
-require "stripe/params/payment_method_configuration_retrieve_params"
-require "stripe/params/payment_method_configuration_update_params"
-require "stripe/params/payment_method_create_params"
-require "stripe/params/payment_method_detach_params"
-require "stripe/params/payment_method_domain_create_params"
-require "stripe/params/payment_method_domain_list_params"
-require "stripe/params/payment_method_domain_retrieve_params"
-require "stripe/params/payment_method_domain_update_params"
-require "stripe/params/payment_method_domain_validate_params"
-require "stripe/params/payment_method_list_params"
-require "stripe/params/payment_method_retrieve_params"
-require "stripe/params/payment_method_update_params"
-require "stripe/params/payment_record_report_payment_attempt_canceled_params"
-require "stripe/params/payment_record_report_payment_attempt_failed_params"
-require "stripe/params/payment_record_report_payment_attempt_guaranteed_params"
-require "stripe/params/payment_record_report_payment_attempt_informational_params"
-require "stripe/params/payment_record_report_payment_attempt_params"
-require "stripe/params/payment_record_report_payment_params"
-require "stripe/params/payment_record_report_refund_params"
-require "stripe/params/payment_record_retrieve_params"
-require "stripe/params/payout_cancel_params"
-require "stripe/params/payout_create_params"
-require "stripe/params/payout_list_params"
-require "stripe/params/payout_retrieve_params"
-require "stripe/params/payout_reverse_params"
-require "stripe/params/payout_update_params"
-require "stripe/params/plan_create_params"
-require "stripe/params/plan_delete_params"
-require "stripe/params/plan_list_params"
-require "stripe/params/plan_retrieve_params"
-require "stripe/params/plan_update_params"
-require "stripe/params/price_create_params"
-require "stripe/params/price_list_params"
-require "stripe/params/price_retrieve_params"
-require "stripe/params/price_search_params"
-require "stripe/params/price_update_params"
-require "stripe/params/product_create_params"
-require "stripe/params/product_delete_params"
-require "stripe/params/product_feature_create_params"
-require "stripe/params/product_feature_delete_params"
-require "stripe/params/product_feature_list_params"
-require "stripe/params/product_feature_retrieve_params"
-require "stripe/params/product_list_params"
-require "stripe/params/product_retrieve_params"
-require "stripe/params/product_search_params"
-require "stripe/params/product_update_params"
-require "stripe/params/promotion_code_create_params"
-require "stripe/params/promotion_code_list_params"
-require "stripe/params/promotion_code_retrieve_params"
-require "stripe/params/promotion_code_update_params"
-require "stripe/params/quote_accept_params"
-require "stripe/params/quote_cancel_params"
-require "stripe/params/quote_computed_upfront_line_items_list_params"
-require "stripe/params/quote_create_params"
-require "stripe/params/quote_finalize_quote_params"
-require "stripe/params/quote_line_item_list_params"
-require "stripe/params/quote_list_computed_upfront_line_items_params"
-require "stripe/params/quote_list_line_items_params"
-require "stripe/params/quote_list_params"
-require "stripe/params/quote_pdf_params"
-require "stripe/params/quote_retrieve_params"
-require "stripe/params/quote_update_params"
-require "stripe/params/radar/early_fraud_warning_list_params"
-require "stripe/params/radar/early_fraud_warning_retrieve_params"
-require "stripe/params/radar/payment_evaluation_create_params"
-require "stripe/params/radar/value_list_create_params"
-require "stripe/params/radar/value_list_delete_params"
-require "stripe/params/radar/value_list_item_create_params"
-require "stripe/params/radar/value_list_item_delete_params"
-require "stripe/params/radar/value_list_item_list_params"
-require "stripe/params/radar/value_list_item_retrieve_params"
-require "stripe/params/radar/value_list_list_params"
-require "stripe/params/radar/value_list_retrieve_params"
-require "stripe/params/radar/value_list_update_params"
-require "stripe/params/refund_cancel_params"
-require "stripe/params/refund_create_params"
-require "stripe/params/refund_expire_params"
-require "stripe/params/refund_list_params"
-require "stripe/params/refund_retrieve_params"
-require "stripe/params/refund_update_params"
-require "stripe/params/reporting/report_run_create_params"
-require "stripe/params/reporting/report_run_list_params"
-require "stripe/params/reporting/report_run_retrieve_params"
-require "stripe/params/reporting/report_type_list_params"
-require "stripe/params/reporting/report_type_retrieve_params"
-require "stripe/params/review_approve_params"
-require "stripe/params/review_list_params"
-require "stripe/params/review_retrieve_params"
-require "stripe/params/setup_attempt_list_params"
-require "stripe/params/setup_intent_cancel_params"
-require "stripe/params/setup_intent_confirm_params"
-require "stripe/params/setup_intent_create_params"
-require "stripe/params/setup_intent_list_params"
-require "stripe/params/setup_intent_retrieve_params"
-require "stripe/params/setup_intent_update_params"
-require "stripe/params/setup_intent_verify_microdeposits_params"
-require "stripe/params/shipping_rate_create_params"
-require "stripe/params/shipping_rate_list_params"
-require "stripe/params/shipping_rate_retrieve_params"
-require "stripe/params/shipping_rate_update_params"
-require "stripe/params/sigma/scheduled_query_run_list_params"
-require "stripe/params/sigma/scheduled_query_run_retrieve_params"
-require "stripe/params/source_create_params"
-require "stripe/params/source_detach_params"
-require "stripe/params/source_retrieve_params"
-require "stripe/params/source_transaction_list_params"
-require "stripe/params/source_update_params"
-require "stripe/params/source_verify_params"
-require "stripe/params/subscription_cancel_params"
-require "stripe/params/subscription_create_params"
-require "stripe/params/subscription_delete_discount_params"
-require "stripe/params/subscription_item_create_params"
-require "stripe/params/subscription_item_delete_params"
-require "stripe/params/subscription_item_list_params"
-require "stripe/params/subscription_item_retrieve_params"
-require "stripe/params/subscription_item_update_params"
-require "stripe/params/subscription_list_params"
-require "stripe/params/subscription_migrate_params"
-require "stripe/params/subscription_resume_params"
-require "stripe/params/subscription_retrieve_params"
-require "stripe/params/subscription_schedule_cancel_params"
-require "stripe/params/subscription_schedule_create_params"
-require "stripe/params/subscription_schedule_list_params"
-require "stripe/params/subscription_schedule_release_params"
-require "stripe/params/subscription_schedule_retrieve_params"
-require "stripe/params/subscription_schedule_update_params"
-require "stripe/params/subscription_search_params"
-require "stripe/params/subscription_update_params"
-require "stripe/params/tax/association_find_params"
-require "stripe/params/tax/calculation_create_params"
-require "stripe/params/tax/calculation_line_item_list_params"
-require "stripe/params/tax/calculation_list_line_items_params"
-require "stripe/params/tax/calculation_retrieve_params"
-require "stripe/params/tax/registration_create_params"
-require "stripe/params/tax/registration_list_params"
-require "stripe/params/tax/registration_retrieve_params"
-require "stripe/params/tax/registration_update_params"
-require "stripe/params/tax/settings_retrieve_params"
-require "stripe/params/tax/settings_update_params"
-require "stripe/params/tax/transaction_create_from_calculation_params"
-require "stripe/params/tax/transaction_create_reversal_params"
-require "stripe/params/tax/transaction_line_item_list_params"
-require "stripe/params/tax/transaction_list_line_items_params"
-require "stripe/params/tax/transaction_retrieve_params"
-require "stripe/params/tax_code_list_params"
-require "stripe/params/tax_code_retrieve_params"
-require "stripe/params/tax_id_create_params"
-require "stripe/params/tax_id_delete_params"
-require "stripe/params/tax_id_list_params"
-require "stripe/params/tax_id_retrieve_params"
-require "stripe/params/tax_rate_create_params"
-require "stripe/params/tax_rate_list_params"
-require "stripe/params/tax_rate_retrieve_params"
-require "stripe/params/tax_rate_update_params"
-require "stripe/params/terminal/configuration_create_params"
-require "stripe/params/terminal/configuration_delete_params"
-require "stripe/params/terminal/configuration_list_params"
-require "stripe/params/terminal/configuration_retrieve_params"
-require "stripe/params/terminal/configuration_update_params"
-require "stripe/params/terminal/connection_token_create_params"
-require "stripe/params/terminal/location_create_params"
-require "stripe/params/terminal/location_delete_params"
-require "stripe/params/terminal/location_list_params"
-require "stripe/params/terminal/location_retrieve_params"
-require "stripe/params/terminal/location_update_params"
-require "stripe/params/terminal/onboarding_link_create_params"
-require "stripe/params/terminal/reader_cancel_action_params"
-require "stripe/params/terminal/reader_collect_inputs_params"
-require "stripe/params/terminal/reader_collect_payment_method_params"
-require "stripe/params/terminal/reader_confirm_payment_intent_params"
-require "stripe/params/terminal/reader_create_params"
-require "stripe/params/terminal/reader_delete_params"
-require "stripe/params/terminal/reader_list_params"
-require "stripe/params/terminal/reader_present_payment_method_params"
-require "stripe/params/terminal/reader_process_payment_intent_params"
-require "stripe/params/terminal/reader_process_setup_intent_params"
-require "stripe/params/terminal/reader_refund_payment_params"
-require "stripe/params/terminal/reader_retrieve_params"
-require "stripe/params/terminal/reader_set_reader_display_params"
-require "stripe/params/terminal/reader_succeed_input_collection_params"
-require "stripe/params/terminal/reader_timeout_input_collection_params"
-require "stripe/params/terminal/reader_update_params"
-require "stripe/params/test_helpers/confirmation_token_create_params"
-require "stripe/params/test_helpers/customer_fund_cash_balance_params"
-require "stripe/params/test_helpers/issuing/authorization_capture_params"
-require "stripe/params/test_helpers/issuing/authorization_create_params"
-require "stripe/params/test_helpers/issuing/authorization_expire_params"
-require "stripe/params/test_helpers/issuing/authorization_finalize_amount_params"
-require "stripe/params/test_helpers/issuing/authorization_increment_params"
-require "stripe/params/test_helpers/issuing/authorization_respond_params"
-require "stripe/params/test_helpers/issuing/authorization_reverse_params"
-require "stripe/params/test_helpers/issuing/card_deliver_card_params"
-require "stripe/params/test_helpers/issuing/card_fail_card_params"
-require "stripe/params/test_helpers/issuing/card_return_card_params"
-require "stripe/params/test_helpers/issuing/card_ship_card_params"
-require "stripe/params/test_helpers/issuing/card_submit_card_params"
-require "stripe/params/test_helpers/issuing/personalization_design_activate_params"
-require "stripe/params/test_helpers/issuing/personalization_design_deactivate_params"
-require "stripe/params/test_helpers/issuing/personalization_design_reject_params"
-require "stripe/params/test_helpers/issuing/transaction_create_force_capture_params"
-require "stripe/params/test_helpers/issuing/transaction_create_unlinked_refund_params"
-require "stripe/params/test_helpers/issuing/transaction_refund_params"
-require "stripe/params/test_helpers/refund_expire_params"
-require "stripe/params/test_helpers/terminal/reader_present_payment_method_params"
-require "stripe/params/test_helpers/terminal/reader_succeed_input_collection_params"
-require "stripe/params/test_helpers/terminal/reader_timeout_input_collection_params"
-require "stripe/params/test_helpers/test_clock_advance_params"
-require "stripe/params/test_helpers/test_clock_create_params"
-require "stripe/params/test_helpers/test_clock_delete_params"
-require "stripe/params/test_helpers/test_clock_list_params"
-require "stripe/params/test_helpers/test_clock_retrieve_params"
-require "stripe/params/test_helpers/treasury/inbound_transfer_fail_params"
-require "stripe/params/test_helpers/treasury/inbound_transfer_return_inbound_transfer_params"
-require "stripe/params/test_helpers/treasury/inbound_transfer_succeed_params"
-require "stripe/params/test_helpers/treasury/outbound_payment_fail_params"
-require "stripe/params/test_helpers/treasury/outbound_payment_post_params"
-require "stripe/params/test_helpers/treasury/outbound_payment_return_outbound_payment_params"
-require "stripe/params/test_helpers/treasury/outbound_payment_update_params"
-require "stripe/params/test_helpers/treasury/outbound_transfer_fail_params"
-require "stripe/params/test_helpers/treasury/outbound_transfer_post_params"
-require "stripe/params/test_helpers/treasury/outbound_transfer_return_outbound_transfer_params"
-require "stripe/params/test_helpers/treasury/outbound_transfer_update_params"
-require "stripe/params/test_helpers/treasury/received_credit_create_params"
-require "stripe/params/test_helpers/treasury/received_debit_create_params"
-require "stripe/params/token_create_params"
-require "stripe/params/token_retrieve_params"
-require "stripe/params/topup_cancel_params"
-require "stripe/params/topup_create_params"
-require "stripe/params/topup_list_params"
-require "stripe/params/topup_retrieve_params"
-require "stripe/params/topup_update_params"
-require "stripe/params/transfer_create_params"
-require "stripe/params/transfer_list_params"
-require "stripe/params/transfer_retrieve_params"
-require "stripe/params/transfer_reversal_create_params"
-require "stripe/params/transfer_reversal_list_params"
-require "stripe/params/transfer_reversal_retrieve_params"
-require "stripe/params/transfer_reversal_update_params"
-require "stripe/params/transfer_update_params"
-require "stripe/params/treasury/credit_reversal_create_params"
-require "stripe/params/treasury/credit_reversal_list_params"
-require "stripe/params/treasury/credit_reversal_retrieve_params"
-require "stripe/params/treasury/debit_reversal_create_params"
-require "stripe/params/treasury/debit_reversal_list_params"
-require "stripe/params/treasury/debit_reversal_retrieve_params"
-require "stripe/params/treasury/financial_account_close_params"
-require "stripe/params/treasury/financial_account_create_params"
-require "stripe/params/treasury/financial_account_features_retrieve_params"
-require "stripe/params/treasury/financial_account_features_update_params"
-require "stripe/params/treasury/financial_account_list_params"
-require "stripe/params/treasury/financial_account_retrieve_features_params"
-require "stripe/params/treasury/financial_account_retrieve_params"
-require "stripe/params/treasury/financial_account_update_features_params"
-require "stripe/params/treasury/financial_account_update_params"
-require "stripe/params/treasury/inbound_transfer_cancel_params"
-require "stripe/params/treasury/inbound_transfer_create_params"
-require "stripe/params/treasury/inbound_transfer_fail_params"
-require "stripe/params/treasury/inbound_transfer_list_params"
-require "stripe/params/treasury/inbound_transfer_retrieve_params"
-require "stripe/params/treasury/inbound_transfer_return_inbound_transfer_params"
-require "stripe/params/treasury/inbound_transfer_succeed_params"
-require "stripe/params/treasury/outbound_payment_cancel_params"
-require "stripe/params/treasury/outbound_payment_create_params"
-require "stripe/params/treasury/outbound_payment_fail_params"
-require "stripe/params/treasury/outbound_payment_list_params"
-require "stripe/params/treasury/outbound_payment_post_params"
-require "stripe/params/treasury/outbound_payment_retrieve_params"
-require "stripe/params/treasury/outbound_payment_return_outbound_payment_params"
-require "stripe/params/treasury/outbound_payment_update_params"
-require "stripe/params/treasury/outbound_transfer_cancel_params"
-require "stripe/params/treasury/outbound_transfer_create_params"
-require "stripe/params/treasury/outbound_transfer_fail_params"
-require "stripe/params/treasury/outbound_transfer_list_params"
-require "stripe/params/treasury/outbound_transfer_post_params"
-require "stripe/params/treasury/outbound_transfer_retrieve_params"
-require "stripe/params/treasury/outbound_transfer_return_outbound_transfer_params"
-require "stripe/params/treasury/outbound_transfer_update_params"
-require "stripe/params/treasury/received_credit_create_params"
-require "stripe/params/treasury/received_credit_list_params"
-require "stripe/params/treasury/received_credit_retrieve_params"
-require "stripe/params/treasury/received_debit_create_params"
-require "stripe/params/treasury/received_debit_list_params"
-require "stripe/params/treasury/received_debit_retrieve_params"
-require "stripe/params/treasury/transaction_entry_list_params"
-require "stripe/params/treasury/transaction_entry_retrieve_params"
-require "stripe/params/treasury/transaction_list_params"
-require "stripe/params/treasury/transaction_retrieve_params"
-require "stripe/params/v2/billing/meter_event_adjustment_create_params"
-require "stripe/params/v2/billing/meter_event_create_params"
-require "stripe/params/v2/billing/meter_event_session_create_params"
-require "stripe/params/v2/billing/meter_event_stream_create_params"
-require "stripe/params/v2/core/account_close_params"
-require "stripe/params/v2/core/account_create_params"
-require "stripe/params/v2/core/account_link_create_params"
-require "stripe/params/v2/core/account_list_params"
-require "stripe/params/v2/core/account_retrieve_params"
-require "stripe/params/v2/core/account_token_create_params"
-require "stripe/params/v2/core/account_token_retrieve_params"
-require "stripe/params/v2/core/account_update_params"
-require "stripe/params/v2/core/accounts/person_create_params"
-require "stripe/params/v2/core/accounts/person_delete_params"
-require "stripe/params/v2/core/accounts/person_list_params"
-require "stripe/params/v2/core/accounts/person_retrieve_params"
-require "stripe/params/v2/core/accounts/person_token_create_params"
-require "stripe/params/v2/core/accounts/person_token_retrieve_params"
-require "stripe/params/v2/core/accounts/person_update_params"
-require "stripe/params/v2/core/event_destination_create_params"
-require "stripe/params/v2/core/event_destination_delete_params"
-require "stripe/params/v2/core/event_destination_disable_params"
-require "stripe/params/v2/core/event_destination_enable_params"
-require "stripe/params/v2/core/event_destination_list_params"
-require "stripe/params/v2/core/event_destination_ping_params"
-require "stripe/params/v2/core/event_destination_retrieve_params"
-require "stripe/params/v2/core/event_destination_update_params"
-require "stripe/params/v2/core/event_list_params"
-require "stripe/params/v2/core/event_retrieve_params"
-require "stripe/params/webhook_endpoint_create_params"
-require "stripe/params/webhook_endpoint_delete_params"
-require "stripe/params/webhook_endpoint_list_params"
-require "stripe/params/webhook_endpoint_retrieve_params"
-require "stripe/params/webhook_endpoint_update_params"
+module Stripe
+  autoload :AccountCapabilityListParams, "stripe/params/account_capability_list_params"
+  autoload :AccountCapabilityRetrieveParams, "stripe/params/account_capability_retrieve_params"
+  autoload :AccountCapabilityUpdateParams, "stripe/params/account_capability_update_params"
+  autoload :AccountCreateParams, "stripe/params/account_create_params"
+  autoload :AccountDeleteParams, "stripe/params/account_delete_params"
+  autoload :AccountExternalAccountCreateParams, "stripe/params/account_external_account_create_params"
+  autoload :AccountExternalAccountDeleteParams, "stripe/params/account_external_account_delete_params"
+  autoload :AccountExternalAccountListParams, "stripe/params/account_external_account_list_params"
+  autoload :AccountExternalAccountRetrieveParams, "stripe/params/account_external_account_retrieve_params"
+  autoload :AccountExternalAccountUpdateParams, "stripe/params/account_external_account_update_params"
+  autoload :AccountLinkCreateParams, "stripe/params/account_link_create_params"
+  autoload :AccountListParams, "stripe/params/account_list_params"
+  autoload :AccountLoginLinkCreateParams, "stripe/params/account_login_link_create_params"
+  autoload :AccountPersonCreateParams, "stripe/params/account_person_create_params"
+  autoload :AccountPersonDeleteParams, "stripe/params/account_person_delete_params"
+  autoload :AccountPersonListParams, "stripe/params/account_person_list_params"
+  autoload :AccountPersonRetrieveParams, "stripe/params/account_person_retrieve_params"
+  autoload :AccountPersonUpdateParams, "stripe/params/account_person_update_params"
+  autoload :AccountPersonsParams, "stripe/params/account_persons_params"
+  autoload :AccountRejectParams, "stripe/params/account_reject_params"
+  autoload :AccountRetrieveCurrentParams, "stripe/params/account_retrieve_current_params"
+  autoload :AccountRetrieveParams, "stripe/params/account_retrieve_params"
+  autoload :AccountSessionCreateParams, "stripe/params/account_session_create_params"
+  autoload :AccountUpdateParams, "stripe/params/account_update_params"
+  autoload :ApplePayDomainCreateParams, "stripe/params/apple_pay_domain_create_params"
+  autoload :ApplePayDomainDeleteParams, "stripe/params/apple_pay_domain_delete_params"
+  autoload :ApplePayDomainListParams, "stripe/params/apple_pay_domain_list_params"
+  autoload :ApplePayDomainRetrieveParams, "stripe/params/apple_pay_domain_retrieve_params"
+  autoload :ApplicationFeeListParams, "stripe/params/application_fee_list_params"
+  autoload :ApplicationFeeRefundCreateParams, "stripe/params/application_fee_refund_create_params"
+  autoload :ApplicationFeeRefundListParams, "stripe/params/application_fee_refund_list_params"
+  autoload :ApplicationFeeRefundRetrieveParams, "stripe/params/application_fee_refund_retrieve_params"
+  autoload :ApplicationFeeRefundUpdateParams, "stripe/params/application_fee_refund_update_params"
+  autoload :ApplicationFeeRetrieveParams, "stripe/params/application_fee_retrieve_params"
+  autoload :BalanceRetrieveParams, "stripe/params/balance_retrieve_params"
+  autoload :BalanceSettingsRetrieveParams, "stripe/params/balance_settings_retrieve_params"
+  autoload :BalanceSettingsUpdateParams, "stripe/params/balance_settings_update_params"
+  autoload :BalanceTransactionListParams, "stripe/params/balance_transaction_list_params"
+  autoload :BalanceTransactionRetrieveParams, "stripe/params/balance_transaction_retrieve_params"
+  autoload :ChargeCaptureParams, "stripe/params/charge_capture_params"
+  autoload :ChargeCreateParams, "stripe/params/charge_create_params"
+  autoload :ChargeListParams, "stripe/params/charge_list_params"
+  autoload :ChargeRetrieveParams, "stripe/params/charge_retrieve_params"
+  autoload :ChargeSearchParams, "stripe/params/charge_search_params"
+  autoload :ChargeUpdateParams, "stripe/params/charge_update_params"
+  autoload :ConfirmationTokenCreateParams, "stripe/params/confirmation_token_create_params"
+  autoload :ConfirmationTokenRetrieveParams, "stripe/params/confirmation_token_retrieve_params"
+  autoload :CountrySpecListParams, "stripe/params/country_spec_list_params"
+  autoload :CountrySpecRetrieveParams, "stripe/params/country_spec_retrieve_params"
+  autoload :CouponCreateParams, "stripe/params/coupon_create_params"
+  autoload :CouponDeleteParams, "stripe/params/coupon_delete_params"
+  autoload :CouponListParams, "stripe/params/coupon_list_params"
+  autoload :CouponRetrieveParams, "stripe/params/coupon_retrieve_params"
+  autoload :CouponUpdateParams, "stripe/params/coupon_update_params"
+  autoload :CreditNoteCreateParams, "stripe/params/credit_note_create_params"
+  autoload :CreditNoteLineItemListParams, "stripe/params/credit_note_line_item_list_params"
+  autoload :CreditNoteListParams, "stripe/params/credit_note_list_params"
+  autoload :CreditNoteListPreviewLineItemsParams, "stripe/params/credit_note_list_preview_line_items_params"
+  autoload :CreditNotePreviewLinesListParams, "stripe/params/credit_note_preview_lines_list_params"
+  autoload :CreditNotePreviewParams, "stripe/params/credit_note_preview_params"
+  autoload :CreditNoteRetrieveParams, "stripe/params/credit_note_retrieve_params"
+  autoload :CreditNoteUpdateParams, "stripe/params/credit_note_update_params"
+  autoload :CreditNoteVoidCreditNoteParams, "stripe/params/credit_note_void_credit_note_params"
+  autoload :CustomerBalanceTransactionCreateParams, "stripe/params/customer_balance_transaction_create_params"
+  autoload :CustomerBalanceTransactionListParams, "stripe/params/customer_balance_transaction_list_params"
+  autoload :CustomerBalanceTransactionRetrieveParams, "stripe/params/customer_balance_transaction_retrieve_params"
+  autoload :CustomerBalanceTransactionUpdateParams, "stripe/params/customer_balance_transaction_update_params"
+  autoload :CustomerCashBalanceRetrieveParams, "stripe/params/customer_cash_balance_retrieve_params"
+  autoload :CustomerCashBalanceTransactionListParams, "stripe/params/customer_cash_balance_transaction_list_params"
+  autoload :CustomerCashBalanceTransactionRetrieveParams, "stripe/params/customer_cash_balance_transaction_retrieve_params"
+  autoload :CustomerCashBalanceUpdateParams, "stripe/params/customer_cash_balance_update_params"
+  autoload :CustomerCreateFundingInstructionsParams, "stripe/params/customer_create_funding_instructions_params"
+  autoload :CustomerCreateParams, "stripe/params/customer_create_params"
+  autoload :CustomerDeleteDiscountParams, "stripe/params/customer_delete_discount_params"
+  autoload :CustomerDeleteParams, "stripe/params/customer_delete_params"
+  autoload :CustomerFundCashBalanceParams, "stripe/params/customer_fund_cash_balance_params"
+  autoload :CustomerFundingInstructionsCreateParams, "stripe/params/customer_funding_instructions_create_params"
+  autoload :CustomerListParams, "stripe/params/customer_list_params"
+  autoload :CustomerListPaymentMethodsParams, "stripe/params/customer_list_payment_methods_params"
+  autoload :CustomerPaymentMethodListParams, "stripe/params/customer_payment_method_list_params"
+  autoload :CustomerPaymentMethodRetrieveParams, "stripe/params/customer_payment_method_retrieve_params"
+  autoload :CustomerPaymentSourceCreateParams, "stripe/params/customer_payment_source_create_params"
+  autoload :CustomerPaymentSourceDeleteParams, "stripe/params/customer_payment_source_delete_params"
+  autoload :CustomerPaymentSourceListParams, "stripe/params/customer_payment_source_list_params"
+  autoload :CustomerPaymentSourceRetrieveParams, "stripe/params/customer_payment_source_retrieve_params"
+  autoload :CustomerPaymentSourceUpdateParams, "stripe/params/customer_payment_source_update_params"
+  autoload :CustomerPaymentSourceVerifyParams, "stripe/params/customer_payment_source_verify_params"
+  autoload :CustomerRetrieveParams, "stripe/params/customer_retrieve_params"
+  autoload :CustomerRetrievePaymentMethodParams, "stripe/params/customer_retrieve_payment_method_params"
+  autoload :CustomerSearchParams, "stripe/params/customer_search_params"
+  autoload :CustomerSessionCreateParams, "stripe/params/customer_session_create_params"
+  autoload :CustomerTaxIdCreateParams, "stripe/params/customer_tax_id_create_params"
+  autoload :CustomerTaxIdDeleteParams, "stripe/params/customer_tax_id_delete_params"
+  autoload :CustomerTaxIdListParams, "stripe/params/customer_tax_id_list_params"
+  autoload :CustomerTaxIdRetrieveParams, "stripe/params/customer_tax_id_retrieve_params"
+  autoload :CustomerUpdateParams, "stripe/params/customer_update_params"
+  autoload :DisputeCloseParams, "stripe/params/dispute_close_params"
+  autoload :DisputeListParams, "stripe/params/dispute_list_params"
+  autoload :DisputeRetrieveParams, "stripe/params/dispute_retrieve_params"
+  autoload :DisputeUpdateParams, "stripe/params/dispute_update_params"
+  autoload :EphemeralKeyCreateParams, "stripe/params/ephemeral_key_create_params"
+  autoload :EphemeralKeyDeleteParams, "stripe/params/ephemeral_key_delete_params"
+  autoload :EventListParams, "stripe/params/event_list_params"
+  autoload :EventRetrieveParams, "stripe/params/event_retrieve_params"
+  autoload :ExchangeRateListParams, "stripe/params/exchange_rate_list_params"
+  autoload :ExchangeRateRetrieveParams, "stripe/params/exchange_rate_retrieve_params"
+  autoload :FileCreateParams, "stripe/params/file_create_params"
+  autoload :FileLinkCreateParams, "stripe/params/file_link_create_params"
+  autoload :FileLinkListParams, "stripe/params/file_link_list_params"
+  autoload :FileLinkRetrieveParams, "stripe/params/file_link_retrieve_params"
+  autoload :FileLinkUpdateParams, "stripe/params/file_link_update_params"
+  autoload :FileListParams, "stripe/params/file_list_params"
+  autoload :FileRetrieveParams, "stripe/params/file_retrieve_params"
+  autoload :InvoiceAddLinesParams, "stripe/params/invoice_add_lines_params"
+  autoload :InvoiceAttachPaymentParams, "stripe/params/invoice_attach_payment_params"
+  autoload :InvoiceCreateParams, "stripe/params/invoice_create_params"
+  autoload :InvoiceCreatePreviewParams, "stripe/params/invoice_create_preview_params"
+  autoload :InvoiceDeleteParams, "stripe/params/invoice_delete_params"
+  autoload :InvoiceFinalizeInvoiceParams, "stripe/params/invoice_finalize_invoice_params"
+  autoload :InvoiceItemCreateParams, "stripe/params/invoice_item_create_params"
+  autoload :InvoiceItemDeleteParams, "stripe/params/invoice_item_delete_params"
+  autoload :InvoiceItemListParams, "stripe/params/invoice_item_list_params"
+  autoload :InvoiceItemRetrieveParams, "stripe/params/invoice_item_retrieve_params"
+  autoload :InvoiceItemUpdateParams, "stripe/params/invoice_item_update_params"
+  autoload :InvoiceLineItemListParams, "stripe/params/invoice_line_item_list_params"
+  autoload :InvoiceLineItemUpdateParams, "stripe/params/invoice_line_item_update_params"
+  autoload :InvoiceListParams, "stripe/params/invoice_list_params"
+  autoload :InvoiceMarkUncollectibleParams, "stripe/params/invoice_mark_uncollectible_params"
+  autoload :InvoicePayParams, "stripe/params/invoice_pay_params"
+  autoload :InvoicePaymentListParams, "stripe/params/invoice_payment_list_params"
+  autoload :InvoicePaymentRetrieveParams, "stripe/params/invoice_payment_retrieve_params"
+  autoload :InvoiceRemoveLinesParams, "stripe/params/invoice_remove_lines_params"
+  autoload :InvoiceRenderingTemplateArchiveParams, "stripe/params/invoice_rendering_template_archive_params"
+  autoload :InvoiceRenderingTemplateListParams, "stripe/params/invoice_rendering_template_list_params"
+  autoload :InvoiceRenderingTemplateRetrieveParams, "stripe/params/invoice_rendering_template_retrieve_params"
+  autoload :InvoiceRenderingTemplateUnarchiveParams, "stripe/params/invoice_rendering_template_unarchive_params"
+  autoload :InvoiceRetrieveParams, "stripe/params/invoice_retrieve_params"
+  autoload :InvoiceSearchParams, "stripe/params/invoice_search_params"
+  autoload :InvoiceSendInvoiceParams, "stripe/params/invoice_send_invoice_params"
+  autoload :InvoiceUpdateLinesParams, "stripe/params/invoice_update_lines_params"
+  autoload :InvoiceUpdateParams, "stripe/params/invoice_update_params"
+  autoload :InvoiceVoidInvoiceParams, "stripe/params/invoice_void_invoice_params"
+  autoload :MandateRetrieveParams, "stripe/params/mandate_retrieve_params"
+  autoload :PaymentAttemptRecordListParams, "stripe/params/payment_attempt_record_list_params"
+  autoload :PaymentAttemptRecordRetrieveParams, "stripe/params/payment_attempt_record_retrieve_params"
+  autoload :PaymentIntentAmountDetailsLineItemListParams, "stripe/params/payment_intent_amount_details_line_item_list_params"
+  autoload :PaymentIntentApplyCustomerBalanceParams, "stripe/params/payment_intent_apply_customer_balance_params"
+  autoload :PaymentIntentCancelParams, "stripe/params/payment_intent_cancel_params"
+  autoload :PaymentIntentCaptureParams, "stripe/params/payment_intent_capture_params"
+  autoload :PaymentIntentConfirmParams, "stripe/params/payment_intent_confirm_params"
+  autoload :PaymentIntentCreateParams, "stripe/params/payment_intent_create_params"
+  autoload :PaymentIntentIncrementAuthorizationParams, "stripe/params/payment_intent_increment_authorization_params"
+  autoload :PaymentIntentListParams, "stripe/params/payment_intent_list_params"
+  autoload :PaymentIntentRetrieveParams, "stripe/params/payment_intent_retrieve_params"
+  autoload :PaymentIntentSearchParams, "stripe/params/payment_intent_search_params"
+  autoload :PaymentIntentUpdateParams, "stripe/params/payment_intent_update_params"
+  autoload :PaymentIntentVerifyMicrodepositsParams, "stripe/params/payment_intent_verify_microdeposits_params"
+  autoload :PaymentLinkCreateParams, "stripe/params/payment_link_create_params"
+  autoload :PaymentLinkLineItemListParams, "stripe/params/payment_link_line_item_list_params"
+  autoload :PaymentLinkListLineItemsParams, "stripe/params/payment_link_list_line_items_params"
+  autoload :PaymentLinkListParams, "stripe/params/payment_link_list_params"
+  autoload :PaymentLinkRetrieveParams, "stripe/params/payment_link_retrieve_params"
+  autoload :PaymentLinkUpdateParams, "stripe/params/payment_link_update_params"
+  autoload :PaymentMethodAttachParams, "stripe/params/payment_method_attach_params"
+  autoload :PaymentMethodConfigurationCreateParams, "stripe/params/payment_method_configuration_create_params"
+  autoload :PaymentMethodConfigurationListParams, "stripe/params/payment_method_configuration_list_params"
+  autoload :PaymentMethodConfigurationRetrieveParams, "stripe/params/payment_method_configuration_retrieve_params"
+  autoload :PaymentMethodConfigurationUpdateParams, "stripe/params/payment_method_configuration_update_params"
+  autoload :PaymentMethodCreateParams, "stripe/params/payment_method_create_params"
+  autoload :PaymentMethodDetachParams, "stripe/params/payment_method_detach_params"
+  autoload :PaymentMethodDomainCreateParams, "stripe/params/payment_method_domain_create_params"
+  autoload :PaymentMethodDomainListParams, "stripe/params/payment_method_domain_list_params"
+  autoload :PaymentMethodDomainRetrieveParams, "stripe/params/payment_method_domain_retrieve_params"
+  autoload :PaymentMethodDomainUpdateParams, "stripe/params/payment_method_domain_update_params"
+  autoload :PaymentMethodDomainValidateParams, "stripe/params/payment_method_domain_validate_params"
+  autoload :PaymentMethodListParams, "stripe/params/payment_method_list_params"
+  autoload :PaymentMethodRetrieveParams, "stripe/params/payment_method_retrieve_params"
+  autoload :PaymentMethodUpdateParams, "stripe/params/payment_method_update_params"
+  autoload :PaymentRecordReportPaymentAttemptCanceledParams, "stripe/params/payment_record_report_payment_attempt_canceled_params"
+  autoload :PaymentRecordReportPaymentAttemptFailedParams, "stripe/params/payment_record_report_payment_attempt_failed_params"
+  autoload :PaymentRecordReportPaymentAttemptGuaranteedParams, "stripe/params/payment_record_report_payment_attempt_guaranteed_params"
+  autoload :PaymentRecordReportPaymentAttemptInformationalParams, "stripe/params/payment_record_report_payment_attempt_informational_params"
+  autoload :PaymentRecordReportPaymentAttemptParams, "stripe/params/payment_record_report_payment_attempt_params"
+  autoload :PaymentRecordReportPaymentParams, "stripe/params/payment_record_report_payment_params"
+  autoload :PaymentRecordReportRefundParams, "stripe/params/payment_record_report_refund_params"
+  autoload :PaymentRecordRetrieveParams, "stripe/params/payment_record_retrieve_params"
+  autoload :PayoutCancelParams, "stripe/params/payout_cancel_params"
+  autoload :PayoutCreateParams, "stripe/params/payout_create_params"
+  autoload :PayoutListParams, "stripe/params/payout_list_params"
+  autoload :PayoutRetrieveParams, "stripe/params/payout_retrieve_params"
+  autoload :PayoutReverseParams, "stripe/params/payout_reverse_params"
+  autoload :PayoutUpdateParams, "stripe/params/payout_update_params"
+  autoload :PlanCreateParams, "stripe/params/plan_create_params"
+  autoload :PlanDeleteParams, "stripe/params/plan_delete_params"
+  autoload :PlanListParams, "stripe/params/plan_list_params"
+  autoload :PlanRetrieveParams, "stripe/params/plan_retrieve_params"
+  autoload :PlanUpdateParams, "stripe/params/plan_update_params"
+  autoload :PriceCreateParams, "stripe/params/price_create_params"
+  autoload :PriceListParams, "stripe/params/price_list_params"
+  autoload :PriceRetrieveParams, "stripe/params/price_retrieve_params"
+  autoload :PriceSearchParams, "stripe/params/price_search_params"
+  autoload :PriceUpdateParams, "stripe/params/price_update_params"
+  autoload :ProductCreateParams, "stripe/params/product_create_params"
+  autoload :ProductDeleteParams, "stripe/params/product_delete_params"
+  autoload :ProductFeatureCreateParams, "stripe/params/product_feature_create_params"
+  autoload :ProductFeatureDeleteParams, "stripe/params/product_feature_delete_params"
+  autoload :ProductFeatureListParams, "stripe/params/product_feature_list_params"
+  autoload :ProductFeatureRetrieveParams, "stripe/params/product_feature_retrieve_params"
+  autoload :ProductListParams, "stripe/params/product_list_params"
+  autoload :ProductRetrieveParams, "stripe/params/product_retrieve_params"
+  autoload :ProductSearchParams, "stripe/params/product_search_params"
+  autoload :ProductUpdateParams, "stripe/params/product_update_params"
+  autoload :PromotionCodeCreateParams, "stripe/params/promotion_code_create_params"
+  autoload :PromotionCodeListParams, "stripe/params/promotion_code_list_params"
+  autoload :PromotionCodeRetrieveParams, "stripe/params/promotion_code_retrieve_params"
+  autoload :PromotionCodeUpdateParams, "stripe/params/promotion_code_update_params"
+  autoload :QuoteAcceptParams, "stripe/params/quote_accept_params"
+  autoload :QuoteCancelParams, "stripe/params/quote_cancel_params"
+  autoload :QuoteComputedUpfrontLineItemsListParams, "stripe/params/quote_computed_upfront_line_items_list_params"
+  autoload :QuoteCreateParams, "stripe/params/quote_create_params"
+  autoload :QuoteFinalizeQuoteParams, "stripe/params/quote_finalize_quote_params"
+  autoload :QuoteLineItemListParams, "stripe/params/quote_line_item_list_params"
+  autoload :QuoteListComputedUpfrontLineItemsParams, "stripe/params/quote_list_computed_upfront_line_items_params"
+  autoload :QuoteListLineItemsParams, "stripe/params/quote_list_line_items_params"
+  autoload :QuoteListParams, "stripe/params/quote_list_params"
+  autoload :QuotePdfParams, "stripe/params/quote_pdf_params"
+  autoload :QuoteRetrieveParams, "stripe/params/quote_retrieve_params"
+  autoload :QuoteUpdateParams, "stripe/params/quote_update_params"
+  autoload :RefundCancelParams, "stripe/params/refund_cancel_params"
+  autoload :RefundCreateParams, "stripe/params/refund_create_params"
+  autoload :RefundExpireParams, "stripe/params/refund_expire_params"
+  autoload :RefundListParams, "stripe/params/refund_list_params"
+  autoload :RefundRetrieveParams, "stripe/params/refund_retrieve_params"
+  autoload :RefundUpdateParams, "stripe/params/refund_update_params"
+  autoload :ReviewApproveParams, "stripe/params/review_approve_params"
+  autoload :ReviewListParams, "stripe/params/review_list_params"
+  autoload :ReviewRetrieveParams, "stripe/params/review_retrieve_params"
+  autoload :SetupAttemptListParams, "stripe/params/setup_attempt_list_params"
+  autoload :SetupIntentCancelParams, "stripe/params/setup_intent_cancel_params"
+  autoload :SetupIntentConfirmParams, "stripe/params/setup_intent_confirm_params"
+  autoload :SetupIntentCreateParams, "stripe/params/setup_intent_create_params"
+  autoload :SetupIntentListParams, "stripe/params/setup_intent_list_params"
+  autoload :SetupIntentRetrieveParams, "stripe/params/setup_intent_retrieve_params"
+  autoload :SetupIntentUpdateParams, "stripe/params/setup_intent_update_params"
+  autoload :SetupIntentVerifyMicrodepositsParams, "stripe/params/setup_intent_verify_microdeposits_params"
+  autoload :ShippingRateCreateParams, "stripe/params/shipping_rate_create_params"
+  autoload :ShippingRateListParams, "stripe/params/shipping_rate_list_params"
+  autoload :ShippingRateRetrieveParams, "stripe/params/shipping_rate_retrieve_params"
+  autoload :ShippingRateUpdateParams, "stripe/params/shipping_rate_update_params"
+  autoload :SourceCreateParams, "stripe/params/source_create_params"
+  autoload :SourceDetachParams, "stripe/params/source_detach_params"
+  autoload :SourceRetrieveParams, "stripe/params/source_retrieve_params"
+  autoload :SourceTransactionListParams, "stripe/params/source_transaction_list_params"
+  autoload :SourceUpdateParams, "stripe/params/source_update_params"
+  autoload :SourceVerifyParams, "stripe/params/source_verify_params"
+  autoload :SubscriptionCancelParams, "stripe/params/subscription_cancel_params"
+  autoload :SubscriptionCreateParams, "stripe/params/subscription_create_params"
+  autoload :SubscriptionDeleteDiscountParams, "stripe/params/subscription_delete_discount_params"
+  autoload :SubscriptionItemCreateParams, "stripe/params/subscription_item_create_params"
+  autoload :SubscriptionItemDeleteParams, "stripe/params/subscription_item_delete_params"
+  autoload :SubscriptionItemListParams, "stripe/params/subscription_item_list_params"
+  autoload :SubscriptionItemRetrieveParams, "stripe/params/subscription_item_retrieve_params"
+  autoload :SubscriptionItemUpdateParams, "stripe/params/subscription_item_update_params"
+  autoload :SubscriptionListParams, "stripe/params/subscription_list_params"
+  autoload :SubscriptionMigrateParams, "stripe/params/subscription_migrate_params"
+  autoload :SubscriptionResumeParams, "stripe/params/subscription_resume_params"
+  autoload :SubscriptionRetrieveParams, "stripe/params/subscription_retrieve_params"
+  autoload :SubscriptionScheduleCancelParams, "stripe/params/subscription_schedule_cancel_params"
+  autoload :SubscriptionScheduleCreateParams, "stripe/params/subscription_schedule_create_params"
+  autoload :SubscriptionScheduleListParams, "stripe/params/subscription_schedule_list_params"
+  autoload :SubscriptionScheduleReleaseParams, "stripe/params/subscription_schedule_release_params"
+  autoload :SubscriptionScheduleRetrieveParams, "stripe/params/subscription_schedule_retrieve_params"
+  autoload :SubscriptionScheduleUpdateParams, "stripe/params/subscription_schedule_update_params"
+  autoload :SubscriptionSearchParams, "stripe/params/subscription_search_params"
+  autoload :SubscriptionUpdateParams, "stripe/params/subscription_update_params"
+  autoload :TaxCodeListParams, "stripe/params/tax_code_list_params"
+  autoload :TaxCodeRetrieveParams, "stripe/params/tax_code_retrieve_params"
+  autoload :TaxIdCreateParams, "stripe/params/tax_id_create_params"
+  autoload :TaxIdDeleteParams, "stripe/params/tax_id_delete_params"
+  autoload :TaxIdListParams, "stripe/params/tax_id_list_params"
+  autoload :TaxIdRetrieveParams, "stripe/params/tax_id_retrieve_params"
+  autoload :TaxRateCreateParams, "stripe/params/tax_rate_create_params"
+  autoload :TaxRateListParams, "stripe/params/tax_rate_list_params"
+  autoload :TaxRateRetrieveParams, "stripe/params/tax_rate_retrieve_params"
+  autoload :TaxRateUpdateParams, "stripe/params/tax_rate_update_params"
+  autoload :TokenCreateParams, "stripe/params/token_create_params"
+  autoload :TokenRetrieveParams, "stripe/params/token_retrieve_params"
+  autoload :TopupCancelParams, "stripe/params/topup_cancel_params"
+  autoload :TopupCreateParams, "stripe/params/topup_create_params"
+  autoload :TopupListParams, "stripe/params/topup_list_params"
+  autoload :TopupRetrieveParams, "stripe/params/topup_retrieve_params"
+  autoload :TopupUpdateParams, "stripe/params/topup_update_params"
+  autoload :TransferCreateParams, "stripe/params/transfer_create_params"
+  autoload :TransferListParams, "stripe/params/transfer_list_params"
+  autoload :TransferRetrieveParams, "stripe/params/transfer_retrieve_params"
+  autoload :TransferReversalCreateParams, "stripe/params/transfer_reversal_create_params"
+  autoload :TransferReversalListParams, "stripe/params/transfer_reversal_list_params"
+  autoload :TransferReversalRetrieveParams, "stripe/params/transfer_reversal_retrieve_params"
+  autoload :TransferReversalUpdateParams, "stripe/params/transfer_reversal_update_params"
+  autoload :TransferUpdateParams, "stripe/params/transfer_update_params"
+  autoload :WebhookEndpointCreateParams, "stripe/params/webhook_endpoint_create_params"
+  autoload :WebhookEndpointDeleteParams, "stripe/params/webhook_endpoint_delete_params"
+  autoload :WebhookEndpointListParams, "stripe/params/webhook_endpoint_list_params"
+  autoload :WebhookEndpointRetrieveParams, "stripe/params/webhook_endpoint_retrieve_params"
+  autoload :WebhookEndpointUpdateParams, "stripe/params/webhook_endpoint_update_params"
+
+  module Apps
+    autoload :SecretCreateParams, "stripe/params/apps/secret_create_params"
+    autoload :SecretDeleteWhereParams, "stripe/params/apps/secret_delete_where_params"
+    autoload :SecretFindParams, "stripe/params/apps/secret_find_params"
+    autoload :SecretListParams, "stripe/params/apps/secret_list_params"
+  end
+
+  module Billing
+    autoload :AlertActivateParams, "stripe/params/billing/alert_activate_params"
+    autoload :AlertArchiveParams, "stripe/params/billing/alert_archive_params"
+    autoload :AlertCreateParams, "stripe/params/billing/alert_create_params"
+    autoload :AlertDeactivateParams, "stripe/params/billing/alert_deactivate_params"
+    autoload :AlertListParams, "stripe/params/billing/alert_list_params"
+    autoload :AlertRetrieveParams, "stripe/params/billing/alert_retrieve_params"
+    autoload :CreditBalanceSummaryRetrieveParams, "stripe/params/billing/credit_balance_summary_retrieve_params"
+    autoload :CreditBalanceTransactionListParams, "stripe/params/billing/credit_balance_transaction_list_params"
+    autoload :CreditBalanceTransactionRetrieveParams, "stripe/params/billing/credit_balance_transaction_retrieve_params"
+    autoload :CreditGrantCreateParams, "stripe/params/billing/credit_grant_create_params"
+    autoload :CreditGrantExpireParams, "stripe/params/billing/credit_grant_expire_params"
+    autoload :CreditGrantListParams, "stripe/params/billing/credit_grant_list_params"
+    autoload :CreditGrantRetrieveParams, "stripe/params/billing/credit_grant_retrieve_params"
+    autoload :CreditGrantUpdateParams, "stripe/params/billing/credit_grant_update_params"
+    autoload :CreditGrantVoidGrantParams, "stripe/params/billing/credit_grant_void_grant_params"
+    autoload :MeterCreateParams, "stripe/params/billing/meter_create_params"
+    autoload :MeterDeactivateParams, "stripe/params/billing/meter_deactivate_params"
+    autoload :MeterEventAdjustmentCreateParams, "stripe/params/billing/meter_event_adjustment_create_params"
+    autoload :MeterEventCreateParams, "stripe/params/billing/meter_event_create_params"
+    autoload :MeterEventSummaryListParams, "stripe/params/billing/meter_event_summary_list_params"
+    autoload :MeterListParams, "stripe/params/billing/meter_list_params"
+    autoload :MeterReactivateParams, "stripe/params/billing/meter_reactivate_params"
+    autoload :MeterRetrieveParams, "stripe/params/billing/meter_retrieve_params"
+    autoload :MeterUpdateParams, "stripe/params/billing/meter_update_params"
+  end
+
+  module BillingPortal
+    autoload :ConfigurationCreateParams, "stripe/params/billing_portal/configuration_create_params"
+    autoload :ConfigurationListParams, "stripe/params/billing_portal/configuration_list_params"
+    autoload :ConfigurationRetrieveParams, "stripe/params/billing_portal/configuration_retrieve_params"
+    autoload :ConfigurationUpdateParams, "stripe/params/billing_portal/configuration_update_params"
+    autoload :SessionCreateParams, "stripe/params/billing_portal/session_create_params"
+  end
+
+  module Checkout
+    autoload :SessionCreateParams, "stripe/params/checkout/session_create_params"
+    autoload :SessionExpireParams, "stripe/params/checkout/session_expire_params"
+    autoload :SessionLineItemListParams, "stripe/params/checkout/session_line_item_list_params"
+    autoload :SessionListLineItemsParams, "stripe/params/checkout/session_list_line_items_params"
+    autoload :SessionListParams, "stripe/params/checkout/session_list_params"
+    autoload :SessionRetrieveParams, "stripe/params/checkout/session_retrieve_params"
+    autoload :SessionUpdateParams, "stripe/params/checkout/session_update_params"
+  end
+
+  module Climate
+    autoload :OrderCancelParams, "stripe/params/climate/order_cancel_params"
+    autoload :OrderCreateParams, "stripe/params/climate/order_create_params"
+    autoload :OrderListParams, "stripe/params/climate/order_list_params"
+    autoload :OrderRetrieveParams, "stripe/params/climate/order_retrieve_params"
+    autoload :OrderUpdateParams, "stripe/params/climate/order_update_params"
+    autoload :ProductListParams, "stripe/params/climate/product_list_params"
+    autoload :ProductRetrieveParams, "stripe/params/climate/product_retrieve_params"
+    autoload :SupplierListParams, "stripe/params/climate/supplier_list_params"
+    autoload :SupplierRetrieveParams, "stripe/params/climate/supplier_retrieve_params"
+  end
+
+  module Entitlements
+    autoload :ActiveEntitlementListParams, "stripe/params/entitlements/active_entitlement_list_params"
+    autoload :ActiveEntitlementRetrieveParams, "stripe/params/entitlements/active_entitlement_retrieve_params"
+    autoload :FeatureCreateParams, "stripe/params/entitlements/feature_create_params"
+    autoload :FeatureListParams, "stripe/params/entitlements/feature_list_params"
+    autoload :FeatureRetrieveParams, "stripe/params/entitlements/feature_retrieve_params"
+    autoload :FeatureUpdateParams, "stripe/params/entitlements/feature_update_params"
+  end
+
+  module FinancialConnections
+    autoload :AccountDisconnectParams, "stripe/params/financial_connections/account_disconnect_params"
+    autoload :AccountListOwnersParams, "stripe/params/financial_connections/account_list_owners_params"
+    autoload :AccountListParams, "stripe/params/financial_connections/account_list_params"
+    autoload :AccountOwnerListParams, "stripe/params/financial_connections/account_owner_list_params"
+    autoload :AccountRefreshAccountParams, "stripe/params/financial_connections/account_refresh_account_params"
+    autoload :AccountRefreshParams, "stripe/params/financial_connections/account_refresh_params"
+    autoload :AccountRetrieveParams, "stripe/params/financial_connections/account_retrieve_params"
+    autoload :AccountSubscribeParams, "stripe/params/financial_connections/account_subscribe_params"
+    autoload :AccountUnsubscribeParams, "stripe/params/financial_connections/account_unsubscribe_params"
+    autoload :SessionCreateParams, "stripe/params/financial_connections/session_create_params"
+    autoload :SessionRetrieveParams, "stripe/params/financial_connections/session_retrieve_params"
+    autoload :TransactionListParams, "stripe/params/financial_connections/transaction_list_params"
+    autoload :TransactionRetrieveParams, "stripe/params/financial_connections/transaction_retrieve_params"
+  end
+
+  module Forwarding
+    autoload :RequestCreateParams, "stripe/params/forwarding/request_create_params"
+    autoload :RequestListParams, "stripe/params/forwarding/request_list_params"
+    autoload :RequestRetrieveParams, "stripe/params/forwarding/request_retrieve_params"
+  end
+
+  module Identity
+    autoload :VerificationReportListParams, "stripe/params/identity/verification_report_list_params"
+    autoload :VerificationReportRetrieveParams, "stripe/params/identity/verification_report_retrieve_params"
+    autoload :VerificationSessionCancelParams, "stripe/params/identity/verification_session_cancel_params"
+    autoload :VerificationSessionCreateParams, "stripe/params/identity/verification_session_create_params"
+    autoload :VerificationSessionListParams, "stripe/params/identity/verification_session_list_params"
+    autoload :VerificationSessionRedactParams, "stripe/params/identity/verification_session_redact_params"
+    autoload :VerificationSessionRetrieveParams, "stripe/params/identity/verification_session_retrieve_params"
+    autoload :VerificationSessionUpdateParams, "stripe/params/identity/verification_session_update_params"
+  end
+
+  module Issuing
+    autoload :AuthorizationApproveParams, "stripe/params/issuing/authorization_approve_params"
+    autoload :AuthorizationCaptureParams, "stripe/params/issuing/authorization_capture_params"
+    autoload :AuthorizationCreateParams, "stripe/params/issuing/authorization_create_params"
+    autoload :AuthorizationDeclineParams, "stripe/params/issuing/authorization_decline_params"
+    autoload :AuthorizationExpireParams, "stripe/params/issuing/authorization_expire_params"
+    autoload :AuthorizationFinalizeAmountParams, "stripe/params/issuing/authorization_finalize_amount_params"
+    autoload :AuthorizationIncrementParams, "stripe/params/issuing/authorization_increment_params"
+    autoload :AuthorizationListParams, "stripe/params/issuing/authorization_list_params"
+    autoload :AuthorizationRespondParams, "stripe/params/issuing/authorization_respond_params"
+    autoload :AuthorizationRetrieveParams, "stripe/params/issuing/authorization_retrieve_params"
+    autoload :AuthorizationReverseParams, "stripe/params/issuing/authorization_reverse_params"
+    autoload :AuthorizationUpdateParams, "stripe/params/issuing/authorization_update_params"
+    autoload :CardCreateParams, "stripe/params/issuing/card_create_params"
+    autoload :CardDeliverCardParams, "stripe/params/issuing/card_deliver_card_params"
+    autoload :CardFailCardParams, "stripe/params/issuing/card_fail_card_params"
+    autoload :CardListParams, "stripe/params/issuing/card_list_params"
+    autoload :CardRetrieveParams, "stripe/params/issuing/card_retrieve_params"
+    autoload :CardReturnCardParams, "stripe/params/issuing/card_return_card_params"
+    autoload :CardShipCardParams, "stripe/params/issuing/card_ship_card_params"
+    autoload :CardSubmitCardParams, "stripe/params/issuing/card_submit_card_params"
+    autoload :CardUpdateParams, "stripe/params/issuing/card_update_params"
+    autoload :CardholderCreateParams, "stripe/params/issuing/cardholder_create_params"
+    autoload :CardholderListParams, "stripe/params/issuing/cardholder_list_params"
+    autoload :CardholderRetrieveParams, "stripe/params/issuing/cardholder_retrieve_params"
+    autoload :CardholderUpdateParams, "stripe/params/issuing/cardholder_update_params"
+    autoload :DisputeCreateParams, "stripe/params/issuing/dispute_create_params"
+    autoload :DisputeListParams, "stripe/params/issuing/dispute_list_params"
+    autoload :DisputeRetrieveParams, "stripe/params/issuing/dispute_retrieve_params"
+    autoload :DisputeSubmitParams, "stripe/params/issuing/dispute_submit_params"
+    autoload :DisputeUpdateParams, "stripe/params/issuing/dispute_update_params"
+    autoload :PersonalizationDesignActivateParams, "stripe/params/issuing/personalization_design_activate_params"
+    autoload :PersonalizationDesignCreateParams, "stripe/params/issuing/personalization_design_create_params"
+    autoload :PersonalizationDesignDeactivateParams, "stripe/params/issuing/personalization_design_deactivate_params"
+    autoload :PersonalizationDesignListParams, "stripe/params/issuing/personalization_design_list_params"
+    autoload :PersonalizationDesignRejectParams, "stripe/params/issuing/personalization_design_reject_params"
+    autoload :PersonalizationDesignRetrieveParams, "stripe/params/issuing/personalization_design_retrieve_params"
+    autoload :PersonalizationDesignUpdateParams, "stripe/params/issuing/personalization_design_update_params"
+    autoload :PhysicalBundleListParams, "stripe/params/issuing/physical_bundle_list_params"
+    autoload :PhysicalBundleRetrieveParams, "stripe/params/issuing/physical_bundle_retrieve_params"
+    autoload :TokenListParams, "stripe/params/issuing/token_list_params"
+    autoload :TokenRetrieveParams, "stripe/params/issuing/token_retrieve_params"
+    autoload :TokenUpdateParams, "stripe/params/issuing/token_update_params"
+    autoload :TransactionCreateForceCaptureParams, "stripe/params/issuing/transaction_create_force_capture_params"
+    autoload :TransactionCreateUnlinkedRefundParams, "stripe/params/issuing/transaction_create_unlinked_refund_params"
+    autoload :TransactionListParams, "stripe/params/issuing/transaction_list_params"
+    autoload :TransactionRefundParams, "stripe/params/issuing/transaction_refund_params"
+    autoload :TransactionRetrieveParams, "stripe/params/issuing/transaction_retrieve_params"
+    autoload :TransactionUpdateParams, "stripe/params/issuing/transaction_update_params"
+  end
+
+  module Radar
+    autoload :EarlyFraudWarningListParams, "stripe/params/radar/early_fraud_warning_list_params"
+    autoload :EarlyFraudWarningRetrieveParams, "stripe/params/radar/early_fraud_warning_retrieve_params"
+    autoload :PaymentEvaluationCreateParams, "stripe/params/radar/payment_evaluation_create_params"
+    autoload :ValueListCreateParams, "stripe/params/radar/value_list_create_params"
+    autoload :ValueListDeleteParams, "stripe/params/radar/value_list_delete_params"
+    autoload :ValueListItemCreateParams, "stripe/params/radar/value_list_item_create_params"
+    autoload :ValueListItemDeleteParams, "stripe/params/radar/value_list_item_delete_params"
+    autoload :ValueListItemListParams, "stripe/params/radar/value_list_item_list_params"
+    autoload :ValueListItemRetrieveParams, "stripe/params/radar/value_list_item_retrieve_params"
+    autoload :ValueListListParams, "stripe/params/radar/value_list_list_params"
+    autoload :ValueListRetrieveParams, "stripe/params/radar/value_list_retrieve_params"
+    autoload :ValueListUpdateParams, "stripe/params/radar/value_list_update_params"
+  end
+
+  module Reporting
+    autoload :ReportRunCreateParams, "stripe/params/reporting/report_run_create_params"
+    autoload :ReportRunListParams, "stripe/params/reporting/report_run_list_params"
+    autoload :ReportRunRetrieveParams, "stripe/params/reporting/report_run_retrieve_params"
+    autoload :ReportTypeListParams, "stripe/params/reporting/report_type_list_params"
+    autoload :ReportTypeRetrieveParams, "stripe/params/reporting/report_type_retrieve_params"
+  end
+
+  module Sigma
+    autoload :ScheduledQueryRunListParams, "stripe/params/sigma/scheduled_query_run_list_params"
+    autoload :ScheduledQueryRunRetrieveParams, "stripe/params/sigma/scheduled_query_run_retrieve_params"
+  end
+
+  module Tax
+    autoload :AssociationFindParams, "stripe/params/tax/association_find_params"
+    autoload :CalculationCreateParams, "stripe/params/tax/calculation_create_params"
+    autoload :CalculationLineItemListParams, "stripe/params/tax/calculation_line_item_list_params"
+    autoload :CalculationListLineItemsParams, "stripe/params/tax/calculation_list_line_items_params"
+    autoload :CalculationRetrieveParams, "stripe/params/tax/calculation_retrieve_params"
+    autoload :RegistrationCreateParams, "stripe/params/tax/registration_create_params"
+    autoload :RegistrationListParams, "stripe/params/tax/registration_list_params"
+    autoload :RegistrationRetrieveParams, "stripe/params/tax/registration_retrieve_params"
+    autoload :RegistrationUpdateParams, "stripe/params/tax/registration_update_params"
+    autoload :SettingsRetrieveParams, "stripe/params/tax/settings_retrieve_params"
+    autoload :SettingsUpdateParams, "stripe/params/tax/settings_update_params"
+    autoload :TransactionCreateFromCalculationParams, "stripe/params/tax/transaction_create_from_calculation_params"
+    autoload :TransactionCreateReversalParams, "stripe/params/tax/transaction_create_reversal_params"
+    autoload :TransactionLineItemListParams, "stripe/params/tax/transaction_line_item_list_params"
+    autoload :TransactionListLineItemsParams, "stripe/params/tax/transaction_list_line_items_params"
+    autoload :TransactionRetrieveParams, "stripe/params/tax/transaction_retrieve_params"
+  end
+
+  module Terminal
+    autoload :ConfigurationCreateParams, "stripe/params/terminal/configuration_create_params"
+    autoload :ConfigurationDeleteParams, "stripe/params/terminal/configuration_delete_params"
+    autoload :ConfigurationListParams, "stripe/params/terminal/configuration_list_params"
+    autoload :ConfigurationRetrieveParams, "stripe/params/terminal/configuration_retrieve_params"
+    autoload :ConfigurationUpdateParams, "stripe/params/terminal/configuration_update_params"
+    autoload :ConnectionTokenCreateParams, "stripe/params/terminal/connection_token_create_params"
+    autoload :LocationCreateParams, "stripe/params/terminal/location_create_params"
+    autoload :LocationDeleteParams, "stripe/params/terminal/location_delete_params"
+    autoload :LocationListParams, "stripe/params/terminal/location_list_params"
+    autoload :LocationRetrieveParams, "stripe/params/terminal/location_retrieve_params"
+    autoload :LocationUpdateParams, "stripe/params/terminal/location_update_params"
+    autoload :OnboardingLinkCreateParams, "stripe/params/terminal/onboarding_link_create_params"
+    autoload :ReaderCancelActionParams, "stripe/params/terminal/reader_cancel_action_params"
+    autoload :ReaderCollectInputsParams, "stripe/params/terminal/reader_collect_inputs_params"
+    autoload :ReaderCollectPaymentMethodParams, "stripe/params/terminal/reader_collect_payment_method_params"
+    autoload :ReaderConfirmPaymentIntentParams, "stripe/params/terminal/reader_confirm_payment_intent_params"
+    autoload :ReaderCreateParams, "stripe/params/terminal/reader_create_params"
+    autoload :ReaderDeleteParams, "stripe/params/terminal/reader_delete_params"
+    autoload :ReaderListParams, "stripe/params/terminal/reader_list_params"
+    autoload :ReaderPresentPaymentMethodParams, "stripe/params/terminal/reader_present_payment_method_params"
+    autoload :ReaderProcessPaymentIntentParams, "stripe/params/terminal/reader_process_payment_intent_params"
+    autoload :ReaderProcessSetupIntentParams, "stripe/params/terminal/reader_process_setup_intent_params"
+    autoload :ReaderRefundPaymentParams, "stripe/params/terminal/reader_refund_payment_params"
+    autoload :ReaderRetrieveParams, "stripe/params/terminal/reader_retrieve_params"
+    autoload :ReaderSetReaderDisplayParams, "stripe/params/terminal/reader_set_reader_display_params"
+    autoload :ReaderSucceedInputCollectionParams, "stripe/params/terminal/reader_succeed_input_collection_params"
+    autoload :ReaderTimeoutInputCollectionParams, "stripe/params/terminal/reader_timeout_input_collection_params"
+    autoload :ReaderUpdateParams, "stripe/params/terminal/reader_update_params"
+  end
+
+  module TestHelpers
+    autoload :ConfirmationTokenCreateParams, "stripe/params/test_helpers/confirmation_token_create_params"
+    autoload :CustomerFundCashBalanceParams, "stripe/params/test_helpers/customer_fund_cash_balance_params"
+    autoload :RefundExpireParams, "stripe/params/test_helpers/refund_expire_params"
+    autoload :TestClockAdvanceParams, "stripe/params/test_helpers/test_clock_advance_params"
+    autoload :TestClockCreateParams, "stripe/params/test_helpers/test_clock_create_params"
+    autoload :TestClockDeleteParams, "stripe/params/test_helpers/test_clock_delete_params"
+    autoload :TestClockListParams, "stripe/params/test_helpers/test_clock_list_params"
+    autoload :TestClockRetrieveParams, "stripe/params/test_helpers/test_clock_retrieve_params"
+
+    module Issuing
+      autoload :AuthorizationCaptureParams, "stripe/params/test_helpers/issuing/authorization_capture_params"
+      autoload :AuthorizationCreateParams, "stripe/params/test_helpers/issuing/authorization_create_params"
+      autoload :AuthorizationExpireParams, "stripe/params/test_helpers/issuing/authorization_expire_params"
+      autoload :AuthorizationFinalizeAmountParams, "stripe/params/test_helpers/issuing/authorization_finalize_amount_params"
+      autoload :AuthorizationIncrementParams, "stripe/params/test_helpers/issuing/authorization_increment_params"
+      autoload :AuthorizationRespondParams, "stripe/params/test_helpers/issuing/authorization_respond_params"
+      autoload :AuthorizationReverseParams, "stripe/params/test_helpers/issuing/authorization_reverse_params"
+      autoload :CardDeliverCardParams, "stripe/params/test_helpers/issuing/card_deliver_card_params"
+      autoload :CardFailCardParams, "stripe/params/test_helpers/issuing/card_fail_card_params"
+      autoload :CardReturnCardParams, "stripe/params/test_helpers/issuing/card_return_card_params"
+      autoload :CardShipCardParams, "stripe/params/test_helpers/issuing/card_ship_card_params"
+      autoload :CardSubmitCardParams, "stripe/params/test_helpers/issuing/card_submit_card_params"
+      autoload :PersonalizationDesignActivateParams, "stripe/params/test_helpers/issuing/personalization_design_activate_params"
+      autoload :PersonalizationDesignDeactivateParams, "stripe/params/test_helpers/issuing/personalization_design_deactivate_params"
+      autoload :PersonalizationDesignRejectParams, "stripe/params/test_helpers/issuing/personalization_design_reject_params"
+      autoload :TransactionCreateForceCaptureParams, "stripe/params/test_helpers/issuing/transaction_create_force_capture_params"
+      autoload :TransactionCreateUnlinkedRefundParams, "stripe/params/test_helpers/issuing/transaction_create_unlinked_refund_params"
+      autoload :TransactionRefundParams, "stripe/params/test_helpers/issuing/transaction_refund_params"
+    end
+
+    module Terminal
+      autoload :ReaderPresentPaymentMethodParams, "stripe/params/test_helpers/terminal/reader_present_payment_method_params"
+      autoload :ReaderSucceedInputCollectionParams, "stripe/params/test_helpers/terminal/reader_succeed_input_collection_params"
+      autoload :ReaderTimeoutInputCollectionParams, "stripe/params/test_helpers/terminal/reader_timeout_input_collection_params"
+    end
+
+    module Treasury
+      autoload :InboundTransferFailParams, "stripe/params/test_helpers/treasury/inbound_transfer_fail_params"
+      autoload :InboundTransferReturnInboundTransferParams, "stripe/params/test_helpers/treasury/inbound_transfer_return_inbound_transfer_params"
+      autoload :InboundTransferSucceedParams, "stripe/params/test_helpers/treasury/inbound_transfer_succeed_params"
+      autoload :OutboundPaymentFailParams, "stripe/params/test_helpers/treasury/outbound_payment_fail_params"
+      autoload :OutboundPaymentPostParams, "stripe/params/test_helpers/treasury/outbound_payment_post_params"
+      autoload :OutboundPaymentReturnOutboundPaymentParams, "stripe/params/test_helpers/treasury/outbound_payment_return_outbound_payment_params"
+      autoload :OutboundPaymentUpdateParams, "stripe/params/test_helpers/treasury/outbound_payment_update_params"
+      autoload :OutboundTransferFailParams, "stripe/params/test_helpers/treasury/outbound_transfer_fail_params"
+      autoload :OutboundTransferPostParams, "stripe/params/test_helpers/treasury/outbound_transfer_post_params"
+      autoload :OutboundTransferReturnOutboundTransferParams, "stripe/params/test_helpers/treasury/outbound_transfer_return_outbound_transfer_params"
+      autoload :OutboundTransferUpdateParams, "stripe/params/test_helpers/treasury/outbound_transfer_update_params"
+      autoload :ReceivedCreditCreateParams, "stripe/params/test_helpers/treasury/received_credit_create_params"
+      autoload :ReceivedDebitCreateParams, "stripe/params/test_helpers/treasury/received_debit_create_params"
+    end
+  end
+
+  module Treasury
+    autoload :CreditReversalCreateParams, "stripe/params/treasury/credit_reversal_create_params"
+    autoload :CreditReversalListParams, "stripe/params/treasury/credit_reversal_list_params"
+    autoload :CreditReversalRetrieveParams, "stripe/params/treasury/credit_reversal_retrieve_params"
+    autoload :DebitReversalCreateParams, "stripe/params/treasury/debit_reversal_create_params"
+    autoload :DebitReversalListParams, "stripe/params/treasury/debit_reversal_list_params"
+    autoload :DebitReversalRetrieveParams, "stripe/params/treasury/debit_reversal_retrieve_params"
+    autoload :FinancialAccountCloseParams, "stripe/params/treasury/financial_account_close_params"
+    autoload :FinancialAccountCreateParams, "stripe/params/treasury/financial_account_create_params"
+    autoload :FinancialAccountFeaturesRetrieveParams, "stripe/params/treasury/financial_account_features_retrieve_params"
+    autoload :FinancialAccountFeaturesUpdateParams, "stripe/params/treasury/financial_account_features_update_params"
+    autoload :FinancialAccountListParams, "stripe/params/treasury/financial_account_list_params"
+    autoload :FinancialAccountRetrieveFeaturesParams, "stripe/params/treasury/financial_account_retrieve_features_params"
+    autoload :FinancialAccountRetrieveParams, "stripe/params/treasury/financial_account_retrieve_params"
+    autoload :FinancialAccountUpdateFeaturesParams, "stripe/params/treasury/financial_account_update_features_params"
+    autoload :FinancialAccountUpdateParams, "stripe/params/treasury/financial_account_update_params"
+    autoload :InboundTransferCancelParams, "stripe/params/treasury/inbound_transfer_cancel_params"
+    autoload :InboundTransferCreateParams, "stripe/params/treasury/inbound_transfer_create_params"
+    autoload :InboundTransferFailParams, "stripe/params/treasury/inbound_transfer_fail_params"
+    autoload :InboundTransferListParams, "stripe/params/treasury/inbound_transfer_list_params"
+    autoload :InboundTransferRetrieveParams, "stripe/params/treasury/inbound_transfer_retrieve_params"
+    autoload :InboundTransferReturnInboundTransferParams, "stripe/params/treasury/inbound_transfer_return_inbound_transfer_params"
+    autoload :InboundTransferSucceedParams, "stripe/params/treasury/inbound_transfer_succeed_params"
+    autoload :OutboundPaymentCancelParams, "stripe/params/treasury/outbound_payment_cancel_params"
+    autoload :OutboundPaymentCreateParams, "stripe/params/treasury/outbound_payment_create_params"
+    autoload :OutboundPaymentFailParams, "stripe/params/treasury/outbound_payment_fail_params"
+    autoload :OutboundPaymentListParams, "stripe/params/treasury/outbound_payment_list_params"
+    autoload :OutboundPaymentPostParams, "stripe/params/treasury/outbound_payment_post_params"
+    autoload :OutboundPaymentRetrieveParams, "stripe/params/treasury/outbound_payment_retrieve_params"
+    autoload :OutboundPaymentReturnOutboundPaymentParams, "stripe/params/treasury/outbound_payment_return_outbound_payment_params"
+    autoload :OutboundPaymentUpdateParams, "stripe/params/treasury/outbound_payment_update_params"
+    autoload :OutboundTransferCancelParams, "stripe/params/treasury/outbound_transfer_cancel_params"
+    autoload :OutboundTransferCreateParams, "stripe/params/treasury/outbound_transfer_create_params"
+    autoload :OutboundTransferFailParams, "stripe/params/treasury/outbound_transfer_fail_params"
+    autoload :OutboundTransferListParams, "stripe/params/treasury/outbound_transfer_list_params"
+    autoload :OutboundTransferPostParams, "stripe/params/treasury/outbound_transfer_post_params"
+    autoload :OutboundTransferRetrieveParams, "stripe/params/treasury/outbound_transfer_retrieve_params"
+    autoload :OutboundTransferReturnOutboundTransferParams, "stripe/params/treasury/outbound_transfer_return_outbound_transfer_params"
+    autoload :OutboundTransferUpdateParams, "stripe/params/treasury/outbound_transfer_update_params"
+    autoload :ReceivedCreditCreateParams, "stripe/params/treasury/received_credit_create_params"
+    autoload :ReceivedCreditListParams, "stripe/params/treasury/received_credit_list_params"
+    autoload :ReceivedCreditRetrieveParams, "stripe/params/treasury/received_credit_retrieve_params"
+    autoload :ReceivedDebitCreateParams, "stripe/params/treasury/received_debit_create_params"
+    autoload :ReceivedDebitListParams, "stripe/params/treasury/received_debit_list_params"
+    autoload :ReceivedDebitRetrieveParams, "stripe/params/treasury/received_debit_retrieve_params"
+    autoload :TransactionEntryListParams, "stripe/params/treasury/transaction_entry_list_params"
+    autoload :TransactionEntryRetrieveParams, "stripe/params/treasury/transaction_entry_retrieve_params"
+    autoload :TransactionListParams, "stripe/params/treasury/transaction_list_params"
+    autoload :TransactionRetrieveParams, "stripe/params/treasury/transaction_retrieve_params"
+  end
+
+  module V2
+
+    module Billing
+      autoload :MeterEventAdjustmentCreateParams, "stripe/params/v2/billing/meter_event_adjustment_create_params"
+      autoload :MeterEventCreateParams, "stripe/params/v2/billing/meter_event_create_params"
+      autoload :MeterEventSessionCreateParams, "stripe/params/v2/billing/meter_event_session_create_params"
+      autoload :MeterEventStreamCreateParams, "stripe/params/v2/billing/meter_event_stream_create_params"
+    end
+
+    module Core
+      autoload :AccountCloseParams, "stripe/params/v2/core/account_close_params"
+      autoload :AccountCreateParams, "stripe/params/v2/core/account_create_params"
+      autoload :AccountLinkCreateParams, "stripe/params/v2/core/account_link_create_params"
+      autoload :AccountListParams, "stripe/params/v2/core/account_list_params"
+      autoload :AccountRetrieveParams, "stripe/params/v2/core/account_retrieve_params"
+      autoload :AccountTokenCreateParams, "stripe/params/v2/core/account_token_create_params"
+      autoload :AccountTokenRetrieveParams, "stripe/params/v2/core/account_token_retrieve_params"
+      autoload :AccountUpdateParams, "stripe/params/v2/core/account_update_params"
+      autoload :EventDestinationCreateParams, "stripe/params/v2/core/event_destination_create_params"
+      autoload :EventDestinationDeleteParams, "stripe/params/v2/core/event_destination_delete_params"
+      autoload :EventDestinationDisableParams, "stripe/params/v2/core/event_destination_disable_params"
+      autoload :EventDestinationEnableParams, "stripe/params/v2/core/event_destination_enable_params"
+      autoload :EventDestinationListParams, "stripe/params/v2/core/event_destination_list_params"
+      autoload :EventDestinationPingParams, "stripe/params/v2/core/event_destination_ping_params"
+      autoload :EventDestinationRetrieveParams, "stripe/params/v2/core/event_destination_retrieve_params"
+      autoload :EventDestinationUpdateParams, "stripe/params/v2/core/event_destination_update_params"
+      autoload :EventListParams, "stripe/params/v2/core/event_list_params"
+      autoload :EventRetrieveParams, "stripe/params/v2/core/event_retrieve_params"
+
+      module Accounts
+        autoload :PersonCreateParams, "stripe/params/v2/core/accounts/person_create_params"
+        autoload :PersonDeleteParams, "stripe/params/v2/core/accounts/person_delete_params"
+        autoload :PersonListParams, "stripe/params/v2/core/accounts/person_list_params"
+        autoload :PersonRetrieveParams, "stripe/params/v2/core/accounts/person_retrieve_params"
+        autoload :PersonTokenCreateParams, "stripe/params/v2/core/accounts/person_token_create_params"
+        autoload :PersonTokenRetrieveParams, "stripe/params/v2/core/accounts/person_token_retrieve_params"
+        autoload :PersonUpdateParams, "stripe/params/v2/core/accounts/person_update_params"
+      end
+    end
+  end
+
+  # Ordered list for Stripe.eager_load! — same order as the original
+  # require calls so eager loading has no load-order surprises.
+  PARAM_FILES = %w[
+    stripe/params/account_capability_list_params
+    stripe/params/account_capability_retrieve_params
+    stripe/params/account_capability_update_params
+    stripe/params/account_create_params
+    stripe/params/account_delete_params
+    stripe/params/account_external_account_create_params
+    stripe/params/account_external_account_delete_params
+    stripe/params/account_external_account_list_params
+    stripe/params/account_external_account_retrieve_params
+    stripe/params/account_external_account_update_params
+    stripe/params/account_link_create_params
+    stripe/params/account_list_params
+    stripe/params/account_login_link_create_params
+    stripe/params/account_person_create_params
+    stripe/params/account_person_delete_params
+    stripe/params/account_person_list_params
+    stripe/params/account_person_retrieve_params
+    stripe/params/account_person_update_params
+    stripe/params/account_persons_params
+    stripe/params/account_reject_params
+    stripe/params/account_retrieve_current_params
+    stripe/params/account_retrieve_params
+    stripe/params/account_session_create_params
+    stripe/params/account_update_params
+    stripe/params/apple_pay_domain_create_params
+    stripe/params/apple_pay_domain_delete_params
+    stripe/params/apple_pay_domain_list_params
+    stripe/params/apple_pay_domain_retrieve_params
+    stripe/params/application_fee_list_params
+    stripe/params/application_fee_refund_create_params
+    stripe/params/application_fee_refund_list_params
+    stripe/params/application_fee_refund_retrieve_params
+    stripe/params/application_fee_refund_update_params
+    stripe/params/application_fee_retrieve_params
+    stripe/params/apps/secret_create_params
+    stripe/params/apps/secret_delete_where_params
+    stripe/params/apps/secret_find_params
+    stripe/params/apps/secret_list_params
+    stripe/params/balance_retrieve_params
+    stripe/params/balance_settings_retrieve_params
+    stripe/params/balance_settings_update_params
+    stripe/params/balance_transaction_list_params
+    stripe/params/balance_transaction_retrieve_params
+    stripe/params/billing/alert_activate_params
+    stripe/params/billing/alert_archive_params
+    stripe/params/billing/alert_create_params
+    stripe/params/billing/alert_deactivate_params
+    stripe/params/billing/alert_list_params
+    stripe/params/billing/alert_retrieve_params
+    stripe/params/billing/credit_balance_summary_retrieve_params
+    stripe/params/billing/credit_balance_transaction_list_params
+    stripe/params/billing/credit_balance_transaction_retrieve_params
+    stripe/params/billing/credit_grant_create_params
+    stripe/params/billing/credit_grant_expire_params
+    stripe/params/billing/credit_grant_list_params
+    stripe/params/billing/credit_grant_retrieve_params
+    stripe/params/billing/credit_grant_update_params
+    stripe/params/billing/credit_grant_void_grant_params
+    stripe/params/billing/meter_create_params
+    stripe/params/billing/meter_deactivate_params
+    stripe/params/billing/meter_event_adjustment_create_params
+    stripe/params/billing/meter_event_create_params
+    stripe/params/billing/meter_event_summary_list_params
+    stripe/params/billing/meter_list_params
+    stripe/params/billing/meter_reactivate_params
+    stripe/params/billing/meter_retrieve_params
+    stripe/params/billing/meter_update_params
+    stripe/params/billing_portal/configuration_create_params
+    stripe/params/billing_portal/configuration_list_params
+    stripe/params/billing_portal/configuration_retrieve_params
+    stripe/params/billing_portal/configuration_update_params
+    stripe/params/billing_portal/session_create_params
+    stripe/params/charge_capture_params
+    stripe/params/charge_create_params
+    stripe/params/charge_list_params
+    stripe/params/charge_retrieve_params
+    stripe/params/charge_search_params
+    stripe/params/charge_update_params
+    stripe/params/checkout/session_create_params
+    stripe/params/checkout/session_expire_params
+    stripe/params/checkout/session_line_item_list_params
+    stripe/params/checkout/session_list_line_items_params
+    stripe/params/checkout/session_list_params
+    stripe/params/checkout/session_retrieve_params
+    stripe/params/checkout/session_update_params
+    stripe/params/climate/order_cancel_params
+    stripe/params/climate/order_create_params
+    stripe/params/climate/order_list_params
+    stripe/params/climate/order_retrieve_params
+    stripe/params/climate/order_update_params
+    stripe/params/climate/product_list_params
+    stripe/params/climate/product_retrieve_params
+    stripe/params/climate/supplier_list_params
+    stripe/params/climate/supplier_retrieve_params
+    stripe/params/confirmation_token_create_params
+    stripe/params/confirmation_token_retrieve_params
+    stripe/params/country_spec_list_params
+    stripe/params/country_spec_retrieve_params
+    stripe/params/coupon_create_params
+    stripe/params/coupon_delete_params
+    stripe/params/coupon_list_params
+    stripe/params/coupon_retrieve_params
+    stripe/params/coupon_update_params
+    stripe/params/credit_note_create_params
+    stripe/params/credit_note_line_item_list_params
+    stripe/params/credit_note_list_params
+    stripe/params/credit_note_list_preview_line_items_params
+    stripe/params/credit_note_preview_lines_list_params
+    stripe/params/credit_note_preview_params
+    stripe/params/credit_note_retrieve_params
+    stripe/params/credit_note_update_params
+    stripe/params/credit_note_void_credit_note_params
+    stripe/params/customer_balance_transaction_create_params
+    stripe/params/customer_balance_transaction_list_params
+    stripe/params/customer_balance_transaction_retrieve_params
+    stripe/params/customer_balance_transaction_update_params
+    stripe/params/customer_cash_balance_retrieve_params
+    stripe/params/customer_cash_balance_transaction_list_params
+    stripe/params/customer_cash_balance_transaction_retrieve_params
+    stripe/params/customer_cash_balance_update_params
+    stripe/params/customer_create_funding_instructions_params
+    stripe/params/customer_create_params
+    stripe/params/customer_delete_discount_params
+    stripe/params/customer_delete_params
+    stripe/params/customer_fund_cash_balance_params
+    stripe/params/customer_funding_instructions_create_params
+    stripe/params/customer_list_params
+    stripe/params/customer_list_payment_methods_params
+    stripe/params/customer_payment_method_list_params
+    stripe/params/customer_payment_method_retrieve_params
+    stripe/params/customer_payment_source_create_params
+    stripe/params/customer_payment_source_delete_params
+    stripe/params/customer_payment_source_list_params
+    stripe/params/customer_payment_source_retrieve_params
+    stripe/params/customer_payment_source_update_params
+    stripe/params/customer_payment_source_verify_params
+    stripe/params/customer_retrieve_params
+    stripe/params/customer_retrieve_payment_method_params
+    stripe/params/customer_search_params
+    stripe/params/customer_session_create_params
+    stripe/params/customer_tax_id_create_params
+    stripe/params/customer_tax_id_delete_params
+    stripe/params/customer_tax_id_list_params
+    stripe/params/customer_tax_id_retrieve_params
+    stripe/params/customer_update_params
+    stripe/params/dispute_close_params
+    stripe/params/dispute_list_params
+    stripe/params/dispute_retrieve_params
+    stripe/params/dispute_update_params
+    stripe/params/entitlements/active_entitlement_list_params
+    stripe/params/entitlements/active_entitlement_retrieve_params
+    stripe/params/entitlements/feature_create_params
+    stripe/params/entitlements/feature_list_params
+    stripe/params/entitlements/feature_retrieve_params
+    stripe/params/entitlements/feature_update_params
+    stripe/params/ephemeral_key_create_params
+    stripe/params/ephemeral_key_delete_params
+    stripe/params/event_list_params
+    stripe/params/event_retrieve_params
+    stripe/params/exchange_rate_list_params
+    stripe/params/exchange_rate_retrieve_params
+    stripe/params/file_create_params
+    stripe/params/file_link_create_params
+    stripe/params/file_link_list_params
+    stripe/params/file_link_retrieve_params
+    stripe/params/file_link_update_params
+    stripe/params/file_list_params
+    stripe/params/file_retrieve_params
+    stripe/params/financial_connections/account_disconnect_params
+    stripe/params/financial_connections/account_list_owners_params
+    stripe/params/financial_connections/account_list_params
+    stripe/params/financial_connections/account_owner_list_params
+    stripe/params/financial_connections/account_refresh_account_params
+    stripe/params/financial_connections/account_refresh_params
+    stripe/params/financial_connections/account_retrieve_params
+    stripe/params/financial_connections/account_subscribe_params
+    stripe/params/financial_connections/account_unsubscribe_params
+    stripe/params/financial_connections/session_create_params
+    stripe/params/financial_connections/session_retrieve_params
+    stripe/params/financial_connections/transaction_list_params
+    stripe/params/financial_connections/transaction_retrieve_params
+    stripe/params/forwarding/request_create_params
+    stripe/params/forwarding/request_list_params
+    stripe/params/forwarding/request_retrieve_params
+    stripe/params/identity/verification_report_list_params
+    stripe/params/identity/verification_report_retrieve_params
+    stripe/params/identity/verification_session_cancel_params
+    stripe/params/identity/verification_session_create_params
+    stripe/params/identity/verification_session_list_params
+    stripe/params/identity/verification_session_redact_params
+    stripe/params/identity/verification_session_retrieve_params
+    stripe/params/identity/verification_session_update_params
+    stripe/params/invoice_add_lines_params
+    stripe/params/invoice_attach_payment_params
+    stripe/params/invoice_create_params
+    stripe/params/invoice_create_preview_params
+    stripe/params/invoice_delete_params
+    stripe/params/invoice_finalize_invoice_params
+    stripe/params/invoice_item_create_params
+    stripe/params/invoice_item_delete_params
+    stripe/params/invoice_item_list_params
+    stripe/params/invoice_item_retrieve_params
+    stripe/params/invoice_item_update_params
+    stripe/params/invoice_line_item_list_params
+    stripe/params/invoice_line_item_update_params
+    stripe/params/invoice_list_params
+    stripe/params/invoice_mark_uncollectible_params
+    stripe/params/invoice_pay_params
+    stripe/params/invoice_payment_list_params
+    stripe/params/invoice_payment_retrieve_params
+    stripe/params/invoice_remove_lines_params
+    stripe/params/invoice_rendering_template_archive_params
+    stripe/params/invoice_rendering_template_list_params
+    stripe/params/invoice_rendering_template_retrieve_params
+    stripe/params/invoice_rendering_template_unarchive_params
+    stripe/params/invoice_retrieve_params
+    stripe/params/invoice_search_params
+    stripe/params/invoice_send_invoice_params
+    stripe/params/invoice_update_lines_params
+    stripe/params/invoice_update_params
+    stripe/params/invoice_void_invoice_params
+    stripe/params/issuing/authorization_approve_params
+    stripe/params/issuing/authorization_capture_params
+    stripe/params/issuing/authorization_create_params
+    stripe/params/issuing/authorization_decline_params
+    stripe/params/issuing/authorization_expire_params
+    stripe/params/issuing/authorization_finalize_amount_params
+    stripe/params/issuing/authorization_increment_params
+    stripe/params/issuing/authorization_list_params
+    stripe/params/issuing/authorization_respond_params
+    stripe/params/issuing/authorization_retrieve_params
+    stripe/params/issuing/authorization_reverse_params
+    stripe/params/issuing/authorization_update_params
+    stripe/params/issuing/card_create_params
+    stripe/params/issuing/card_deliver_card_params
+    stripe/params/issuing/card_fail_card_params
+    stripe/params/issuing/card_list_params
+    stripe/params/issuing/card_retrieve_params
+    stripe/params/issuing/card_return_card_params
+    stripe/params/issuing/card_ship_card_params
+    stripe/params/issuing/card_submit_card_params
+    stripe/params/issuing/card_update_params
+    stripe/params/issuing/cardholder_create_params
+    stripe/params/issuing/cardholder_list_params
+    stripe/params/issuing/cardholder_retrieve_params
+    stripe/params/issuing/cardholder_update_params
+    stripe/params/issuing/dispute_create_params
+    stripe/params/issuing/dispute_list_params
+    stripe/params/issuing/dispute_retrieve_params
+    stripe/params/issuing/dispute_submit_params
+    stripe/params/issuing/dispute_update_params
+    stripe/params/issuing/personalization_design_activate_params
+    stripe/params/issuing/personalization_design_create_params
+    stripe/params/issuing/personalization_design_deactivate_params
+    stripe/params/issuing/personalization_design_list_params
+    stripe/params/issuing/personalization_design_reject_params
+    stripe/params/issuing/personalization_design_retrieve_params
+    stripe/params/issuing/personalization_design_update_params
+    stripe/params/issuing/physical_bundle_list_params
+    stripe/params/issuing/physical_bundle_retrieve_params
+    stripe/params/issuing/token_list_params
+    stripe/params/issuing/token_retrieve_params
+    stripe/params/issuing/token_update_params
+    stripe/params/issuing/transaction_create_force_capture_params
+    stripe/params/issuing/transaction_create_unlinked_refund_params
+    stripe/params/issuing/transaction_list_params
+    stripe/params/issuing/transaction_refund_params
+    stripe/params/issuing/transaction_retrieve_params
+    stripe/params/issuing/transaction_update_params
+    stripe/params/mandate_retrieve_params
+    stripe/params/payment_attempt_record_list_params
+    stripe/params/payment_attempt_record_retrieve_params
+    stripe/params/payment_intent_amount_details_line_item_list_params
+    stripe/params/payment_intent_apply_customer_balance_params
+    stripe/params/payment_intent_cancel_params
+    stripe/params/payment_intent_capture_params
+    stripe/params/payment_intent_confirm_params
+    stripe/params/payment_intent_create_params
+    stripe/params/payment_intent_increment_authorization_params
+    stripe/params/payment_intent_list_params
+    stripe/params/payment_intent_retrieve_params
+    stripe/params/payment_intent_search_params
+    stripe/params/payment_intent_update_params
+    stripe/params/payment_intent_verify_microdeposits_params
+    stripe/params/payment_link_create_params
+    stripe/params/payment_link_line_item_list_params
+    stripe/params/payment_link_list_line_items_params
+    stripe/params/payment_link_list_params
+    stripe/params/payment_link_retrieve_params
+    stripe/params/payment_link_update_params
+    stripe/params/payment_method_attach_params
+    stripe/params/payment_method_configuration_create_params
+    stripe/params/payment_method_configuration_list_params
+    stripe/params/payment_method_configuration_retrieve_params
+    stripe/params/payment_method_configuration_update_params
+    stripe/params/payment_method_create_params
+    stripe/params/payment_method_detach_params
+    stripe/params/payment_method_domain_create_params
+    stripe/params/payment_method_domain_list_params
+    stripe/params/payment_method_domain_retrieve_params
+    stripe/params/payment_method_domain_update_params
+    stripe/params/payment_method_domain_validate_params
+    stripe/params/payment_method_list_params
+    stripe/params/payment_method_retrieve_params
+    stripe/params/payment_method_update_params
+    stripe/params/payment_record_report_payment_attempt_canceled_params
+    stripe/params/payment_record_report_payment_attempt_failed_params
+    stripe/params/payment_record_report_payment_attempt_guaranteed_params
+    stripe/params/payment_record_report_payment_attempt_informational_params
+    stripe/params/payment_record_report_payment_attempt_params
+    stripe/params/payment_record_report_payment_params
+    stripe/params/payment_record_report_refund_params
+    stripe/params/payment_record_retrieve_params
+    stripe/params/payout_cancel_params
+    stripe/params/payout_create_params
+    stripe/params/payout_list_params
+    stripe/params/payout_retrieve_params
+    stripe/params/payout_reverse_params
+    stripe/params/payout_update_params
+    stripe/params/plan_create_params
+    stripe/params/plan_delete_params
+    stripe/params/plan_list_params
+    stripe/params/plan_retrieve_params
+    stripe/params/plan_update_params
+    stripe/params/price_create_params
+    stripe/params/price_list_params
+    stripe/params/price_retrieve_params
+    stripe/params/price_search_params
+    stripe/params/price_update_params
+    stripe/params/product_create_params
+    stripe/params/product_delete_params
+    stripe/params/product_feature_create_params
+    stripe/params/product_feature_delete_params
+    stripe/params/product_feature_list_params
+    stripe/params/product_feature_retrieve_params
+    stripe/params/product_list_params
+    stripe/params/product_retrieve_params
+    stripe/params/product_search_params
+    stripe/params/product_update_params
+    stripe/params/promotion_code_create_params
+    stripe/params/promotion_code_list_params
+    stripe/params/promotion_code_retrieve_params
+    stripe/params/promotion_code_update_params
+    stripe/params/quote_accept_params
+    stripe/params/quote_cancel_params
+    stripe/params/quote_computed_upfront_line_items_list_params
+    stripe/params/quote_create_params
+    stripe/params/quote_finalize_quote_params
+    stripe/params/quote_line_item_list_params
+    stripe/params/quote_list_computed_upfront_line_items_params
+    stripe/params/quote_list_line_items_params
+    stripe/params/quote_list_params
+    stripe/params/quote_pdf_params
+    stripe/params/quote_retrieve_params
+    stripe/params/quote_update_params
+    stripe/params/radar/early_fraud_warning_list_params
+    stripe/params/radar/early_fraud_warning_retrieve_params
+    stripe/params/radar/payment_evaluation_create_params
+    stripe/params/radar/value_list_create_params
+    stripe/params/radar/value_list_delete_params
+    stripe/params/radar/value_list_item_create_params
+    stripe/params/radar/value_list_item_delete_params
+    stripe/params/radar/value_list_item_list_params
+    stripe/params/radar/value_list_item_retrieve_params
+    stripe/params/radar/value_list_list_params
+    stripe/params/radar/value_list_retrieve_params
+    stripe/params/radar/value_list_update_params
+    stripe/params/refund_cancel_params
+    stripe/params/refund_create_params
+    stripe/params/refund_expire_params
+    stripe/params/refund_list_params
+    stripe/params/refund_retrieve_params
+    stripe/params/refund_update_params
+    stripe/params/reporting/report_run_create_params
+    stripe/params/reporting/report_run_list_params
+    stripe/params/reporting/report_run_retrieve_params
+    stripe/params/reporting/report_type_list_params
+    stripe/params/reporting/report_type_retrieve_params
+    stripe/params/review_approve_params
+    stripe/params/review_list_params
+    stripe/params/review_retrieve_params
+    stripe/params/setup_attempt_list_params
+    stripe/params/setup_intent_cancel_params
+    stripe/params/setup_intent_confirm_params
+    stripe/params/setup_intent_create_params
+    stripe/params/setup_intent_list_params
+    stripe/params/setup_intent_retrieve_params
+    stripe/params/setup_intent_update_params
+    stripe/params/setup_intent_verify_microdeposits_params
+    stripe/params/shipping_rate_create_params
+    stripe/params/shipping_rate_list_params
+    stripe/params/shipping_rate_retrieve_params
+    stripe/params/shipping_rate_update_params
+    stripe/params/sigma/scheduled_query_run_list_params
+    stripe/params/sigma/scheduled_query_run_retrieve_params
+    stripe/params/source_create_params
+    stripe/params/source_detach_params
+    stripe/params/source_retrieve_params
+    stripe/params/source_transaction_list_params
+    stripe/params/source_update_params
+    stripe/params/source_verify_params
+    stripe/params/subscription_cancel_params
+    stripe/params/subscription_create_params
+    stripe/params/subscription_delete_discount_params
+    stripe/params/subscription_item_create_params
+    stripe/params/subscription_item_delete_params
+    stripe/params/subscription_item_list_params
+    stripe/params/subscription_item_retrieve_params
+    stripe/params/subscription_item_update_params
+    stripe/params/subscription_list_params
+    stripe/params/subscription_migrate_params
+    stripe/params/subscription_resume_params
+    stripe/params/subscription_retrieve_params
+    stripe/params/subscription_schedule_cancel_params
+    stripe/params/subscription_schedule_create_params
+    stripe/params/subscription_schedule_list_params
+    stripe/params/subscription_schedule_release_params
+    stripe/params/subscription_schedule_retrieve_params
+    stripe/params/subscription_schedule_update_params
+    stripe/params/subscription_search_params
+    stripe/params/subscription_update_params
+    stripe/params/tax/association_find_params
+    stripe/params/tax/calculation_create_params
+    stripe/params/tax/calculation_line_item_list_params
+    stripe/params/tax/calculation_list_line_items_params
+    stripe/params/tax/calculation_retrieve_params
+    stripe/params/tax/registration_create_params
+    stripe/params/tax/registration_list_params
+    stripe/params/tax/registration_retrieve_params
+    stripe/params/tax/registration_update_params
+    stripe/params/tax/settings_retrieve_params
+    stripe/params/tax/settings_update_params
+    stripe/params/tax/transaction_create_from_calculation_params
+    stripe/params/tax/transaction_create_reversal_params
+    stripe/params/tax/transaction_line_item_list_params
+    stripe/params/tax/transaction_list_line_items_params
+    stripe/params/tax/transaction_retrieve_params
+    stripe/params/tax_code_list_params
+    stripe/params/tax_code_retrieve_params
+    stripe/params/tax_id_create_params
+    stripe/params/tax_id_delete_params
+    stripe/params/tax_id_list_params
+    stripe/params/tax_id_retrieve_params
+    stripe/params/tax_rate_create_params
+    stripe/params/tax_rate_list_params
+    stripe/params/tax_rate_retrieve_params
+    stripe/params/tax_rate_update_params
+    stripe/params/terminal/configuration_create_params
+    stripe/params/terminal/configuration_delete_params
+    stripe/params/terminal/configuration_list_params
+    stripe/params/terminal/configuration_retrieve_params
+    stripe/params/terminal/configuration_update_params
+    stripe/params/terminal/connection_token_create_params
+    stripe/params/terminal/location_create_params
+    stripe/params/terminal/location_delete_params
+    stripe/params/terminal/location_list_params
+    stripe/params/terminal/location_retrieve_params
+    stripe/params/terminal/location_update_params
+    stripe/params/terminal/onboarding_link_create_params
+    stripe/params/terminal/reader_cancel_action_params
+    stripe/params/terminal/reader_collect_inputs_params
+    stripe/params/terminal/reader_collect_payment_method_params
+    stripe/params/terminal/reader_confirm_payment_intent_params
+    stripe/params/terminal/reader_create_params
+    stripe/params/terminal/reader_delete_params
+    stripe/params/terminal/reader_list_params
+    stripe/params/terminal/reader_present_payment_method_params
+    stripe/params/terminal/reader_process_payment_intent_params
+    stripe/params/terminal/reader_process_setup_intent_params
+    stripe/params/terminal/reader_refund_payment_params
+    stripe/params/terminal/reader_retrieve_params
+    stripe/params/terminal/reader_set_reader_display_params
+    stripe/params/terminal/reader_succeed_input_collection_params
+    stripe/params/terminal/reader_timeout_input_collection_params
+    stripe/params/terminal/reader_update_params
+    stripe/params/test_helpers/confirmation_token_create_params
+    stripe/params/test_helpers/customer_fund_cash_balance_params
+    stripe/params/test_helpers/issuing/authorization_capture_params
+    stripe/params/test_helpers/issuing/authorization_create_params
+    stripe/params/test_helpers/issuing/authorization_expire_params
+    stripe/params/test_helpers/issuing/authorization_finalize_amount_params
+    stripe/params/test_helpers/issuing/authorization_increment_params
+    stripe/params/test_helpers/issuing/authorization_respond_params
+    stripe/params/test_helpers/issuing/authorization_reverse_params
+    stripe/params/test_helpers/issuing/card_deliver_card_params
+    stripe/params/test_helpers/issuing/card_fail_card_params
+    stripe/params/test_helpers/issuing/card_return_card_params
+    stripe/params/test_helpers/issuing/card_ship_card_params
+    stripe/params/test_helpers/issuing/card_submit_card_params
+    stripe/params/test_helpers/issuing/personalization_design_activate_params
+    stripe/params/test_helpers/issuing/personalization_design_deactivate_params
+    stripe/params/test_helpers/issuing/personalization_design_reject_params
+    stripe/params/test_helpers/issuing/transaction_create_force_capture_params
+    stripe/params/test_helpers/issuing/transaction_create_unlinked_refund_params
+    stripe/params/test_helpers/issuing/transaction_refund_params
+    stripe/params/test_helpers/refund_expire_params
+    stripe/params/test_helpers/terminal/reader_present_payment_method_params
+    stripe/params/test_helpers/terminal/reader_succeed_input_collection_params
+    stripe/params/test_helpers/terminal/reader_timeout_input_collection_params
+    stripe/params/test_helpers/test_clock_advance_params
+    stripe/params/test_helpers/test_clock_create_params
+    stripe/params/test_helpers/test_clock_delete_params
+    stripe/params/test_helpers/test_clock_list_params
+    stripe/params/test_helpers/test_clock_retrieve_params
+    stripe/params/test_helpers/treasury/inbound_transfer_fail_params
+    stripe/params/test_helpers/treasury/inbound_transfer_return_inbound_transfer_params
+    stripe/params/test_helpers/treasury/inbound_transfer_succeed_params
+    stripe/params/test_helpers/treasury/outbound_payment_fail_params
+    stripe/params/test_helpers/treasury/outbound_payment_post_params
+    stripe/params/test_helpers/treasury/outbound_payment_return_outbound_payment_params
+    stripe/params/test_helpers/treasury/outbound_payment_update_params
+    stripe/params/test_helpers/treasury/outbound_transfer_fail_params
+    stripe/params/test_helpers/treasury/outbound_transfer_post_params
+    stripe/params/test_helpers/treasury/outbound_transfer_return_outbound_transfer_params
+    stripe/params/test_helpers/treasury/outbound_transfer_update_params
+    stripe/params/test_helpers/treasury/received_credit_create_params
+    stripe/params/test_helpers/treasury/received_debit_create_params
+    stripe/params/token_create_params
+    stripe/params/token_retrieve_params
+    stripe/params/topup_cancel_params
+    stripe/params/topup_create_params
+    stripe/params/topup_list_params
+    stripe/params/topup_retrieve_params
+    stripe/params/topup_update_params
+    stripe/params/transfer_create_params
+    stripe/params/transfer_list_params
+    stripe/params/transfer_retrieve_params
+    stripe/params/transfer_reversal_create_params
+    stripe/params/transfer_reversal_list_params
+    stripe/params/transfer_reversal_retrieve_params
+    stripe/params/transfer_reversal_update_params
+    stripe/params/transfer_update_params
+    stripe/params/treasury/credit_reversal_create_params
+    stripe/params/treasury/credit_reversal_list_params
+    stripe/params/treasury/credit_reversal_retrieve_params
+    stripe/params/treasury/debit_reversal_create_params
+    stripe/params/treasury/debit_reversal_list_params
+    stripe/params/treasury/debit_reversal_retrieve_params
+    stripe/params/treasury/financial_account_close_params
+    stripe/params/treasury/financial_account_create_params
+    stripe/params/treasury/financial_account_features_retrieve_params
+    stripe/params/treasury/financial_account_features_update_params
+    stripe/params/treasury/financial_account_list_params
+    stripe/params/treasury/financial_account_retrieve_features_params
+    stripe/params/treasury/financial_account_retrieve_params
+    stripe/params/treasury/financial_account_update_features_params
+    stripe/params/treasury/financial_account_update_params
+    stripe/params/treasury/inbound_transfer_cancel_params
+    stripe/params/treasury/inbound_transfer_create_params
+    stripe/params/treasury/inbound_transfer_fail_params
+    stripe/params/treasury/inbound_transfer_list_params
+    stripe/params/treasury/inbound_transfer_retrieve_params
+    stripe/params/treasury/inbound_transfer_return_inbound_transfer_params
+    stripe/params/treasury/inbound_transfer_succeed_params
+    stripe/params/treasury/outbound_payment_cancel_params
+    stripe/params/treasury/outbound_payment_create_params
+    stripe/params/treasury/outbound_payment_fail_params
+    stripe/params/treasury/outbound_payment_list_params
+    stripe/params/treasury/outbound_payment_post_params
+    stripe/params/treasury/outbound_payment_retrieve_params
+    stripe/params/treasury/outbound_payment_return_outbound_payment_params
+    stripe/params/treasury/outbound_payment_update_params
+    stripe/params/treasury/outbound_transfer_cancel_params
+    stripe/params/treasury/outbound_transfer_create_params
+    stripe/params/treasury/outbound_transfer_fail_params
+    stripe/params/treasury/outbound_transfer_list_params
+    stripe/params/treasury/outbound_transfer_post_params
+    stripe/params/treasury/outbound_transfer_retrieve_params
+    stripe/params/treasury/outbound_transfer_return_outbound_transfer_params
+    stripe/params/treasury/outbound_transfer_update_params
+    stripe/params/treasury/received_credit_create_params
+    stripe/params/treasury/received_credit_list_params
+    stripe/params/treasury/received_credit_retrieve_params
+    stripe/params/treasury/received_debit_create_params
+    stripe/params/treasury/received_debit_list_params
+    stripe/params/treasury/received_debit_retrieve_params
+    stripe/params/treasury/transaction_entry_list_params
+    stripe/params/treasury/transaction_entry_retrieve_params
+    stripe/params/treasury/transaction_list_params
+    stripe/params/treasury/transaction_retrieve_params
+    stripe/params/v2/billing/meter_event_adjustment_create_params
+    stripe/params/v2/billing/meter_event_create_params
+    stripe/params/v2/billing/meter_event_session_create_params
+    stripe/params/v2/billing/meter_event_stream_create_params
+    stripe/params/v2/core/account_close_params
+    stripe/params/v2/core/account_create_params
+    stripe/params/v2/core/account_link_create_params
+    stripe/params/v2/core/account_list_params
+    stripe/params/v2/core/account_retrieve_params
+    stripe/params/v2/core/account_token_create_params
+    stripe/params/v2/core/account_token_retrieve_params
+    stripe/params/v2/core/account_update_params
+    stripe/params/v2/core/accounts/person_create_params
+    stripe/params/v2/core/accounts/person_delete_params
+    stripe/params/v2/core/accounts/person_list_params
+    stripe/params/v2/core/accounts/person_retrieve_params
+    stripe/params/v2/core/accounts/person_token_create_params
+    stripe/params/v2/core/accounts/person_token_retrieve_params
+    stripe/params/v2/core/accounts/person_update_params
+    stripe/params/v2/core/event_destination_create_params
+    stripe/params/v2/core/event_destination_delete_params
+    stripe/params/v2/core/event_destination_disable_params
+    stripe/params/v2/core/event_destination_enable_params
+    stripe/params/v2/core/event_destination_list_params
+    stripe/params/v2/core/event_destination_ping_params
+    stripe/params/v2/core/event_destination_retrieve_params
+    stripe/params/v2/core/event_destination_update_params
+    stripe/params/v2/core/event_list_params
+    stripe/params/v2/core/event_retrieve_params
+    stripe/params/webhook_endpoint_create_params
+    stripe/params/webhook_endpoint_delete_params
+    stripe/params/webhook_endpoint_list_params
+    stripe/params/webhook_endpoint_retrieve_params
+    stripe/params/webhook_endpoint_update_params
+  ].freeze
+end

--- a/lib/stripe/params.rb
+++ b/lib/stripe/params.rb
@@ -19,8 +19,8 @@ module Stripe
   autoload :AccountPersonDeleteParams, "stripe/params/account_person_delete_params"
   autoload :AccountPersonListParams, "stripe/params/account_person_list_params"
   autoload :AccountPersonRetrieveParams, "stripe/params/account_person_retrieve_params"
-  autoload :AccountPersonUpdateParams, "stripe/params/account_person_update_params"
   autoload :AccountPersonsParams, "stripe/params/account_persons_params"
+  autoload :AccountPersonUpdateParams, "stripe/params/account_person_update_params"
   autoload :AccountRejectParams, "stripe/params/account_reject_params"
   autoload :AccountRetrieveCurrentParams, "stripe/params/account_retrieve_current_params"
   autoload :AccountRetrieveParams, "stripe/params/account_retrieve_params"
@@ -131,9 +131,9 @@ module Stripe
   autoload :InvoiceLineItemUpdateParams, "stripe/params/invoice_line_item_update_params"
   autoload :InvoiceListParams, "stripe/params/invoice_list_params"
   autoload :InvoiceMarkUncollectibleParams, "stripe/params/invoice_mark_uncollectible_params"
-  autoload :InvoicePayParams, "stripe/params/invoice_pay_params"
   autoload :InvoicePaymentListParams, "stripe/params/invoice_payment_list_params"
   autoload :InvoicePaymentRetrieveParams, "stripe/params/invoice_payment_retrieve_params"
+  autoload :InvoicePayParams, "stripe/params/invoice_pay_params"
   autoload :InvoiceRemoveLinesParams, "stripe/params/invoice_remove_lines_params"
   autoload :InvoiceRenderingTemplateArchiveParams, "stripe/params/invoice_rendering_template_archive_params"
   autoload :InvoiceRenderingTemplateListParams, "stripe/params/invoice_rendering_template_list_params"
@@ -436,16 +436,16 @@ module Stripe
     autoload :CardCreateParams, "stripe/params/issuing/card_create_params"
     autoload :CardDeliverCardParams, "stripe/params/issuing/card_deliver_card_params"
     autoload :CardFailCardParams, "stripe/params/issuing/card_fail_card_params"
+    autoload :CardholderCreateParams, "stripe/params/issuing/cardholder_create_params"
+    autoload :CardholderListParams, "stripe/params/issuing/cardholder_list_params"
+    autoload :CardholderRetrieveParams, "stripe/params/issuing/cardholder_retrieve_params"
+    autoload :CardholderUpdateParams, "stripe/params/issuing/cardholder_update_params"
     autoload :CardListParams, "stripe/params/issuing/card_list_params"
     autoload :CardRetrieveParams, "stripe/params/issuing/card_retrieve_params"
     autoload :CardReturnCardParams, "stripe/params/issuing/card_return_card_params"
     autoload :CardShipCardParams, "stripe/params/issuing/card_ship_card_params"
     autoload :CardSubmitCardParams, "stripe/params/issuing/card_submit_card_params"
     autoload :CardUpdateParams, "stripe/params/issuing/card_update_params"
-    autoload :CardholderCreateParams, "stripe/params/issuing/cardholder_create_params"
-    autoload :CardholderListParams, "stripe/params/issuing/cardholder_list_params"
-    autoload :CardholderRetrieveParams, "stripe/params/issuing/cardholder_retrieve_params"
-    autoload :CardholderUpdateParams, "stripe/params/issuing/cardholder_update_params"
     autoload :DisputeCreateParams, "stripe/params/issuing/dispute_create_params"
     autoload :DisputeListParams, "stripe/params/issuing/dispute_list_params"
     autoload :DisputeRetrieveParams, "stripe/params/issuing/dispute_retrieve_params"
@@ -710,9 +710,10 @@ module Stripe
       end
     end
   end
+end
 
-  # Ordered list for Stripe.eager_load! — same order as the original
-  # require calls so eager loading has no load-order surprises.
+module Stripe
+  # rubocop:disable Metrics/CollectionLiteralLength
   PARAM_FILES = %w[
     stripe/params/account_capability_list_params
     stripe/params/account_capability_retrieve_params
@@ -1329,4 +1330,5 @@ module Stripe
     stripe/params/webhook_endpoint_retrieve_params
     stripe/params/webhook_endpoint_update_params
   ].freeze
+  # rubocop:enable Metrics/CollectionLiteralLength
 end

--- a/lib/stripe/params.rb
+++ b/lib/stripe/params.rb
@@ -71,7 +71,8 @@ module Stripe
   autoload :CustomerBalanceTransactionUpdateParams, "stripe/params/customer_balance_transaction_update_params"
   autoload :CustomerCashBalanceRetrieveParams, "stripe/params/customer_cash_balance_retrieve_params"
   autoload :CustomerCashBalanceTransactionListParams, "stripe/params/customer_cash_balance_transaction_list_params"
-  autoload :CustomerCashBalanceTransactionRetrieveParams, "stripe/params/customer_cash_balance_transaction_retrieve_params"
+  autoload :CustomerCashBalanceTransactionRetrieveParams,
+           "stripe/params/customer_cash_balance_transaction_retrieve_params"
   autoload :CustomerCashBalanceUpdateParams, "stripe/params/customer_cash_balance_update_params"
   autoload :CustomerCreateFundingInstructionsParams, "stripe/params/customer_create_funding_instructions_params"
   autoload :CustomerCreateParams, "stripe/params/customer_create_params"
@@ -147,7 +148,8 @@ module Stripe
   autoload :MandateRetrieveParams, "stripe/params/mandate_retrieve_params"
   autoload :PaymentAttemptRecordListParams, "stripe/params/payment_attempt_record_list_params"
   autoload :PaymentAttemptRecordRetrieveParams, "stripe/params/payment_attempt_record_retrieve_params"
-  autoload :PaymentIntentAmountDetailsLineItemListParams, "stripe/params/payment_intent_amount_details_line_item_list_params"
+  autoload :PaymentIntentAmountDetailsLineItemListParams,
+           "stripe/params/payment_intent_amount_details_line_item_list_params"
   autoload :PaymentIntentApplyCustomerBalanceParams, "stripe/params/payment_intent_apply_customer_balance_params"
   autoload :PaymentIntentCancelParams, "stripe/params/payment_intent_cancel_params"
   autoload :PaymentIntentCaptureParams, "stripe/params/payment_intent_capture_params"
@@ -180,10 +182,14 @@ module Stripe
   autoload :PaymentMethodListParams, "stripe/params/payment_method_list_params"
   autoload :PaymentMethodRetrieveParams, "stripe/params/payment_method_retrieve_params"
   autoload :PaymentMethodUpdateParams, "stripe/params/payment_method_update_params"
-  autoload :PaymentRecordReportPaymentAttemptCanceledParams, "stripe/params/payment_record_report_payment_attempt_canceled_params"
-  autoload :PaymentRecordReportPaymentAttemptFailedParams, "stripe/params/payment_record_report_payment_attempt_failed_params"
-  autoload :PaymentRecordReportPaymentAttemptGuaranteedParams, "stripe/params/payment_record_report_payment_attempt_guaranteed_params"
-  autoload :PaymentRecordReportPaymentAttemptInformationalParams, "stripe/params/payment_record_report_payment_attempt_informational_params"
+  autoload :PaymentRecordReportPaymentAttemptCanceledParams,
+           "stripe/params/payment_record_report_payment_attempt_canceled_params"
+  autoload :PaymentRecordReportPaymentAttemptFailedParams,
+           "stripe/params/payment_record_report_payment_attempt_failed_params"
+  autoload :PaymentRecordReportPaymentAttemptGuaranteedParams,
+           "stripe/params/payment_record_report_payment_attempt_guaranteed_params"
+  autoload :PaymentRecordReportPaymentAttemptInformationalParams,
+           "stripe/params/payment_record_report_payment_attempt_informational_params"
   autoload :PaymentRecordReportPaymentAttemptParams, "stripe/params/payment_record_report_payment_attempt_params"
   autoload :PaymentRecordReportPaymentParams, "stripe/params/payment_record_report_payment_params"
   autoload :PaymentRecordReportRefundParams, "stripe/params/payment_record_report_refund_params"
@@ -557,7 +563,8 @@ module Stripe
       autoload :AuthorizationCaptureParams, "stripe/params/test_helpers/issuing/authorization_capture_params"
       autoload :AuthorizationCreateParams, "stripe/params/test_helpers/issuing/authorization_create_params"
       autoload :AuthorizationExpireParams, "stripe/params/test_helpers/issuing/authorization_expire_params"
-      autoload :AuthorizationFinalizeAmountParams, "stripe/params/test_helpers/issuing/authorization_finalize_amount_params"
+      autoload :AuthorizationFinalizeAmountParams,
+               "stripe/params/test_helpers/issuing/authorization_finalize_amount_params"
       autoload :AuthorizationIncrementParams, "stripe/params/test_helpers/issuing/authorization_increment_params"
       autoload :AuthorizationRespondParams, "stripe/params/test_helpers/issuing/authorization_respond_params"
       autoload :AuthorizationReverseParams, "stripe/params/test_helpers/issuing/authorization_reverse_params"
@@ -566,31 +573,42 @@ module Stripe
       autoload :CardReturnCardParams, "stripe/params/test_helpers/issuing/card_return_card_params"
       autoload :CardShipCardParams, "stripe/params/test_helpers/issuing/card_ship_card_params"
       autoload :CardSubmitCardParams, "stripe/params/test_helpers/issuing/card_submit_card_params"
-      autoload :PersonalizationDesignActivateParams, "stripe/params/test_helpers/issuing/personalization_design_activate_params"
-      autoload :PersonalizationDesignDeactivateParams, "stripe/params/test_helpers/issuing/personalization_design_deactivate_params"
-      autoload :PersonalizationDesignRejectParams, "stripe/params/test_helpers/issuing/personalization_design_reject_params"
-      autoload :TransactionCreateForceCaptureParams, "stripe/params/test_helpers/issuing/transaction_create_force_capture_params"
-      autoload :TransactionCreateUnlinkedRefundParams, "stripe/params/test_helpers/issuing/transaction_create_unlinked_refund_params"
+      autoload :PersonalizationDesignActivateParams,
+               "stripe/params/test_helpers/issuing/personalization_design_activate_params"
+      autoload :PersonalizationDesignDeactivateParams,
+               "stripe/params/test_helpers/issuing/personalization_design_deactivate_params"
+      autoload :PersonalizationDesignRejectParams,
+               "stripe/params/test_helpers/issuing/personalization_design_reject_params"
+      autoload :TransactionCreateForceCaptureParams,
+               "stripe/params/test_helpers/issuing/transaction_create_force_capture_params"
+      autoload :TransactionCreateUnlinkedRefundParams,
+               "stripe/params/test_helpers/issuing/transaction_create_unlinked_refund_params"
       autoload :TransactionRefundParams, "stripe/params/test_helpers/issuing/transaction_refund_params"
     end
 
     module Terminal
-      autoload :ReaderPresentPaymentMethodParams, "stripe/params/test_helpers/terminal/reader_present_payment_method_params"
-      autoload :ReaderSucceedInputCollectionParams, "stripe/params/test_helpers/terminal/reader_succeed_input_collection_params"
-      autoload :ReaderTimeoutInputCollectionParams, "stripe/params/test_helpers/terminal/reader_timeout_input_collection_params"
+      autoload :ReaderPresentPaymentMethodParams,
+               "stripe/params/test_helpers/terminal/reader_present_payment_method_params"
+      autoload :ReaderSucceedInputCollectionParams,
+               "stripe/params/test_helpers/terminal/reader_succeed_input_collection_params"
+      autoload :ReaderTimeoutInputCollectionParams,
+               "stripe/params/test_helpers/terminal/reader_timeout_input_collection_params"
     end
 
     module Treasury
       autoload :InboundTransferFailParams, "stripe/params/test_helpers/treasury/inbound_transfer_fail_params"
-      autoload :InboundTransferReturnInboundTransferParams, "stripe/params/test_helpers/treasury/inbound_transfer_return_inbound_transfer_params"
+      autoload :InboundTransferReturnInboundTransferParams,
+               "stripe/params/test_helpers/treasury/inbound_transfer_return_inbound_transfer_params"
       autoload :InboundTransferSucceedParams, "stripe/params/test_helpers/treasury/inbound_transfer_succeed_params"
       autoload :OutboundPaymentFailParams, "stripe/params/test_helpers/treasury/outbound_payment_fail_params"
       autoload :OutboundPaymentPostParams, "stripe/params/test_helpers/treasury/outbound_payment_post_params"
-      autoload :OutboundPaymentReturnOutboundPaymentParams, "stripe/params/test_helpers/treasury/outbound_payment_return_outbound_payment_params"
+      autoload :OutboundPaymentReturnOutboundPaymentParams,
+               "stripe/params/test_helpers/treasury/outbound_payment_return_outbound_payment_params"
       autoload :OutboundPaymentUpdateParams, "stripe/params/test_helpers/treasury/outbound_payment_update_params"
       autoload :OutboundTransferFailParams, "stripe/params/test_helpers/treasury/outbound_transfer_fail_params"
       autoload :OutboundTransferPostParams, "stripe/params/test_helpers/treasury/outbound_transfer_post_params"
-      autoload :OutboundTransferReturnOutboundTransferParams, "stripe/params/test_helpers/treasury/outbound_transfer_return_outbound_transfer_params"
+      autoload :OutboundTransferReturnOutboundTransferParams,
+               "stripe/params/test_helpers/treasury/outbound_transfer_return_outbound_transfer_params"
       autoload :OutboundTransferUpdateParams, "stripe/params/test_helpers/treasury/outbound_transfer_update_params"
       autoload :ReceivedCreditCreateParams, "stripe/params/test_helpers/treasury/received_credit_create_params"
       autoload :ReceivedDebitCreateParams, "stripe/params/test_helpers/treasury/received_debit_create_params"
@@ -606,10 +624,12 @@ module Stripe
     autoload :DebitReversalRetrieveParams, "stripe/params/treasury/debit_reversal_retrieve_params"
     autoload :FinancialAccountCloseParams, "stripe/params/treasury/financial_account_close_params"
     autoload :FinancialAccountCreateParams, "stripe/params/treasury/financial_account_create_params"
-    autoload :FinancialAccountFeaturesRetrieveParams, "stripe/params/treasury/financial_account_features_retrieve_params"
+    autoload :FinancialAccountFeaturesRetrieveParams,
+             "stripe/params/treasury/financial_account_features_retrieve_params"
     autoload :FinancialAccountFeaturesUpdateParams, "stripe/params/treasury/financial_account_features_update_params"
     autoload :FinancialAccountListParams, "stripe/params/treasury/financial_account_list_params"
-    autoload :FinancialAccountRetrieveFeaturesParams, "stripe/params/treasury/financial_account_retrieve_features_params"
+    autoload :FinancialAccountRetrieveFeaturesParams,
+             "stripe/params/treasury/financial_account_retrieve_features_params"
     autoload :FinancialAccountRetrieveParams, "stripe/params/treasury/financial_account_retrieve_params"
     autoload :FinancialAccountUpdateFeaturesParams, "stripe/params/treasury/financial_account_update_features_params"
     autoload :FinancialAccountUpdateParams, "stripe/params/treasury/financial_account_update_params"
@@ -618,7 +638,8 @@ module Stripe
     autoload :InboundTransferFailParams, "stripe/params/treasury/inbound_transfer_fail_params"
     autoload :InboundTransferListParams, "stripe/params/treasury/inbound_transfer_list_params"
     autoload :InboundTransferRetrieveParams, "stripe/params/treasury/inbound_transfer_retrieve_params"
-    autoload :InboundTransferReturnInboundTransferParams, "stripe/params/treasury/inbound_transfer_return_inbound_transfer_params"
+    autoload :InboundTransferReturnInboundTransferParams,
+             "stripe/params/treasury/inbound_transfer_return_inbound_transfer_params"
     autoload :InboundTransferSucceedParams, "stripe/params/treasury/inbound_transfer_succeed_params"
     autoload :OutboundPaymentCancelParams, "stripe/params/treasury/outbound_payment_cancel_params"
     autoload :OutboundPaymentCreateParams, "stripe/params/treasury/outbound_payment_create_params"
@@ -626,7 +647,8 @@ module Stripe
     autoload :OutboundPaymentListParams, "stripe/params/treasury/outbound_payment_list_params"
     autoload :OutboundPaymentPostParams, "stripe/params/treasury/outbound_payment_post_params"
     autoload :OutboundPaymentRetrieveParams, "stripe/params/treasury/outbound_payment_retrieve_params"
-    autoload :OutboundPaymentReturnOutboundPaymentParams, "stripe/params/treasury/outbound_payment_return_outbound_payment_params"
+    autoload :OutboundPaymentReturnOutboundPaymentParams,
+             "stripe/params/treasury/outbound_payment_return_outbound_payment_params"
     autoload :OutboundPaymentUpdateParams, "stripe/params/treasury/outbound_payment_update_params"
     autoload :OutboundTransferCancelParams, "stripe/params/treasury/outbound_transfer_cancel_params"
     autoload :OutboundTransferCreateParams, "stripe/params/treasury/outbound_transfer_create_params"
@@ -634,7 +656,8 @@ module Stripe
     autoload :OutboundTransferListParams, "stripe/params/treasury/outbound_transfer_list_params"
     autoload :OutboundTransferPostParams, "stripe/params/treasury/outbound_transfer_post_params"
     autoload :OutboundTransferRetrieveParams, "stripe/params/treasury/outbound_transfer_retrieve_params"
-    autoload :OutboundTransferReturnOutboundTransferParams, "stripe/params/treasury/outbound_transfer_return_outbound_transfer_params"
+    autoload :OutboundTransferReturnOutboundTransferParams,
+             "stripe/params/treasury/outbound_transfer_return_outbound_transfer_params"
     autoload :OutboundTransferUpdateParams, "stripe/params/treasury/outbound_transfer_update_params"
     autoload :ReceivedCreditCreateParams, "stripe/params/treasury/received_credit_create_params"
     autoload :ReceivedCreditListParams, "stripe/params/treasury/received_credit_list_params"
@@ -649,7 +672,6 @@ module Stripe
   end
 
   module V2
-
     module Billing
       autoload :MeterEventAdjustmentCreateParams, "stripe/params/v2/billing/meter_event_adjustment_create_params"
       autoload :MeterEventCreateParams, "stripe/params/v2/billing/meter_event_create_params"

--- a/lib/stripe/railtie.rb
+++ b/lib/stripe/railtie.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Stripe
+  class Railtie < ::Rails::Railtie
+    config.eager_load_namespaces << Stripe
+  end
+end

--- a/lib/stripe/railtie.rb
+++ b/lib/stripe/railtie.rb
@@ -1,3 +1,4 @@
+# typed: ignore
 # frozen_string_literal: true
 
 module Stripe

--- a/lib/stripe/resources.rb
+++ b/lib/stripe/resources.rb
@@ -1,181 +1,459 @@
 # File generated from our OpenAPI spec
 # frozen_string_literal: true
 
-require "stripe/resources/account"
-require "stripe/resources/account_link"
-require "stripe/resources/account_session"
-require "stripe/resources/apple_pay_domain"
-require "stripe/resources/application"
-require "stripe/resources/application_fee"
-require "stripe/resources/application_fee_refund"
-require "stripe/resources/apps/secret"
-require "stripe/resources/balance"
-require "stripe/resources/balance_settings"
-require "stripe/resources/balance_transaction"
-require "stripe/resources/bank_account"
-require "stripe/resources/billing/alert"
-require "stripe/resources/billing/alert_triggered"
-require "stripe/resources/billing/credit_balance_summary"
-require "stripe/resources/billing/credit_balance_transaction"
-require "stripe/resources/billing/credit_grant"
-require "stripe/resources/billing/meter"
-require "stripe/resources/billing/meter_event"
-require "stripe/resources/billing/meter_event_adjustment"
-require "stripe/resources/billing/meter_event_summary"
-require "stripe/resources/billing_portal/configuration"
-require "stripe/resources/billing_portal/session"
-require "stripe/resources/capability"
-require "stripe/resources/card"
-require "stripe/resources/cash_balance"
-require "stripe/resources/charge"
-require "stripe/resources/checkout/session"
-require "stripe/resources/climate/order"
-require "stripe/resources/climate/product"
-require "stripe/resources/climate/supplier"
-require "stripe/resources/confirmation_token"
-require "stripe/resources/connect_collection_transfer"
-require "stripe/resources/country_spec"
-require "stripe/resources/coupon"
-require "stripe/resources/credit_note"
-require "stripe/resources/credit_note_line_item"
-require "stripe/resources/customer"
-require "stripe/resources/customer_balance_transaction"
-require "stripe/resources/customer_cash_balance_transaction"
-require "stripe/resources/customer_session"
-require "stripe/resources/discount"
-require "stripe/resources/dispute"
-require "stripe/resources/entitlements/active_entitlement"
-require "stripe/resources/entitlements/active_entitlement_summary"
-require "stripe/resources/entitlements/feature"
-require "stripe/resources/ephemeral_key"
-require "stripe/resources/event"
-require "stripe/resources/exchange_rate"
-require "stripe/resources/file"
-require "stripe/resources/file_link"
-require "stripe/resources/financial_connections/account"
-require "stripe/resources/financial_connections/account_owner"
-require "stripe/resources/financial_connections/account_ownership"
-require "stripe/resources/financial_connections/session"
-require "stripe/resources/financial_connections/transaction"
-require "stripe/resources/forwarding/request"
-require "stripe/resources/funding_instructions"
-require "stripe/resources/identity/verification_report"
-require "stripe/resources/identity/verification_session"
-require "stripe/resources/invoice"
-require "stripe/resources/invoice_item"
-require "stripe/resources/invoice_line_item"
-require "stripe/resources/invoice_payment"
-require "stripe/resources/invoice_rendering_template"
-require "stripe/resources/issuing/authorization"
-require "stripe/resources/issuing/card"
-require "stripe/resources/issuing/cardholder"
-require "stripe/resources/issuing/dispute"
-require "stripe/resources/issuing/personalization_design"
-require "stripe/resources/issuing/physical_bundle"
-require "stripe/resources/issuing/token"
-require "stripe/resources/issuing/transaction"
-require "stripe/resources/line_item"
-require "stripe/resources/login_link"
-require "stripe/resources/mandate"
-require "stripe/resources/payment_attempt_record"
-require "stripe/resources/payment_intent"
-require "stripe/resources/payment_intent_amount_details_line_item"
-require "stripe/resources/payment_link"
-require "stripe/resources/payment_method"
-require "stripe/resources/payment_method_configuration"
-require "stripe/resources/payment_method_domain"
-require "stripe/resources/payment_record"
-require "stripe/resources/payout"
-require "stripe/resources/person"
-require "stripe/resources/plan"
-require "stripe/resources/price"
-require "stripe/resources/product"
-require "stripe/resources/product_feature"
-require "stripe/resources/promotion_code"
-require "stripe/resources/quote"
-require "stripe/resources/radar/early_fraud_warning"
-require "stripe/resources/radar/payment_evaluation"
-require "stripe/resources/radar/value_list"
-require "stripe/resources/radar/value_list_item"
-require "stripe/resources/refund"
-require "stripe/resources/reporting/report_run"
-require "stripe/resources/reporting/report_type"
-require "stripe/resources/reserve/hold"
-require "stripe/resources/reserve/plan"
-require "stripe/resources/reserve/release"
-require "stripe/resources/reserve_transaction"
-require "stripe/resources/reversal"
-require "stripe/resources/review"
-require "stripe/resources/setup_attempt"
-require "stripe/resources/setup_intent"
-require "stripe/resources/shipping_rate"
-require "stripe/resources/sigma/scheduled_query_run"
-require "stripe/resources/source"
-require "stripe/resources/source_mandate_notification"
-require "stripe/resources/source_transaction"
-require "stripe/resources/subscription"
-require "stripe/resources/subscription_item"
-require "stripe/resources/subscription_schedule"
-require "stripe/resources/tax/association"
-require "stripe/resources/tax/calculation"
-require "stripe/resources/tax/calculation_line_item"
-require "stripe/resources/tax/registration"
-require "stripe/resources/tax/settings"
-require "stripe/resources/tax/transaction"
-require "stripe/resources/tax/transaction_line_item"
-require "stripe/resources/tax_code"
-require "stripe/resources/tax_deducted_at_source"
-require "stripe/resources/tax_id"
-require "stripe/resources/tax_rate"
-require "stripe/resources/terminal/configuration"
-require "stripe/resources/terminal/connection_token"
-require "stripe/resources/terminal/location"
-require "stripe/resources/terminal/onboarding_link"
-require "stripe/resources/terminal/reader"
-require "stripe/resources/test_helpers/test_clock"
-require "stripe/resources/token"
-require "stripe/resources/topup"
-require "stripe/resources/transfer"
-require "stripe/resources/treasury/credit_reversal"
-require "stripe/resources/treasury/debit_reversal"
-require "stripe/resources/treasury/financial_account"
-require "stripe/resources/treasury/financial_account_features"
-require "stripe/resources/treasury/inbound_transfer"
-require "stripe/resources/treasury/outbound_payment"
-require "stripe/resources/treasury/outbound_transfer"
-require "stripe/resources/treasury/received_credit"
-require "stripe/resources/treasury/received_debit"
-require "stripe/resources/treasury/transaction"
-require "stripe/resources/treasury/transaction_entry"
-require "stripe/resources/v2/billing/meter_event"
-require "stripe/resources/v2/billing/meter_event_adjustment"
-require "stripe/resources/v2/billing/meter_event_session"
-require "stripe/resources/v2/core/account"
-require "stripe/resources/v2/core/account_link"
-require "stripe/resources/v2/core/account_person"
-require "stripe/resources/v2/core/account_person_token"
-require "stripe/resources/v2/core/account_token"
-require "stripe/resources/v2/core/event"
-require "stripe/resources/v2/core/event_destination"
-require "stripe/resources/v2/deleted_object"
-require "stripe/resources/webhook_endpoint"
-require "stripe/events/v1_billing_meter_error_report_triggered_event"
-require "stripe/events/v1_billing_meter_no_meter_found_event"
-require "stripe/events/v2_core_account_closed_event"
-require "stripe/events/v2_core_account_created_event"
-require "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
-require "stripe/events/v2_core_account_including_configuration_customer_updated_event"
-require "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
-require "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
-require "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
-require "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
-require "stripe/events/v2_core_account_including_defaults_updated_event"
-require "stripe/events/v2_core_account_including_future_requirements_updated_event"
-require "stripe/events/v2_core_account_including_identity_updated_event"
-require "stripe/events/v2_core_account_including_requirements_updated_event"
-require "stripe/events/v2_core_account_link_returned_event"
-require "stripe/events/v2_core_account_person_created_event"
-require "stripe/events/v2_core_account_person_deleted_event"
-require "stripe/events/v2_core_account_person_updated_event"
-require "stripe/events/v2_core_account_updated_event"
-require "stripe/events/v2_core_event_destination_ping_event"
+module Stripe
+  autoload :Account, "stripe/resources/account"
+  autoload :AccountLink, "stripe/resources/account_link"
+  autoload :AccountSession, "stripe/resources/account_session"
+  autoload :ApplePayDomain, "stripe/resources/apple_pay_domain"
+  autoload :Application, "stripe/resources/application"
+  autoload :ApplicationFee, "stripe/resources/application_fee"
+  autoload :ApplicationFeeRefund, "stripe/resources/application_fee_refund"
+  autoload :Balance, "stripe/resources/balance"
+  autoload :BalanceSettings, "stripe/resources/balance_settings"
+  autoload :BalanceTransaction, "stripe/resources/balance_transaction"
+  autoload :BankAccount, "stripe/resources/bank_account"
+  autoload :Capability, "stripe/resources/capability"
+  autoload :Card, "stripe/resources/card"
+  autoload :CashBalance, "stripe/resources/cash_balance"
+  autoload :Charge, "stripe/resources/charge"
+  autoload :ConfirmationToken, "stripe/resources/confirmation_token"
+  autoload :ConnectCollectionTransfer, "stripe/resources/connect_collection_transfer"
+  autoload :CountrySpec, "stripe/resources/country_spec"
+  autoload :Coupon, "stripe/resources/coupon"
+  autoload :CreditNote, "stripe/resources/credit_note"
+  autoload :CreditNoteLineItem, "stripe/resources/credit_note_line_item"
+  autoload :Customer, "stripe/resources/customer"
+  autoload :CustomerBalanceTransaction, "stripe/resources/customer_balance_transaction"
+  autoload :CustomerCashBalanceTransaction, "stripe/resources/customer_cash_balance_transaction"
+  autoload :CustomerSession, "stripe/resources/customer_session"
+  autoload :Discount, "stripe/resources/discount"
+  autoload :Dispute, "stripe/resources/dispute"
+  autoload :EphemeralKey, "stripe/resources/ephemeral_key"
+  autoload :Event, "stripe/resources/event"
+  autoload :ExchangeRate, "stripe/resources/exchange_rate"
+  autoload :File, "stripe/resources/file"
+  autoload :FileLink, "stripe/resources/file_link"
+  autoload :FundingInstructions, "stripe/resources/funding_instructions"
+  autoload :Invoice, "stripe/resources/invoice"
+  autoload :InvoiceItem, "stripe/resources/invoice_item"
+  autoload :InvoiceLineItem, "stripe/resources/invoice_line_item"
+  autoload :InvoicePayment, "stripe/resources/invoice_payment"
+  autoload :InvoiceRenderingTemplate, "stripe/resources/invoice_rendering_template"
+  autoload :LineItem, "stripe/resources/line_item"
+  autoload :LoginLink, "stripe/resources/login_link"
+  autoload :Mandate, "stripe/resources/mandate"
+  autoload :PaymentAttemptRecord, "stripe/resources/payment_attempt_record"
+  autoload :PaymentIntent, "stripe/resources/payment_intent"
+  autoload :PaymentIntentAmountDetailsLineItem, "stripe/resources/payment_intent_amount_details_line_item"
+  autoload :PaymentLink, "stripe/resources/payment_link"
+  autoload :PaymentMethod, "stripe/resources/payment_method"
+  autoload :PaymentMethodConfiguration, "stripe/resources/payment_method_configuration"
+  autoload :PaymentMethodDomain, "stripe/resources/payment_method_domain"
+  autoload :PaymentRecord, "stripe/resources/payment_record"
+  autoload :Payout, "stripe/resources/payout"
+  autoload :Person, "stripe/resources/person"
+  autoload :Plan, "stripe/resources/plan"
+  autoload :Price, "stripe/resources/price"
+  autoload :Product, "stripe/resources/product"
+  autoload :ProductFeature, "stripe/resources/product_feature"
+  autoload :PromotionCode, "stripe/resources/promotion_code"
+  autoload :Quote, "stripe/resources/quote"
+  autoload :Refund, "stripe/resources/refund"
+  autoload :ReserveTransaction, "stripe/resources/reserve_transaction"
+  autoload :Reversal, "stripe/resources/reversal"
+  autoload :Review, "stripe/resources/review"
+  autoload :SetupAttempt, "stripe/resources/setup_attempt"
+  autoload :SetupIntent, "stripe/resources/setup_intent"
+  autoload :ShippingRate, "stripe/resources/shipping_rate"
+  autoload :Source, "stripe/resources/source"
+  autoload :SourceMandateNotification, "stripe/resources/source_mandate_notification"
+  autoload :SourceTransaction, "stripe/resources/source_transaction"
+  autoload :Subscription, "stripe/resources/subscription"
+  autoload :SubscriptionItem, "stripe/resources/subscription_item"
+  autoload :SubscriptionSchedule, "stripe/resources/subscription_schedule"
+  autoload :TaxCode, "stripe/resources/tax_code"
+  autoload :TaxDeductedAtSource, "stripe/resources/tax_deducted_at_source"
+  autoload :TaxId, "stripe/resources/tax_id"
+  autoload :TaxRate, "stripe/resources/tax_rate"
+  autoload :Token, "stripe/resources/token"
+  autoload :Topup, "stripe/resources/topup"
+  autoload :Transfer, "stripe/resources/transfer"
+  autoload :WebhookEndpoint, "stripe/resources/webhook_endpoint"
+
+  module Apps
+    autoload :Secret, "stripe/resources/apps/secret"
+  end
+
+  module Billing
+    autoload :Alert, "stripe/resources/billing/alert"
+    autoload :AlertTriggered, "stripe/resources/billing/alert_triggered"
+    autoload :CreditBalanceSummary, "stripe/resources/billing/credit_balance_summary"
+    autoload :CreditBalanceTransaction, "stripe/resources/billing/credit_balance_transaction"
+    autoload :CreditGrant, "stripe/resources/billing/credit_grant"
+    autoload :Meter, "stripe/resources/billing/meter"
+    autoload :MeterEvent, "stripe/resources/billing/meter_event"
+    autoload :MeterEventAdjustment, "stripe/resources/billing/meter_event_adjustment"
+    autoload :MeterEventSummary, "stripe/resources/billing/meter_event_summary"
+  end
+
+  module BillingPortal
+    autoload :Configuration, "stripe/resources/billing_portal/configuration"
+    autoload :Session, "stripe/resources/billing_portal/session"
+  end
+
+  module Checkout
+    autoload :Session, "stripe/resources/checkout/session"
+  end
+
+  module Climate
+    autoload :Order, "stripe/resources/climate/order"
+    autoload :Product, "stripe/resources/climate/product"
+    autoload :Supplier, "stripe/resources/climate/supplier"
+  end
+
+  module Entitlements
+    autoload :ActiveEntitlement, "stripe/resources/entitlements/active_entitlement"
+    autoload :ActiveEntitlementSummary, "stripe/resources/entitlements/active_entitlement_summary"
+    autoload :Feature, "stripe/resources/entitlements/feature"
+  end
+
+  module Events
+    autoload :V1BillingMeterErrorReportTriggeredEvent, "stripe/events/v1_billing_meter_error_report_triggered_event"
+    autoload :V1BillingMeterErrorReportTriggeredEventNotification, "stripe/events/v1_billing_meter_error_report_triggered_event"
+    autoload :V1BillingMeterNoMeterFoundEvent, "stripe/events/v1_billing_meter_no_meter_found_event"
+    autoload :V1BillingMeterNoMeterFoundEventNotification, "stripe/events/v1_billing_meter_no_meter_found_event"
+    autoload :V2CoreAccountClosedEvent, "stripe/events/v2_core_account_closed_event"
+    autoload :V2CoreAccountClosedEventNotification, "stripe/events/v2_core_account_closed_event"
+    autoload :V2CoreAccountCreatedEvent, "stripe/events/v2_core_account_created_event"
+    autoload :V2CoreAccountCreatedEventNotification, "stripe/events/v2_core_account_created_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEvent, "stripe/events/v2_core_account_including_configuration_customer_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_customer_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEvent, "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEvent, "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
+    autoload :V2CoreAccountIncludingDefaultsUpdatedEvent, "stripe/events/v2_core_account_including_defaults_updated_event"
+    autoload :V2CoreAccountIncludingDefaultsUpdatedEventNotification, "stripe/events/v2_core_account_including_defaults_updated_event"
+    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEvent, "stripe/events/v2_core_account_including_future_requirements_updated_event"
+    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, "stripe/events/v2_core_account_including_future_requirements_updated_event"
+    autoload :V2CoreAccountIncludingIdentityUpdatedEvent, "stripe/events/v2_core_account_including_identity_updated_event"
+    autoload :V2CoreAccountIncludingIdentityUpdatedEventNotification, "stripe/events/v2_core_account_including_identity_updated_event"
+    autoload :V2CoreAccountIncludingRequirementsUpdatedEvent, "stripe/events/v2_core_account_including_requirements_updated_event"
+    autoload :V2CoreAccountIncludingRequirementsUpdatedEventNotification, "stripe/events/v2_core_account_including_requirements_updated_event"
+    autoload :V2CoreAccountLinkReturnedEvent, "stripe/events/v2_core_account_link_returned_event"
+    autoload :V2CoreAccountLinkReturnedEventNotification, "stripe/events/v2_core_account_link_returned_event"
+    autoload :V2CoreAccountPersonCreatedEvent, "stripe/events/v2_core_account_person_created_event"
+    autoload :V2CoreAccountPersonCreatedEventNotification, "stripe/events/v2_core_account_person_created_event"
+    autoload :V2CoreAccountPersonDeletedEvent, "stripe/events/v2_core_account_person_deleted_event"
+    autoload :V2CoreAccountPersonDeletedEventNotification, "stripe/events/v2_core_account_person_deleted_event"
+    autoload :V2CoreAccountPersonUpdatedEvent, "stripe/events/v2_core_account_person_updated_event"
+    autoload :V2CoreAccountPersonUpdatedEventNotification, "stripe/events/v2_core_account_person_updated_event"
+    autoload :V2CoreAccountUpdatedEvent, "stripe/events/v2_core_account_updated_event"
+    autoload :V2CoreAccountUpdatedEventNotification, "stripe/events/v2_core_account_updated_event"
+    autoload :V2CoreEventDestinationPingEvent, "stripe/events/v2_core_event_destination_ping_event"
+    autoload :V2CoreEventDestinationPingEventNotification, "stripe/events/v2_core_event_destination_ping_event"
+  end
+
+  module FinancialConnections
+    autoload :Account, "stripe/resources/financial_connections/account"
+    autoload :AccountOwner, "stripe/resources/financial_connections/account_owner"
+    autoload :AccountOwnership, "stripe/resources/financial_connections/account_ownership"
+    autoload :Session, "stripe/resources/financial_connections/session"
+    autoload :Transaction, "stripe/resources/financial_connections/transaction"
+  end
+
+  module Forwarding
+    autoload :Request, "stripe/resources/forwarding/request"
+  end
+
+  module Identity
+    autoload :VerificationReport, "stripe/resources/identity/verification_report"
+    autoload :VerificationSession, "stripe/resources/identity/verification_session"
+  end
+
+  module Issuing
+    autoload :Authorization, "stripe/resources/issuing/authorization"
+    autoload :Card, "stripe/resources/issuing/card"
+    autoload :Cardholder, "stripe/resources/issuing/cardholder"
+    autoload :Dispute, "stripe/resources/issuing/dispute"
+    autoload :PersonalizationDesign, "stripe/resources/issuing/personalization_design"
+    autoload :PhysicalBundle, "stripe/resources/issuing/physical_bundle"
+    autoload :Token, "stripe/resources/issuing/token"
+    autoload :Transaction, "stripe/resources/issuing/transaction"
+  end
+
+  module Radar
+    autoload :EarlyFraudWarning, "stripe/resources/radar/early_fraud_warning"
+    autoload :PaymentEvaluation, "stripe/resources/radar/payment_evaluation"
+    autoload :ValueList, "stripe/resources/radar/value_list"
+    autoload :ValueListItem, "stripe/resources/radar/value_list_item"
+  end
+
+  module Reporting
+    autoload :ReportRun, "stripe/resources/reporting/report_run"
+    autoload :ReportType, "stripe/resources/reporting/report_type"
+  end
+
+  module Reserve
+    autoload :Hold, "stripe/resources/reserve/hold"
+    autoload :Plan, "stripe/resources/reserve/plan"
+    autoload :Release, "stripe/resources/reserve/release"
+  end
+
+  module Sigma
+    autoload :ScheduledQueryRun, "stripe/resources/sigma/scheduled_query_run"
+  end
+
+  module Tax
+    autoload :Association, "stripe/resources/tax/association"
+    autoload :Calculation, "stripe/resources/tax/calculation"
+    autoload :CalculationLineItem, "stripe/resources/tax/calculation_line_item"
+    autoload :Registration, "stripe/resources/tax/registration"
+    autoload :Settings, "stripe/resources/tax/settings"
+    autoload :Transaction, "stripe/resources/tax/transaction"
+    autoload :TransactionLineItem, "stripe/resources/tax/transaction_line_item"
+  end
+
+  module Terminal
+    autoload :Configuration, "stripe/resources/terminal/configuration"
+    autoload :ConnectionToken, "stripe/resources/terminal/connection_token"
+    autoload :Location, "stripe/resources/terminal/location"
+    autoload :OnboardingLink, "stripe/resources/terminal/onboarding_link"
+    autoload :Reader, "stripe/resources/terminal/reader"
+  end
+
+  module TestHelpers
+    autoload :TestClock, "stripe/resources/test_helpers/test_clock"
+  end
+
+  module Treasury
+    autoload :CreditReversal, "stripe/resources/treasury/credit_reversal"
+    autoload :DebitReversal, "stripe/resources/treasury/debit_reversal"
+    autoload :FinancialAccount, "stripe/resources/treasury/financial_account"
+    autoload :FinancialAccountFeatures, "stripe/resources/treasury/financial_account_features"
+    autoload :InboundTransfer, "stripe/resources/treasury/inbound_transfer"
+    autoload :OutboundPayment, "stripe/resources/treasury/outbound_payment"
+    autoload :OutboundTransfer, "stripe/resources/treasury/outbound_transfer"
+    autoload :ReceivedCredit, "stripe/resources/treasury/received_credit"
+    autoload :ReceivedDebit, "stripe/resources/treasury/received_debit"
+    autoload :Transaction, "stripe/resources/treasury/transaction"
+    autoload :TransactionEntry, "stripe/resources/treasury/transaction_entry"
+  end
+
+  module V2
+    autoload :Amount, "stripe/resources/v2/amount"
+    autoload :DeletedObject, "stripe/resources/v2/deleted_object"
+
+    module Billing
+      autoload :MeterEvent, "stripe/resources/v2/billing/meter_event"
+      autoload :MeterEventAdjustment, "stripe/resources/v2/billing/meter_event_adjustment"
+      autoload :MeterEventSession, "stripe/resources/v2/billing/meter_event_session"
+    end
+
+    module Core
+      autoload :Account, "stripe/resources/v2/core/account"
+      autoload :AccountLink, "stripe/resources/v2/core/account_link"
+      autoload :AccountPerson, "stripe/resources/v2/core/account_person"
+      autoload :AccountPersonToken, "stripe/resources/v2/core/account_person_token"
+      autoload :AccountToken, "stripe/resources/v2/core/account_token"
+      autoload :Event, "stripe/resources/v2/core/event"
+      autoload :EventDestination, "stripe/resources/v2/core/event_destination"
+      autoload :EventNotification, "stripe/resources/v2/core/event_notification"
+      autoload :EventReason, "stripe/resources/v2/core/event_notification"
+      autoload :EventReasonRequest, "stripe/resources/v2/core/event_notification"
+      autoload :RelatedObject, "stripe/resources/v2/core/event_notification"
+    end
+  end
+
+  # Ordered list for Stripe.eager_load! — same order as the original
+  # require calls so eager loading has no load-order surprises.
+  RESOURCE_FILES = %w[
+    stripe/resources/v2/amount
+    stripe/resources/v2/deleted_object
+    stripe/resources/v2/core/event_notification
+    stripe/resources/account
+    stripe/resources/account_link
+    stripe/resources/account_session
+    stripe/resources/apple_pay_domain
+    stripe/resources/application
+    stripe/resources/application_fee
+    stripe/resources/application_fee_refund
+    stripe/resources/apps/secret
+    stripe/resources/balance
+    stripe/resources/balance_settings
+    stripe/resources/balance_transaction
+    stripe/resources/bank_account
+    stripe/resources/billing/alert
+    stripe/resources/billing/alert_triggered
+    stripe/resources/billing/credit_balance_summary
+    stripe/resources/billing/credit_balance_transaction
+    stripe/resources/billing/credit_grant
+    stripe/resources/billing/meter
+    stripe/resources/billing/meter_event
+    stripe/resources/billing/meter_event_adjustment
+    stripe/resources/billing/meter_event_summary
+    stripe/resources/billing_portal/configuration
+    stripe/resources/billing_portal/session
+    stripe/resources/capability
+    stripe/resources/card
+    stripe/resources/cash_balance
+    stripe/resources/charge
+    stripe/resources/checkout/session
+    stripe/resources/climate/order
+    stripe/resources/climate/product
+    stripe/resources/climate/supplier
+    stripe/resources/confirmation_token
+    stripe/resources/connect_collection_transfer
+    stripe/resources/country_spec
+    stripe/resources/coupon
+    stripe/resources/credit_note
+    stripe/resources/credit_note_line_item
+    stripe/resources/customer
+    stripe/resources/customer_balance_transaction
+    stripe/resources/customer_cash_balance_transaction
+    stripe/resources/customer_session
+    stripe/resources/discount
+    stripe/resources/dispute
+    stripe/resources/entitlements/active_entitlement
+    stripe/resources/entitlements/active_entitlement_summary
+    stripe/resources/entitlements/feature
+    stripe/resources/ephemeral_key
+    stripe/resources/event
+    stripe/resources/exchange_rate
+    stripe/resources/file
+    stripe/resources/file_link
+    stripe/resources/financial_connections/account
+    stripe/resources/financial_connections/account_owner
+    stripe/resources/financial_connections/account_ownership
+    stripe/resources/financial_connections/session
+    stripe/resources/financial_connections/transaction
+    stripe/resources/forwarding/request
+    stripe/resources/funding_instructions
+    stripe/resources/identity/verification_report
+    stripe/resources/identity/verification_session
+    stripe/resources/invoice
+    stripe/resources/invoice_item
+    stripe/resources/invoice_line_item
+    stripe/resources/invoice_payment
+    stripe/resources/invoice_rendering_template
+    stripe/resources/issuing/authorization
+    stripe/resources/issuing/card
+    stripe/resources/issuing/cardholder
+    stripe/resources/issuing/dispute
+    stripe/resources/issuing/personalization_design
+    stripe/resources/issuing/physical_bundle
+    stripe/resources/issuing/token
+    stripe/resources/issuing/transaction
+    stripe/resources/line_item
+    stripe/resources/login_link
+    stripe/resources/mandate
+    stripe/resources/payment_attempt_record
+    stripe/resources/payment_intent
+    stripe/resources/payment_intent_amount_details_line_item
+    stripe/resources/payment_link
+    stripe/resources/payment_method
+    stripe/resources/payment_method_configuration
+    stripe/resources/payment_method_domain
+    stripe/resources/payment_record
+    stripe/resources/payout
+    stripe/resources/person
+    stripe/resources/plan
+    stripe/resources/price
+    stripe/resources/product
+    stripe/resources/product_feature
+    stripe/resources/promotion_code
+    stripe/resources/quote
+    stripe/resources/radar/early_fraud_warning
+    stripe/resources/radar/payment_evaluation
+    stripe/resources/radar/value_list
+    stripe/resources/radar/value_list_item
+    stripe/resources/refund
+    stripe/resources/reporting/report_run
+    stripe/resources/reporting/report_type
+    stripe/resources/reserve/hold
+    stripe/resources/reserve/plan
+    stripe/resources/reserve/release
+    stripe/resources/reserve_transaction
+    stripe/resources/reversal
+    stripe/resources/review
+    stripe/resources/setup_attempt
+    stripe/resources/setup_intent
+    stripe/resources/shipping_rate
+    stripe/resources/sigma/scheduled_query_run
+    stripe/resources/source
+    stripe/resources/source_mandate_notification
+    stripe/resources/source_transaction
+    stripe/resources/subscription
+    stripe/resources/subscription_item
+    stripe/resources/subscription_schedule
+    stripe/resources/tax/association
+    stripe/resources/tax/calculation
+    stripe/resources/tax/calculation_line_item
+    stripe/resources/tax/registration
+    stripe/resources/tax/settings
+    stripe/resources/tax/transaction
+    stripe/resources/tax/transaction_line_item
+    stripe/resources/tax_code
+    stripe/resources/tax_deducted_at_source
+    stripe/resources/tax_id
+    stripe/resources/tax_rate
+    stripe/resources/terminal/configuration
+    stripe/resources/terminal/connection_token
+    stripe/resources/terminal/location
+    stripe/resources/terminal/onboarding_link
+    stripe/resources/terminal/reader
+    stripe/resources/test_helpers/test_clock
+    stripe/resources/token
+    stripe/resources/topup
+    stripe/resources/transfer
+    stripe/resources/treasury/credit_reversal
+    stripe/resources/treasury/debit_reversal
+    stripe/resources/treasury/financial_account
+    stripe/resources/treasury/financial_account_features
+    stripe/resources/treasury/inbound_transfer
+    stripe/resources/treasury/outbound_payment
+    stripe/resources/treasury/outbound_transfer
+    stripe/resources/treasury/received_credit
+    stripe/resources/treasury/received_debit
+    stripe/resources/treasury/transaction
+    stripe/resources/treasury/transaction_entry
+    stripe/resources/v2/billing/meter_event
+    stripe/resources/v2/billing/meter_event_adjustment
+    stripe/resources/v2/billing/meter_event_session
+    stripe/resources/v2/core/account
+    stripe/resources/v2/core/account_link
+    stripe/resources/v2/core/account_person
+    stripe/resources/v2/core/account_person_token
+    stripe/resources/v2/core/account_token
+    stripe/resources/v2/core/event
+    stripe/resources/v2/core/event_destination
+    stripe/resources/webhook_endpoint
+    stripe/events/v1_billing_meter_error_report_triggered_event
+    stripe/events/v1_billing_meter_no_meter_found_event
+    stripe/events/v2_core_account_closed_event
+    stripe/events/v2_core_account_created_event
+    stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event
+    stripe/events/v2_core_account_including_configuration_customer_updated_event
+    stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event
+    stripe/events/v2_core_account_including_configuration_merchant_updated_event
+    stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event
+    stripe/events/v2_core_account_including_configuration_recipient_updated_event
+    stripe/events/v2_core_account_including_defaults_updated_event
+    stripe/events/v2_core_account_including_future_requirements_updated_event
+    stripe/events/v2_core_account_including_identity_updated_event
+    stripe/events/v2_core_account_including_requirements_updated_event
+    stripe/events/v2_core_account_link_returned_event
+    stripe/events/v2_core_account_person_created_event
+    stripe/events/v2_core_account_person_deleted_event
+    stripe/events/v2_core_account_person_updated_event
+    stripe/events/v2_core_account_updated_event
+    stripe/events/v2_core_event_destination_ping_event
+  ].freeze
+end

--- a/lib/stripe/resources.rb
+++ b/lib/stripe/resources.rb
@@ -120,33 +120,54 @@ module Stripe
 
   module Events
     autoload :V1BillingMeterErrorReportTriggeredEvent, "stripe/events/v1_billing_meter_error_report_triggered_event"
-    autoload :V1BillingMeterErrorReportTriggeredEventNotification, "stripe/events/v1_billing_meter_error_report_triggered_event"
+    autoload :V1BillingMeterErrorReportTriggeredEventNotification,
+             "stripe/events/v1_billing_meter_error_report_triggered_event"
     autoload :V1BillingMeterNoMeterFoundEvent, "stripe/events/v1_billing_meter_no_meter_found_event"
     autoload :V1BillingMeterNoMeterFoundEventNotification, "stripe/events/v1_billing_meter_no_meter_found_event"
     autoload :V2CoreAccountClosedEvent, "stripe/events/v2_core_account_closed_event"
     autoload :V2CoreAccountClosedEventNotification, "stripe/events/v2_core_account_closed_event"
     autoload :V2CoreAccountCreatedEvent, "stripe/events/v2_core_account_created_event"
     autoload :V2CoreAccountCreatedEventNotification, "stripe/events/v2_core_account_created_event"
-    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEvent, "stripe/events/v2_core_account_including_configuration_customer_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_customer_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEvent, "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent, "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEvent, "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
-    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
-    autoload :V2CoreAccountIncludingDefaultsUpdatedEvent, "stripe/events/v2_core_account_including_defaults_updated_event"
-    autoload :V2CoreAccountIncludingDefaultsUpdatedEventNotification, "stripe/events/v2_core_account_including_defaults_updated_event"
-    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEvent, "stripe/events/v2_core_account_including_future_requirements_updated_event"
-    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, "stripe/events/v2_core_account_including_future_requirements_updated_event"
-    autoload :V2CoreAccountIncludingIdentityUpdatedEvent, "stripe/events/v2_core_account_including_identity_updated_event"
-    autoload :V2CoreAccountIncludingIdentityUpdatedEventNotification, "stripe/events/v2_core_account_including_identity_updated_event"
-    autoload :V2CoreAccountIncludingRequirementsUpdatedEvent, "stripe/events/v2_core_account_including_requirements_updated_event"
-    autoload :V2CoreAccountIncludingRequirementsUpdatedEventNotification, "stripe/events/v2_core_account_including_requirements_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_customer_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_customer_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_customer_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_merchant_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_merchant_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_recipient_capability_status_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEvent,
+             "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
+    autoload :V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_configuration_recipient_updated_event"
+    autoload :V2CoreAccountIncludingDefaultsUpdatedEvent,
+             "stripe/events/v2_core_account_including_defaults_updated_event"
+    autoload :V2CoreAccountIncludingDefaultsUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_defaults_updated_event"
+    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEvent,
+             "stripe/events/v2_core_account_including_future_requirements_updated_event"
+    autoload :V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_future_requirements_updated_event"
+    autoload :V2CoreAccountIncludingIdentityUpdatedEvent,
+             "stripe/events/v2_core_account_including_identity_updated_event"
+    autoload :V2CoreAccountIncludingIdentityUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_identity_updated_event"
+    autoload :V2CoreAccountIncludingRequirementsUpdatedEvent,
+             "stripe/events/v2_core_account_including_requirements_updated_event"
+    autoload :V2CoreAccountIncludingRequirementsUpdatedEventNotification,
+             "stripe/events/v2_core_account_including_requirements_updated_event"
     autoload :V2CoreAccountLinkReturnedEvent, "stripe/events/v2_core_account_link_returned_event"
     autoload :V2CoreAccountLinkReturnedEventNotification, "stripe/events/v2_core_account_link_returned_event"
     autoload :V2CoreAccountPersonCreatedEvent, "stripe/events/v2_core_account_person_created_event"

--- a/lib/stripe/resources.rb
+++ b/lib/stripe/resources.rb
@@ -269,7 +269,6 @@ module Stripe
   end
 
   module V2
-    autoload :Amount, "stripe/resources/v2/amount"
     autoload :DeletedObject, "stripe/resources/v2/deleted_object"
 
     module Billing
@@ -292,12 +291,10 @@ module Stripe
       autoload :RelatedObject, "stripe/resources/v2/core/event_notification"
     end
   end
+end
 
-  # Ordered list for Stripe.eager_load! — same order as the original
-  # require calls so eager loading has no load-order surprises.
+module Stripe
   RESOURCE_FILES = %w[
-    stripe/resources/v2/amount
-    stripe/resources/v2/deleted_object
     stripe/resources/v2/core/event_notification
     stripe/resources/account
     stripe/resources/account_link
@@ -455,6 +452,7 @@ module Stripe
     stripe/resources/v2/core/account_token
     stripe/resources/v2/core/event
     stripe/resources/v2/core/event_destination
+    stripe/resources/v2/deleted_object
     stripe/resources/webhook_endpoint
     stripe/events/v1_billing_meter_error_report_triggered_event
     stripe/events/v1_billing_meter_no_meter_found_event

--- a/lib/stripe/services.rb
+++ b/lib/stripe/services.rb
@@ -1,192 +1,460 @@
 # File generated from our OpenAPI spec
 # frozen_string_literal: true
 
-require "stripe/services/account_capability_service"
-require "stripe/services/account_external_account_service"
-require "stripe/services/account_link_service"
-require "stripe/services/account_login_link_service"
-require "stripe/services/account_person_service"
-require "stripe/services/account_service"
-require "stripe/services/account_session_service"
-require "stripe/services/apple_pay_domain_service"
-require "stripe/services/application_fee_refund_service"
-require "stripe/services/application_fee_service"
-require "stripe/services/apps/secret_service"
-require "stripe/services/apps_service"
-require "stripe/services/balance_service"
-require "stripe/services/balance_settings_service"
-require "stripe/services/balance_transaction_service"
-require "stripe/services/billing/alert_service"
-require "stripe/services/billing/credit_balance_summary_service"
-require "stripe/services/billing/credit_balance_transaction_service"
-require "stripe/services/billing/credit_grant_service"
-require "stripe/services/billing/meter_event_adjustment_service"
-require "stripe/services/billing/meter_event_service"
-require "stripe/services/billing/meter_event_summary_service"
-require "stripe/services/billing/meter_service"
-require "stripe/services/billing_portal/configuration_service"
-require "stripe/services/billing_portal/session_service"
-require "stripe/services/billing_portal_service"
-require "stripe/services/billing_service"
-require "stripe/services/charge_service"
-require "stripe/services/checkout/session_line_item_service"
-require "stripe/services/checkout/session_service"
-require "stripe/services/checkout_service"
-require "stripe/services/climate/order_service"
-require "stripe/services/climate/product_service"
-require "stripe/services/climate/supplier_service"
-require "stripe/services/climate_service"
-require "stripe/services/confirmation_token_service"
-require "stripe/services/country_spec_service"
-require "stripe/services/coupon_service"
-require "stripe/services/credit_note_line_item_service"
-require "stripe/services/credit_note_preview_lines_service"
-require "stripe/services/credit_note_service"
-require "stripe/services/customer_balance_transaction_service"
-require "stripe/services/customer_cash_balance_service"
-require "stripe/services/customer_cash_balance_transaction_service"
-require "stripe/services/customer_funding_instructions_service"
-require "stripe/services/customer_payment_method_service"
-require "stripe/services/customer_payment_source_service"
-require "stripe/services/customer_service"
-require "stripe/services/customer_session_service"
-require "stripe/services/customer_tax_id_service"
-require "stripe/services/dispute_service"
-require "stripe/services/entitlements/active_entitlement_service"
-require "stripe/services/entitlements/feature_service"
-require "stripe/services/entitlements_service"
-require "stripe/services/ephemeral_key_service"
-require "stripe/services/event_service"
-require "stripe/services/exchange_rate_service"
-require "stripe/services/file_link_service"
-require "stripe/services/file_service"
-require "stripe/services/financial_connections/account_owner_service"
-require "stripe/services/financial_connections/account_service"
-require "stripe/services/financial_connections/session_service"
-require "stripe/services/financial_connections/transaction_service"
-require "stripe/services/financial_connections_service"
-require "stripe/services/forwarding/request_service"
-require "stripe/services/forwarding_service"
-require "stripe/services/identity/verification_report_service"
-require "stripe/services/identity/verification_session_service"
-require "stripe/services/identity_service"
-require "stripe/services/invoice_item_service"
-require "stripe/services/invoice_line_item_service"
-require "stripe/services/invoice_payment_service"
-require "stripe/services/invoice_rendering_template_service"
-require "stripe/services/invoice_service"
-require "stripe/services/issuing/authorization_service"
-require "stripe/services/issuing/card_service"
-require "stripe/services/issuing/cardholder_service"
-require "stripe/services/issuing/dispute_service"
-require "stripe/services/issuing/personalization_design_service"
-require "stripe/services/issuing/physical_bundle_service"
-require "stripe/services/issuing/token_service"
-require "stripe/services/issuing/transaction_service"
-require "stripe/services/issuing_service"
-require "stripe/services/mandate_service"
-require "stripe/services/payment_attempt_record_service"
-require "stripe/services/payment_intent_amount_details_line_item_service"
-require "stripe/services/payment_intent_service"
-require "stripe/services/payment_link_line_item_service"
-require "stripe/services/payment_link_service"
-require "stripe/services/payment_method_configuration_service"
-require "stripe/services/payment_method_domain_service"
-require "stripe/services/payment_method_service"
-require "stripe/services/payment_record_service"
-require "stripe/services/payout_service"
-require "stripe/services/plan_service"
-require "stripe/services/price_service"
-require "stripe/services/product_feature_service"
-require "stripe/services/product_service"
-require "stripe/services/promotion_code_service"
-require "stripe/services/quote_computed_upfront_line_items_service"
-require "stripe/services/quote_line_item_service"
-require "stripe/services/quote_service"
-require "stripe/services/radar/early_fraud_warning_service"
-require "stripe/services/radar/payment_evaluation_service"
-require "stripe/services/radar/value_list_item_service"
-require "stripe/services/radar/value_list_service"
-require "stripe/services/radar_service"
-require "stripe/services/refund_service"
-require "stripe/services/reporting/report_run_service"
-require "stripe/services/reporting/report_type_service"
-require "stripe/services/reporting_service"
-require "stripe/services/review_service"
-require "stripe/services/setup_attempt_service"
-require "stripe/services/setup_intent_service"
-require "stripe/services/shipping_rate_service"
-require "stripe/services/sigma/scheduled_query_run_service"
-require "stripe/services/sigma_service"
-require "stripe/services/source_service"
-require "stripe/services/source_transaction_service"
-require "stripe/services/subscription_item_service"
-require "stripe/services/subscription_schedule_service"
-require "stripe/services/subscription_service"
-require "stripe/services/tax/association_service"
-require "stripe/services/tax/calculation_line_item_service"
-require "stripe/services/tax/calculation_service"
-require "stripe/services/tax/registration_service"
-require "stripe/services/tax/settings_service"
-require "stripe/services/tax/transaction_line_item_service"
-require "stripe/services/tax/transaction_service"
-require "stripe/services/tax_code_service"
-require "stripe/services/tax_id_service"
-require "stripe/services/tax_rate_service"
-require "stripe/services/tax_service"
-require "stripe/services/terminal/configuration_service"
-require "stripe/services/terminal/connection_token_service"
-require "stripe/services/terminal/location_service"
-require "stripe/services/terminal/onboarding_link_service"
-require "stripe/services/terminal/reader_service"
-require "stripe/services/terminal_service"
-require "stripe/services/test_helpers/confirmation_token_service"
-require "stripe/services/test_helpers/customer_service"
-require "stripe/services/test_helpers/issuing/authorization_service"
-require "stripe/services/test_helpers/issuing/card_service"
-require "stripe/services/test_helpers/issuing/personalization_design_service"
-require "stripe/services/test_helpers/issuing/transaction_service"
-require "stripe/services/test_helpers/issuing_service"
-require "stripe/services/test_helpers/refund_service"
-require "stripe/services/test_helpers/terminal/reader_service"
-require "stripe/services/test_helpers/terminal_service"
-require "stripe/services/test_helpers/test_clock_service"
-require "stripe/services/test_helpers/treasury/inbound_transfer_service"
-require "stripe/services/test_helpers/treasury/outbound_payment_service"
-require "stripe/services/test_helpers/treasury/outbound_transfer_service"
-require "stripe/services/test_helpers/treasury/received_credit_service"
-require "stripe/services/test_helpers/treasury/received_debit_service"
-require "stripe/services/test_helpers/treasury_service"
-require "stripe/services/test_helpers_service"
-require "stripe/services/token_service"
-require "stripe/services/topup_service"
-require "stripe/services/transfer_reversal_service"
-require "stripe/services/transfer_service"
-require "stripe/services/treasury/credit_reversal_service"
-require "stripe/services/treasury/debit_reversal_service"
-require "stripe/services/treasury/financial_account_features_service"
-require "stripe/services/treasury/financial_account_service"
-require "stripe/services/treasury/inbound_transfer_service"
-require "stripe/services/treasury/outbound_payment_service"
-require "stripe/services/treasury/outbound_transfer_service"
-require "stripe/services/treasury/received_credit_service"
-require "stripe/services/treasury/received_debit_service"
-require "stripe/services/treasury/transaction_entry_service"
-require "stripe/services/treasury/transaction_service"
-require "stripe/services/treasury_service"
-require "stripe/services/v1_services"
-require "stripe/services/v2/billing/meter_event_adjustment_service"
-require "stripe/services/v2/billing/meter_event_service"
-require "stripe/services/v2/billing/meter_event_session_service"
-require "stripe/services/v2/billing/meter_event_stream_service"
-require "stripe/services/v2/billing_service"
-require "stripe/services/v2/core/account_link_service"
-require "stripe/services/v2/core/account_service"
-require "stripe/services/v2/core/account_token_service"
-require "stripe/services/v2/core/accounts/person_service"
-require "stripe/services/v2/core/accounts/person_token_service"
-require "stripe/services/v2/core/event_destination_service"
-require "stripe/services/v2/core/event_service"
-require "stripe/services/v2/core_service"
-require "stripe/services/v2_services"
-require "stripe/services/webhook_endpoint_service"
+module Stripe
+  autoload :AccountCapabilityService, "stripe/services/account_capability_service"
+  autoload :AccountExternalAccountService, "stripe/services/account_external_account_service"
+  autoload :AccountLinkService, "stripe/services/account_link_service"
+  autoload :AccountLoginLinkService, "stripe/services/account_login_link_service"
+  autoload :AccountPersonService, "stripe/services/account_person_service"
+  autoload :AccountService, "stripe/services/account_service"
+  autoload :AccountSessionService, "stripe/services/account_session_service"
+  autoload :ApplePayDomainService, "stripe/services/apple_pay_domain_service"
+  autoload :ApplicationFeeRefundService, "stripe/services/application_fee_refund_service"
+  autoload :ApplicationFeeService, "stripe/services/application_fee_service"
+  autoload :AppsService, "stripe/services/apps_service"
+  autoload :BalanceService, "stripe/services/balance_service"
+  autoload :BalanceSettingsService, "stripe/services/balance_settings_service"
+  autoload :BalanceTransactionService, "stripe/services/balance_transaction_service"
+  autoload :BillingPortalService, "stripe/services/billing_portal_service"
+  autoload :BillingService, "stripe/services/billing_service"
+  autoload :ChargeService, "stripe/services/charge_service"
+  autoload :CheckoutService, "stripe/services/checkout_service"
+  autoload :ClimateService, "stripe/services/climate_service"
+  autoload :ConfirmationTokenService, "stripe/services/confirmation_token_service"
+  autoload :CountrySpecService, "stripe/services/country_spec_service"
+  autoload :CouponService, "stripe/services/coupon_service"
+  autoload :CreditNoteLineItemService, "stripe/services/credit_note_line_item_service"
+  autoload :CreditNotePreviewLinesService, "stripe/services/credit_note_preview_lines_service"
+  autoload :CreditNoteService, "stripe/services/credit_note_service"
+  autoload :CustomerBalanceTransactionService, "stripe/services/customer_balance_transaction_service"
+  autoload :CustomerCashBalanceService, "stripe/services/customer_cash_balance_service"
+  autoload :CustomerCashBalanceTransactionService, "stripe/services/customer_cash_balance_transaction_service"
+  autoload :CustomerFundingInstructionsService, "stripe/services/customer_funding_instructions_service"
+  autoload :CustomerPaymentMethodService, "stripe/services/customer_payment_method_service"
+  autoload :CustomerPaymentSourceService, "stripe/services/customer_payment_source_service"
+  autoload :CustomerService, "stripe/services/customer_service"
+  autoload :CustomerSessionService, "stripe/services/customer_session_service"
+  autoload :CustomerTaxIdService, "stripe/services/customer_tax_id_service"
+  autoload :DisputeService, "stripe/services/dispute_service"
+  autoload :EntitlementsService, "stripe/services/entitlements_service"
+  autoload :EphemeralKeyService, "stripe/services/ephemeral_key_service"
+  autoload :EventService, "stripe/services/event_service"
+  autoload :ExchangeRateService, "stripe/services/exchange_rate_service"
+  autoload :FileLinkService, "stripe/services/file_link_service"
+  autoload :FileService, "stripe/services/file_service"
+  autoload :FinancialConnectionsService, "stripe/services/financial_connections_service"
+  autoload :ForwardingService, "stripe/services/forwarding_service"
+  autoload :IdentityService, "stripe/services/identity_service"
+  autoload :InvoiceItemService, "stripe/services/invoice_item_service"
+  autoload :InvoiceLineItemService, "stripe/services/invoice_line_item_service"
+  autoload :InvoicePaymentService, "stripe/services/invoice_payment_service"
+  autoload :InvoiceRenderingTemplateService, "stripe/services/invoice_rendering_template_service"
+  autoload :InvoiceService, "stripe/services/invoice_service"
+  autoload :IssuingService, "stripe/services/issuing_service"
+  autoload :MandateService, "stripe/services/mandate_service"
+  autoload :PaymentAttemptRecordService, "stripe/services/payment_attempt_record_service"
+  autoload :PaymentIntentAmountDetailsLineItemService, "stripe/services/payment_intent_amount_details_line_item_service"
+  autoload :PaymentIntentService, "stripe/services/payment_intent_service"
+  autoload :PaymentLinkLineItemService, "stripe/services/payment_link_line_item_service"
+  autoload :PaymentLinkService, "stripe/services/payment_link_service"
+  autoload :PaymentMethodConfigurationService, "stripe/services/payment_method_configuration_service"
+  autoload :PaymentMethodDomainService, "stripe/services/payment_method_domain_service"
+  autoload :PaymentMethodService, "stripe/services/payment_method_service"
+  autoload :PaymentRecordService, "stripe/services/payment_record_service"
+  autoload :PayoutService, "stripe/services/payout_service"
+  autoload :PlanService, "stripe/services/plan_service"
+  autoload :PriceService, "stripe/services/price_service"
+  autoload :ProductFeatureService, "stripe/services/product_feature_service"
+  autoload :ProductService, "stripe/services/product_service"
+  autoload :PromotionCodeService, "stripe/services/promotion_code_service"
+  autoload :QuoteComputedUpfrontLineItemsService, "stripe/services/quote_computed_upfront_line_items_service"
+  autoload :QuoteLineItemService, "stripe/services/quote_line_item_service"
+  autoload :QuoteService, "stripe/services/quote_service"
+  autoload :RadarService, "stripe/services/radar_service"
+  autoload :RefundService, "stripe/services/refund_service"
+  autoload :ReportingService, "stripe/services/reporting_service"
+  autoload :ReviewService, "stripe/services/review_service"
+  autoload :SetupAttemptService, "stripe/services/setup_attempt_service"
+  autoload :SetupIntentService, "stripe/services/setup_intent_service"
+  autoload :ShippingRateService, "stripe/services/shipping_rate_service"
+  autoload :SigmaService, "stripe/services/sigma_service"
+  autoload :SourceService, "stripe/services/source_service"
+  autoload :SourceTransactionService, "stripe/services/source_transaction_service"
+  autoload :SubscriptionItemService, "stripe/services/subscription_item_service"
+  autoload :SubscriptionScheduleService, "stripe/services/subscription_schedule_service"
+  autoload :SubscriptionService, "stripe/services/subscription_service"
+  autoload :TaxCodeService, "stripe/services/tax_code_service"
+  autoload :TaxIdService, "stripe/services/tax_id_service"
+  autoload :TaxRateService, "stripe/services/tax_rate_service"
+  autoload :TaxService, "stripe/services/tax_service"
+  autoload :TerminalService, "stripe/services/terminal_service"
+  autoload :TestHelpersService, "stripe/services/test_helpers_service"
+  autoload :TokenService, "stripe/services/token_service"
+  autoload :TopupService, "stripe/services/topup_service"
+  autoload :TransferReversalService, "stripe/services/transfer_reversal_service"
+  autoload :TransferService, "stripe/services/transfer_service"
+  autoload :TreasuryService, "stripe/services/treasury_service"
+  autoload :V1Services, "stripe/services/v1_services"
+  autoload :V2Services, "stripe/services/v2_services"
+  autoload :WebhookEndpointService, "stripe/services/webhook_endpoint_service"
+
+  module Apps
+    autoload :SecretService, "stripe/services/apps/secret_service"
+  end
+
+  module Billing
+    autoload :AlertService, "stripe/services/billing/alert_service"
+    autoload :CreditBalanceSummaryService, "stripe/services/billing/credit_balance_summary_service"
+    autoload :CreditBalanceTransactionService, "stripe/services/billing/credit_balance_transaction_service"
+    autoload :CreditGrantService, "stripe/services/billing/credit_grant_service"
+    autoload :MeterEventAdjustmentService, "stripe/services/billing/meter_event_adjustment_service"
+    autoload :MeterEventService, "stripe/services/billing/meter_event_service"
+    autoload :MeterEventSummaryService, "stripe/services/billing/meter_event_summary_service"
+    autoload :MeterService, "stripe/services/billing/meter_service"
+  end
+
+  module BillingPortal
+    autoload :ConfigurationService, "stripe/services/billing_portal/configuration_service"
+    autoload :SessionService, "stripe/services/billing_portal/session_service"
+  end
+
+  module Checkout
+    autoload :SessionLineItemService, "stripe/services/checkout/session_line_item_service"
+    autoload :SessionService, "stripe/services/checkout/session_service"
+  end
+
+  module Climate
+    autoload :OrderService, "stripe/services/climate/order_service"
+    autoload :ProductService, "stripe/services/climate/product_service"
+    autoload :SupplierService, "stripe/services/climate/supplier_service"
+  end
+
+  module Entitlements
+    autoload :ActiveEntitlementService, "stripe/services/entitlements/active_entitlement_service"
+    autoload :FeatureService, "stripe/services/entitlements/feature_service"
+  end
+
+  module FinancialConnections
+    autoload :AccountOwnerService, "stripe/services/financial_connections/account_owner_service"
+    autoload :AccountService, "stripe/services/financial_connections/account_service"
+    autoload :SessionService, "stripe/services/financial_connections/session_service"
+    autoload :TransactionService, "stripe/services/financial_connections/transaction_service"
+  end
+
+  module Forwarding
+    autoload :RequestService, "stripe/services/forwarding/request_service"
+  end
+
+  module Identity
+    autoload :VerificationReportService, "stripe/services/identity/verification_report_service"
+    autoload :VerificationSessionService, "stripe/services/identity/verification_session_service"
+  end
+
+  module Issuing
+    autoload :AuthorizationService, "stripe/services/issuing/authorization_service"
+    autoload :CardService, "stripe/services/issuing/card_service"
+    autoload :CardholderService, "stripe/services/issuing/cardholder_service"
+    autoload :DisputeService, "stripe/services/issuing/dispute_service"
+    autoload :PersonalizationDesignService, "stripe/services/issuing/personalization_design_service"
+    autoload :PhysicalBundleService, "stripe/services/issuing/physical_bundle_service"
+    autoload :TokenService, "stripe/services/issuing/token_service"
+    autoload :TransactionService, "stripe/services/issuing/transaction_service"
+  end
+
+  module Radar
+    autoload :EarlyFraudWarningService, "stripe/services/radar/early_fraud_warning_service"
+    autoload :PaymentEvaluationService, "stripe/services/radar/payment_evaluation_service"
+    autoload :ValueListItemService, "stripe/services/radar/value_list_item_service"
+    autoload :ValueListService, "stripe/services/radar/value_list_service"
+  end
+
+  module Reporting
+    autoload :ReportRunService, "stripe/services/reporting/report_run_service"
+    autoload :ReportTypeService, "stripe/services/reporting/report_type_service"
+  end
+
+  module Sigma
+    autoload :ScheduledQueryRunService, "stripe/services/sigma/scheduled_query_run_service"
+  end
+
+  module Tax
+    autoload :AssociationService, "stripe/services/tax/association_service"
+    autoload :CalculationLineItemService, "stripe/services/tax/calculation_line_item_service"
+    autoload :CalculationService, "stripe/services/tax/calculation_service"
+    autoload :RegistrationService, "stripe/services/tax/registration_service"
+    autoload :SettingsService, "stripe/services/tax/settings_service"
+    autoload :TransactionLineItemService, "stripe/services/tax/transaction_line_item_service"
+    autoload :TransactionService, "stripe/services/tax/transaction_service"
+  end
+
+  module Terminal
+    autoload :ConfigurationService, "stripe/services/terminal/configuration_service"
+    autoload :ConnectionTokenService, "stripe/services/terminal/connection_token_service"
+    autoload :LocationService, "stripe/services/terminal/location_service"
+    autoload :OnboardingLinkService, "stripe/services/terminal/onboarding_link_service"
+    autoload :ReaderService, "stripe/services/terminal/reader_service"
+  end
+
+  module TestHelpers
+    autoload :ConfirmationTokenService, "stripe/services/test_helpers/confirmation_token_service"
+    autoload :CustomerService, "stripe/services/test_helpers/customer_service"
+    autoload :IssuingService, "stripe/services/test_helpers/issuing_service"
+    autoload :RefundService, "stripe/services/test_helpers/refund_service"
+    autoload :TerminalService, "stripe/services/test_helpers/terminal_service"
+    autoload :TestClockService, "stripe/services/test_helpers/test_clock_service"
+    autoload :TreasuryService, "stripe/services/test_helpers/treasury_service"
+
+    module Issuing
+      autoload :AuthorizationService, "stripe/services/test_helpers/issuing/authorization_service"
+      autoload :CardService, "stripe/services/test_helpers/issuing/card_service"
+      autoload :PersonalizationDesignService, "stripe/services/test_helpers/issuing/personalization_design_service"
+      autoload :TransactionService, "stripe/services/test_helpers/issuing/transaction_service"
+    end
+
+    module Terminal
+      autoload :ReaderService, "stripe/services/test_helpers/terminal/reader_service"
+    end
+
+    module Treasury
+      autoload :InboundTransferService, "stripe/services/test_helpers/treasury/inbound_transfer_service"
+      autoload :OutboundPaymentService, "stripe/services/test_helpers/treasury/outbound_payment_service"
+      autoload :OutboundTransferService, "stripe/services/test_helpers/treasury/outbound_transfer_service"
+      autoload :ReceivedCreditService, "stripe/services/test_helpers/treasury/received_credit_service"
+      autoload :ReceivedDebitService, "stripe/services/test_helpers/treasury/received_debit_service"
+    end
+  end
+
+  module Treasury
+    autoload :CreditReversalService, "stripe/services/treasury/credit_reversal_service"
+    autoload :DebitReversalService, "stripe/services/treasury/debit_reversal_service"
+    autoload :FinancialAccountFeaturesService, "stripe/services/treasury/financial_account_features_service"
+    autoload :FinancialAccountService, "stripe/services/treasury/financial_account_service"
+    autoload :InboundTransferService, "stripe/services/treasury/inbound_transfer_service"
+    autoload :OutboundPaymentService, "stripe/services/treasury/outbound_payment_service"
+    autoload :OutboundTransferService, "stripe/services/treasury/outbound_transfer_service"
+    autoload :ReceivedCreditService, "stripe/services/treasury/received_credit_service"
+    autoload :ReceivedDebitService, "stripe/services/treasury/received_debit_service"
+    autoload :TransactionEntryService, "stripe/services/treasury/transaction_entry_service"
+    autoload :TransactionService, "stripe/services/treasury/transaction_service"
+  end
+
+  module V2
+    autoload :BillingService, "stripe/services/v2/billing_service"
+    autoload :CoreService, "stripe/services/v2/core_service"
+
+    module Billing
+      autoload :MeterEventAdjustmentService, "stripe/services/v2/billing/meter_event_adjustment_service"
+      autoload :MeterEventService, "stripe/services/v2/billing/meter_event_service"
+      autoload :MeterEventSessionService, "stripe/services/v2/billing/meter_event_session_service"
+      autoload :MeterEventStreamService, "stripe/services/v2/billing/meter_event_stream_service"
+    end
+
+    module Core
+      autoload :AccountLinkService, "stripe/services/v2/core/account_link_service"
+      autoload :AccountService, "stripe/services/v2/core/account_service"
+      autoload :AccountTokenService, "stripe/services/v2/core/account_token_service"
+      autoload :EventDestinationService, "stripe/services/v2/core/event_destination_service"
+      autoload :EventService, "stripe/services/v2/core/event_service"
+
+      module Accounts
+        autoload :PersonService, "stripe/services/v2/core/accounts/person_service"
+        autoload :PersonTokenService, "stripe/services/v2/core/accounts/person_token_service"
+      end
+    end
+  end
+
+  # Ordered list for Stripe.eager_load! — same order as the original
+  # require calls so eager loading has no load-order surprises.
+  SERVICE_FILES = %w[
+    stripe/services/account_capability_service
+    stripe/services/account_external_account_service
+    stripe/services/account_link_service
+    stripe/services/account_login_link_service
+    stripe/services/account_person_service
+    stripe/services/account_service
+    stripe/services/account_session_service
+    stripe/services/apple_pay_domain_service
+    stripe/services/application_fee_refund_service
+    stripe/services/application_fee_service
+    stripe/services/apps/secret_service
+    stripe/services/apps_service
+    stripe/services/balance_service
+    stripe/services/balance_settings_service
+    stripe/services/balance_transaction_service
+    stripe/services/billing/alert_service
+    stripe/services/billing/credit_balance_summary_service
+    stripe/services/billing/credit_balance_transaction_service
+    stripe/services/billing/credit_grant_service
+    stripe/services/billing/meter_event_adjustment_service
+    stripe/services/billing/meter_event_service
+    stripe/services/billing/meter_event_summary_service
+    stripe/services/billing/meter_service
+    stripe/services/billing_portal/configuration_service
+    stripe/services/billing_portal/session_service
+    stripe/services/billing_portal_service
+    stripe/services/billing_service
+    stripe/services/charge_service
+    stripe/services/checkout/session_line_item_service
+    stripe/services/checkout/session_service
+    stripe/services/checkout_service
+    stripe/services/climate/order_service
+    stripe/services/climate/product_service
+    stripe/services/climate/supplier_service
+    stripe/services/climate_service
+    stripe/services/confirmation_token_service
+    stripe/services/country_spec_service
+    stripe/services/coupon_service
+    stripe/services/credit_note_line_item_service
+    stripe/services/credit_note_preview_lines_service
+    stripe/services/credit_note_service
+    stripe/services/customer_balance_transaction_service
+    stripe/services/customer_cash_balance_service
+    stripe/services/customer_cash_balance_transaction_service
+    stripe/services/customer_funding_instructions_service
+    stripe/services/customer_payment_method_service
+    stripe/services/customer_payment_source_service
+    stripe/services/customer_service
+    stripe/services/customer_session_service
+    stripe/services/customer_tax_id_service
+    stripe/services/dispute_service
+    stripe/services/entitlements/active_entitlement_service
+    stripe/services/entitlements/feature_service
+    stripe/services/entitlements_service
+    stripe/services/ephemeral_key_service
+    stripe/services/event_service
+    stripe/services/exchange_rate_service
+    stripe/services/file_link_service
+    stripe/services/file_service
+    stripe/services/financial_connections/account_owner_service
+    stripe/services/financial_connections/account_service
+    stripe/services/financial_connections/session_service
+    stripe/services/financial_connections/transaction_service
+    stripe/services/financial_connections_service
+    stripe/services/forwarding/request_service
+    stripe/services/forwarding_service
+    stripe/services/identity/verification_report_service
+    stripe/services/identity/verification_session_service
+    stripe/services/identity_service
+    stripe/services/invoice_item_service
+    stripe/services/invoice_line_item_service
+    stripe/services/invoice_payment_service
+    stripe/services/invoice_rendering_template_service
+    stripe/services/invoice_service
+    stripe/services/issuing/authorization_service
+    stripe/services/issuing/card_service
+    stripe/services/issuing/cardholder_service
+    stripe/services/issuing/dispute_service
+    stripe/services/issuing/personalization_design_service
+    stripe/services/issuing/physical_bundle_service
+    stripe/services/issuing/token_service
+    stripe/services/issuing/transaction_service
+    stripe/services/issuing_service
+    stripe/services/mandate_service
+    stripe/services/payment_attempt_record_service
+    stripe/services/payment_intent_amount_details_line_item_service
+    stripe/services/payment_intent_service
+    stripe/services/payment_link_line_item_service
+    stripe/services/payment_link_service
+    stripe/services/payment_method_configuration_service
+    stripe/services/payment_method_domain_service
+    stripe/services/payment_method_service
+    stripe/services/payment_record_service
+    stripe/services/payout_service
+    stripe/services/plan_service
+    stripe/services/price_service
+    stripe/services/product_feature_service
+    stripe/services/product_service
+    stripe/services/promotion_code_service
+    stripe/services/quote_computed_upfront_line_items_service
+    stripe/services/quote_line_item_service
+    stripe/services/quote_service
+    stripe/services/radar/early_fraud_warning_service
+    stripe/services/radar/payment_evaluation_service
+    stripe/services/radar/value_list_item_service
+    stripe/services/radar/value_list_service
+    stripe/services/radar_service
+    stripe/services/refund_service
+    stripe/services/reporting/report_run_service
+    stripe/services/reporting/report_type_service
+    stripe/services/reporting_service
+    stripe/services/review_service
+    stripe/services/setup_attempt_service
+    stripe/services/setup_intent_service
+    stripe/services/shipping_rate_service
+    stripe/services/sigma/scheduled_query_run_service
+    stripe/services/sigma_service
+    stripe/services/source_service
+    stripe/services/source_transaction_service
+    stripe/services/subscription_item_service
+    stripe/services/subscription_schedule_service
+    stripe/services/subscription_service
+    stripe/services/tax/association_service
+    stripe/services/tax/calculation_line_item_service
+    stripe/services/tax/calculation_service
+    stripe/services/tax/registration_service
+    stripe/services/tax/settings_service
+    stripe/services/tax/transaction_line_item_service
+    stripe/services/tax/transaction_service
+    stripe/services/tax_code_service
+    stripe/services/tax_id_service
+    stripe/services/tax_rate_service
+    stripe/services/tax_service
+    stripe/services/terminal/configuration_service
+    stripe/services/terminal/connection_token_service
+    stripe/services/terminal/location_service
+    stripe/services/terminal/onboarding_link_service
+    stripe/services/terminal/reader_service
+    stripe/services/terminal_service
+    stripe/services/test_helpers/confirmation_token_service
+    stripe/services/test_helpers/customer_service
+    stripe/services/test_helpers/issuing/authorization_service
+    stripe/services/test_helpers/issuing/card_service
+    stripe/services/test_helpers/issuing/personalization_design_service
+    stripe/services/test_helpers/issuing/transaction_service
+    stripe/services/test_helpers/issuing_service
+    stripe/services/test_helpers/refund_service
+    stripe/services/test_helpers/terminal/reader_service
+    stripe/services/test_helpers/terminal_service
+    stripe/services/test_helpers/test_clock_service
+    stripe/services/test_helpers/treasury/inbound_transfer_service
+    stripe/services/test_helpers/treasury/outbound_payment_service
+    stripe/services/test_helpers/treasury/outbound_transfer_service
+    stripe/services/test_helpers/treasury/received_credit_service
+    stripe/services/test_helpers/treasury/received_debit_service
+    stripe/services/test_helpers/treasury_service
+    stripe/services/test_helpers_service
+    stripe/services/token_service
+    stripe/services/topup_service
+    stripe/services/transfer_reversal_service
+    stripe/services/transfer_service
+    stripe/services/treasury/credit_reversal_service
+    stripe/services/treasury/debit_reversal_service
+    stripe/services/treasury/financial_account_features_service
+    stripe/services/treasury/financial_account_service
+    stripe/services/treasury/inbound_transfer_service
+    stripe/services/treasury/outbound_payment_service
+    stripe/services/treasury/outbound_transfer_service
+    stripe/services/treasury/received_credit_service
+    stripe/services/treasury/received_debit_service
+    stripe/services/treasury/transaction_entry_service
+    stripe/services/treasury/transaction_service
+    stripe/services/treasury_service
+    stripe/services/v1_services
+    stripe/services/v2/billing/meter_event_adjustment_service
+    stripe/services/v2/billing/meter_event_service
+    stripe/services/v2/billing/meter_event_session_service
+    stripe/services/v2/billing/meter_event_stream_service
+    stripe/services/v2/billing_service
+    stripe/services/v2/core/account_link_service
+    stripe/services/v2/core/account_service
+    stripe/services/v2/core/account_token_service
+    stripe/services/v2/core/accounts/person_service
+    stripe/services/v2/core/accounts/person_token_service
+    stripe/services/v2/core/event_destination_service
+    stripe/services/v2/core/event_service
+    stripe/services/v2/core_service
+    stripe/services/v2_services
+    stripe/services/webhook_endpoint_service
+  ].freeze
+end

--- a/lib/stripe/services.rb
+++ b/lib/stripe/services.rb
@@ -153,8 +153,8 @@ module Stripe
 
   module Issuing
     autoload :AuthorizationService, "stripe/services/issuing/authorization_service"
-    autoload :CardService, "stripe/services/issuing/card_service"
     autoload :CardholderService, "stripe/services/issuing/cardholder_service"
+    autoload :CardService, "stripe/services/issuing/card_service"
     autoload :DisputeService, "stripe/services/issuing/dispute_service"
     autoload :PersonalizationDesignService, "stripe/services/issuing/personalization_design_service"
     autoload :PhysicalBundleService, "stripe/services/issuing/physical_bundle_service"
@@ -263,9 +263,9 @@ module Stripe
       end
     end
   end
+end
 
-  # Ordered list for Stripe.eager_load! — same order as the original
-  # require calls so eager loading has no load-order surprises.
+module Stripe
   SERVICE_FILES = %w[
     stripe/services/account_capability_service
     stripe/services/account_external_account_service

--- a/test/stripe/autoload_test.rb
+++ b/test/stripe/autoload_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", __dir__)
+
+module Stripe
+  class AutoloadTest < Test::Unit::TestCase
+    context "autoloaded constants" do
+      should "resolve all v1 object type classes" do
+        Stripe::ObjectTypes.object_names_to_classes.each do |name, klass|
+          assert_kind_of Class, klass, "#{name} did not resolve to a class"
+        end
+      end
+
+      should "resolve all v2 object type classes" do
+        Stripe::ObjectTypes.v2_object_names_to_classes.each do |name, klass|
+          assert_kind_of Class, klass, "#{name} did not resolve to a class"
+        end
+      end
+
+      should "resolve all v2 event type classes" do
+        Stripe::EventTypes.v2_event_types_to_classes.each do |type, klass|
+          assert_kind_of Class, klass, "#{type} did not resolve to a class"
+        end
+      end
+
+      should "resolve all event notification type classes" do
+        Stripe::EventTypes.event_notification_types_to_classes.each do |type, klass|
+          assert_kind_of Class, klass, "#{type} did not resolve to a class"
+        end
+      end
+
+      should "define EventNotification constants from event files" do
+        # Each event file defines both *Event and *EventNotification.
+        # Verify the *EventNotification constants are accessible.
+        assert_kind_of Class, Stripe::Events::V2CoreAccountClosedEventNotification
+        assert_kind_of Class, Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification
+      end
+    end
+
+    context ".eager_load!" do
+      should "load all registered files without error" do
+        assert_nothing_raised { Stripe.eager_load! }
+      end
+
+      should "make all resource constants available" do
+        Stripe.eager_load!
+
+        # Spot-check a sample of resources across namespaces
+        assert_equal "customer", Stripe::Customer::OBJECT_NAME
+        assert_equal "billing.alert", Stripe::Billing::Alert::OBJECT_NAME
+        assert_equal "checkout.session", Stripe::Checkout::Session::OBJECT_NAME
+        assert_equal "issuing.card", Stripe::Issuing::Card::OBJECT_NAME
+        assert_equal "treasury.financial_account", Stripe::Treasury::FinancialAccount::OBJECT_NAME
+      end
+    end
+  end
+end

--- a/test/stripe/railtie_test.rb
+++ b/test/stripe/railtie_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test/unit"
+
+begin
+  require "rails"
+rescue LoadError
+  # Rails is not a dependency of stripe-ruby; skip these tests when unavailable.
+end
+
+if defined?(::Rails::Railtie)
+  require "stripe"
+
+  class RailtieTest < Test::Unit::TestCase
+    test "Railtie is defined and is a Rails::Railtie" do
+      assert_operator Stripe::Railtie, :<, ::Rails::Railtie
+    end
+
+    test "Stripe is registered in eager_load_namespaces" do
+      app = Class.new(Rails::Application) do
+        config.eager_load = false
+        config.active_support.to_time_preserves_timezone = :zone
+      end
+      assert_includes app.config.eager_load_namespaces, Stripe
+    end
+  end
+end

--- a/test/stripe/railtie_test.rb
+++ b/test/stripe/railtie_test.rb
@@ -1,3 +1,4 @@
+# typed: ignore
 # frozen_string_literal: true
 
 require "test/unit"
@@ -8,7 +9,7 @@ rescue LoadError
   # Rails is not a dependency of stripe-ruby; skip these tests when unavailable.
 end
 
-if defined?(::Rails::Railtie)
+if defined?(Rails::Railtie)
   require "stripe"
 
   class RailtieTest < Test::Unit::TestCase


### PR DESCRIPTION
## Use `autoload` instead of eager `require` for generated resource, service, and param files

### Problem

`require "stripe"` eagerly loads all ~985 generated files (resources, services, params) even when only a handful of Stripe classes are used. This allocates ~20 MB and 193k objects, and takes 200ms–1.4s depending on hardware. Every Ruby process that uses the Stripe gem pays this cost at boot — Rails apps, background workers, CLI tools, test suites.

In a Rails app, stripe-ruby retains more memory at boot than `activesupport`, `activerecord`, and `actionpack` combined — making it the single largest gem by retained memory after rubygems itself. In a standalone script, it dominates even more: 83% of all allocated memory comes from stripe-ruby.

Reported in #1432. Plaid's Ruby gem had the same problem and fixed it by enabling `useAutoload` in their OpenAPI generator ([plaid/plaid-ruby#454](https://github.com/plaid/plaid-ruby/issues/454)).

### Solution

Replace the `require` calls in the three generated barrel files (`resources.rb`, `services.rb`, `params.rb`) with `autoload` declarations. Ruby's built-in [`autoload`](https://ruby-doc.org/3.3.0/Module.html#method-i-autoload) registers a file to be loaded the first time its constant is referenced, so classes like `Stripe::Customer` or `Stripe::PaymentIntent` are only loaded when actually used.

```ruby
# Before (resources.rb):
require "stripe/resources/customer"
require "stripe/resources/payment_intent"
# ... 175 more requires

# After:
module Stripe
  autoload :Customer, "stripe/resources/customer"
  autoload :PaymentIntent, "stripe/resources/payment_intent"
  # ...
end
```

The three files that were explicitly required in `lib/stripe.rb` before the barrel files (`v2/amount`, `v2/deleted_object`, `v2/core/event_notification`) are folded into the resources autoload — they're only referenced at runtime, not at require-time.

Each event file defines both an `*Event` class and an `*EventNotification` class, so both constants get autoload entries pointing to the same file (e.g. `autoload :V2CoreAccountClosedEvent` and `autoload :V2CoreAccountClosedEventNotification` both point to `stripe/events/v2_core_account_closed_event`).

#### `Stripe.eager_load!` for production

For pre-fork servers (Puma, Unicorn) and other production environments where you want deterministic, upfront loading, the gem now provides `Stripe.eager_load!`. It walks the same generated file list in the same order as the old `require` calls — no `Dir[]` globbing, no module introspection, just the exact same files in the exact same sequence. Each barrel file stores its ordered file list as a frozen constant (`RESOURCE_FILES`, `SERVICE_FILES`, `PARAM_FILES`).

```ruby
# In a Puma config, Unicorn before_fork, etc.:
Stripe.eager_load!
```

A `Stripe::Railtie` is included that registers `Stripe` in `config.eager_load_namespaces`, so Rails calls `eager_load!` automatically when `config.eager_load = true` (the default in production). No configuration needed.

### Note on code generation

The three modified barrel files are generated from the OpenAPI spec. This PR modifies the generated output directly to demonstrate the approach, provide benchmarks, and validate against CI. **The real fix belongs in the code generator** — replacing `require` with `autoload` in the barrel file templates, and emitting the `*_FILES` constants for `eager_load!`. I expect this PR won't be merged as-is but should serve as a specification for the generator change.

### Tests

Added `test/stripe/autoload_test.rb` covering:
- All v1 and v2 object type classes resolve through autoload
- All v2 event type classes resolve (the `*Event` constants)
- All event notification type classes resolve (the `*EventNotification` constants — these were a bug in the first revision)
- `Stripe.eager_load!` runs without error and makes all resource constants available

### Backwards compatibility

This is a drop-in upgrade — no code changes required. All existing constants (`Stripe::Customer`, `Stripe::Billing::Alert`, etc.) resolve exactly as before; `autoload` triggers transparently on first reference. `require "stripe/resources/customer"` and similar direct requires continue to work (Ruby's `require` is idempotent with `autoload`). Ruby's `autoload` has been thread-safe since 2.0.

New public API (additive only):
- `Stripe.eager_load!` — opt-in, for pre-fork servers and non-Rails production use
- `Stripe::Railtie` — auto-registers `Stripe` in `config.eager_load_namespaces` when Rails is present

The only observable difference: code that inspects `Stripe.constants` immediately after `require "stripe"` will see fewer constants until they are actually referenced. This does not affect normal usage.

### Benchmarks

All benchmarks: Ruby 4.0.2, Apple M1 Pro, `memory_profiler` gem.

#### Standalone (`require "stripe"` only)

| | Before | After | Change |
|---|---|---|---|
| **Boot time** (median of 10) | 214 ms | 61 ms | **−71%** |
| **Allocated memory** | 20.1 MB / 193k objects | 3.6 MB / 35k objects | **−82%** |
| **Retained memory** | 9.0 MB / 83k objects | 1.4 MB / 12k objects | **−85%** |
| **stripe gem allocated** | 16.6 MB / 161k objects | 0.5 MB / 5.5k objects | **−97%** |
| **stripe gem retained** | 7.8 MB | 0.3 MB | **−96%** |

#### With Rails (`require "rails/all"` + `require "stripe"`)

| | Before | After |
|---|---|---|
| **stripe gem retained** | 7.9 MB (#1 gem) | 0.3 MB (#5 gem) |
| **stripe gem alloc objects** | 161k (#2 gem) | 5.4k (#9 gem) |

Before, stripe-ruby retains more memory than activesupport (0.5 MB), activerecord (0.3 MB), and actionpack (0.2 MB) combined. After, it drops below all of them.

<details>
<summary>Benchmark script</summary>

```ruby
require "memory_profiler"
require "benchmark"

report = MemoryProfiler.report do
  require "stripe"
end

puts "Total allocated: %s bytes (%s objects)" % [report.total_allocated_memsize, report.total_allocated]
puts "Total retained:  %s bytes (%s objects)" % [report.total_retained_memsize, report.total_retained]
puts
puts "allocated memory by gem"
puts "---"
report.allocated_memory_by_gem.first(10).each do |stat|
  puts "  %10d  %s" % [stat[:count], stat[:data]]
end
puts
puts "allocated memory by file"
puts "---"
report.allocated_memory_by_file.first(10).each do |stat|
  name = stat[:data].sub(Dir.pwd + "/", "").sub(%r{.*/gems/}, "")
  puts "  %10d  %s" % [stat[:count], name]
end
puts
puts "retained memory by gem"
puts "---"
report.retained_memory_by_gem.first(10).each do |stat|
  puts "  %10d  %s" % [stat[:count], stat[:data]]
end
puts
puts "allocated objects by gem"
puts "---"
report.allocated_objects_by_gem.first(10).each do |stat|
  puts "  %10d  %s" % [stat[:count], stat[:data]]
end

# Boot time
times = 10.times.map do
  `ruby -I lib -e 'require "benchmark"; puts Benchmark.measure { require "stripe" }.real' 2>/dev/null`.strip.to_f
end
puts
puts "Boot time (10 runs, sorted): %s" % times.sort.map { |t| "%.3fs" % t }.join(", ")
puts "Median: %.3fs" % times.sort[5]
```
</details>

<details>
<summary>Raw output — before (master), standalone</summary>

```
Total allocated: 20058345 bytes (193067 objects)
Total retained:  8995915 bytes (83197 objects)

allocated memory by gem
---
    16629994  stripe-ruby/lib
     1215639  rubygems
      805655  uri-1.1.1
      251704  resolv-0.7.1
      221177  arm64-darwin24
      202953  net-http-0.9.1
      121021  fileutils
      115935  forwardable
      110893  openssl
       63490  delegate

retained memory by gem
---
     7775410  stripe-ruby/lib
      230726  uri-1.1.1
      221391  rubygems
      200353  arm64-darwin24
      133964  resolv-0.7.1
      115265  net-http-0.9.1
       49562  openssl
       46229  fileutils
       42328  delegate
       24121  json-2.19.4

allocated objects by gem
---
      161176  stripe-ruby/lib
        8905  rubygems
        8826  uri-1.1.1
        2289  resolv-0.7.1
        2269  net-http-0.9.1
        2087  arm64-darwin24
        1354  fileutils
        1166  openssl
         968  forwardable
         566  socket

Boot time (10 runs, sorted): 0.211s, 0.211s, 0.212s, 0.213s, 0.214s, 0.214s, 0.215s, 0.216s, 0.217s, 0.218s
Median: 0.214s
```
</details>

<details>
<summary>Raw output — after (autoload), standalone</summary>

```
Total allocated: 3614469 bytes (35381 objects)
Total retained:  1379431 bytes (12426 objects)

allocated memory by gem
---
      879635  rubygems
      805655  uri-1.1.1
      522122  stripe-ruby/lib
      251704  resolv-0.7.1
      221177  arm64-darwin24
      202953  net-http-0.9.1
      121021  fileutils
      115935  forwardable
      110893  openssl
       63490  delegate

retained memory by gem
---
      337762  stripe-ruby/lib
      230726  uri-1.1.1
      200353  arm64-darwin24
      133964  resolv-0.7.1
      115265  net-http-0.9.1
       49562  openssl
       46229  fileutils
       42555  rubygems
       42328  delegate
       24121  json-2.19.4

allocated objects by gem
---
        8826  uri-1.1.1
        6919  rubygems
        5476  stripe-ruby/lib
        2289  resolv-0.7.1
        2269  net-http-0.9.1
        2087  arm64-darwin24
        1354  fileutils
        1166  openssl
         968  forwardable
         566  socket

Boot time (10 runs, sorted): 0.060s, 0.060s, 0.060s, 0.061s, 0.061s, 0.061s, 0.062s, 0.063s, 0.063s, 0.075s
Median: 0.061s
```
</details>

<details>
<summary>Raw output — before (master), with Rails 8.1</summary>

```
Total allocated: 467200640 bytes (3306155 objects)
Total retained:  13925894 bytes (131326 objects)

allocated memory by gem
---
   439818524  rubygems
    16616514  stripe-ruby/lib
     1504158  activesupport-8.1.2.1
      873891  uri-1.1.1
      645135  ffi-1.17.4-arm64-darwin
      605035  nokogiri-1.19.1-arm64-darwin
      584370  activerecord-8.1.2.1
      549698  marcel-1.1.0
      535903  concurrent-ruby-1.3.6
      487507  prism-1.9.0
      377689  actionpack-8.1.2.1
      339879  rack-3.2.6
      308579  railties-8.1.2.1
      298661  mail-2.9.0
      269680  specifications

retained memory by gem
---
     7872970  stripe-ruby/lib
      739130  rubygems
      464421  activesupport-8.1.2.1
      418754  marcel-1.1.0
      356367  ffi-1.17.4-arm64-darwin
      325192  nokogiri-1.19.1-arm64-darwin
      321503  activerecord-8.1.2.1
      275114  prism-1.9.0
      272628  uri-1.1.1
      237443  concurrent-ruby-1.3.6
      227008  rack-3.2.6
      214818  actionpack-8.1.2.1
      210840  specifications
      206514  arm64-darwin24
      178966  mail-2.9.0

allocated objects by gem
---
     3033056  rubygems
      160852  stripe-ruby/lib
       16133  activesupport-8.1.2.1
        8940  uri-1.1.1
        8545  marcel-1.1.0
        6233  ffi-1.17.4-arm64-darwin
        5963  activerecord-8.1.2.1
        5882  nokogiri-1.19.1-arm64-darwin
        5735  concurrent-ruby-1.3.6
        4535  prism-1.9.0
        3797  actionpack-8.1.2.1
        3549  rack-3.2.6
        3295  mail-2.9.0
        3139  specifications
        2999  railties-8.1.2.1
```
</details>

<details>
<summary>Raw output — after (autoload), with Rails 8.1</summary>

```
Total allocated: 82478797 bytes (727675 objects)
Total retained:  6210090 bytes (59783 objects)

allocated memory by gem
---
    71196104  rubygems
     1504158  activesupport-8.1.2.1
      873891  uri-1.1.1
      645135  ffi-1.17.4-arm64-darwin
      605035  nokogiri-1.19.1-arm64-darwin
      584370  activerecord-8.1.2.1
      549698  marcel-1.1.0
      535903  concurrent-ruby-1.3.6
      517082  stripe-ruby/lib
      487507  prism-1.9.0
      377689  actionpack-8.1.2.1
      339879  rack-3.2.6
      308579  railties-8.1.2.1
      298670  mail-2.9.0
      269680  specifications

retained memory by gem
---
      560294  rubygems
      464381  activesupport-8.1.2.1
      418754  marcel-1.1.0
      356367  ffi-1.17.4-arm64-darwin
      336042  stripe-ruby/lib
      325192  nokogiri-1.19.1-arm64-darwin
      321503  activerecord-8.1.2.1
      275114  prism-1.9.0
      272628  uri-1.1.1
      237443  concurrent-ruby-1.3.6
      227008  rack-3.2.6
      214818  actionpack-8.1.2.1
      210840  specifications
      206514  arm64-darwin24
      178966  mail-2.9.0

allocated objects by gem
---
      610066  rubygems
       16133  activesupport-8.1.2.1
        8940  uri-1.1.1
        8545  marcel-1.1.0
        6233  ffi-1.17.4-arm64-darwin
        5963  activerecord-8.1.2.1
        5882  nokogiri-1.19.1-arm64-darwin
        5735  concurrent-ruby-1.3.6
        5362  stripe-ruby/lib
        4535  prism-1.9.0
        3797  actionpack-8.1.2.1
        3549  rack-3.2.6
        3295  mail-2.9.0
        3139  specifications
        2999  railties-8.1.2.1
```
</details>

Ref #1432
