### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -201,6 +201,9 @@ module Stripe
       )
       req_opts = RequestOptions.extract_opts_from_hash(req_opts)
 
+      notice = http_resp["stripe-notice"]
+      warn("WARNING: #{notice}") if notice
+
       resp = interpret_response(http_resp)
 
       # If being called from `APIRequestor#request`, put the last response in

--- a/test/stripe/api_requestor_test.rb
+++ b/test/stripe/api_requestor_test.rb
@@ -1312,6 +1312,29 @@ module Stripe
     end
 
     context "#execute_request" do
+      context "Stripe-Notice header" do
+        should "emit a warning when the header is present" do
+          stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/charges")
+            .to_return(
+              body: JSON.generate(object: "charge"),
+              headers: { "Stripe-Notice" => "This is a notice" }
+            )
+
+          requestor = APIRequestor.new("sk_test_123")
+          requestor.expects(:warn).with("WARNING: This is a notice")
+          requestor.execute_request(:post, "/v1/charges", :api)
+        end
+
+        should "not emit a warning when the header is absent" do
+          stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/charges")
+            .to_return(body: JSON.generate(object: "charge"))
+
+          requestor = APIRequestor.new("sk_test_123")
+          requestor.expects(:warn).never
+          requestor.execute_request(:post, "/v1/charges", :api)
+        end
+      end
+
       should "handle success response with empty body" do
         stub_request(:post, "#{Stripe::DEFAULT_API_BASE}/v1/charges")
           .to_return(body: "", status: 200)


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
