### PR TITLE
Fix V2 namespace singularization

### DIFF
--- a/lib/stripe/services.rb
+++ b/lib/stripe/services.rb
@@ -336,9 +336,9 @@ module Stripe
     autoload :MoneyManagementService, "stripe/services/v2/money_management_service"
     autoload :NetworkService, "stripe/services/v2/network_service"
     autoload :OrchestratedCommerceService, "stripe/services/v2/orchestrated_commerce_service"
-    autoload :PaymentService, "stripe/services/v2/payment_service"
+    autoload :PaymentsService, "stripe/services/v2/payments_service"
     autoload :ReportingService, "stripe/services/v2/reporting_service"
-    autoload :SignalService, "stripe/services/v2/signal_service"
+    autoload :SignalsService, "stripe/services/v2/signals_service"
     autoload :TaxService, "stripe/services/v2/tax_service"
     autoload :TestHelperService, "stripe/services/v2/test_helper_service"
 
@@ -847,15 +847,15 @@ module Stripe
     stripe/services/v2/network_service
     stripe/services/v2/orchestrated_commerce/agreement_service
     stripe/services/v2/orchestrated_commerce_service
-    stripe/services/v2/payment_service
     stripe/services/v2/payments/off_session_payment_service
     stripe/services/v2/payments/settlement_allocation_intent_service
     stripe/services/v2/payments/settlement_allocation_intents/split_service
+    stripe/services/v2/payments_service
     stripe/services/v2/reporting/report_run_service
     stripe/services/v2/reporting/report_service
     stripe/services/v2/reporting_service
-    stripe/services/v2/signal_service
     stripe/services/v2/signals/account_signal_service
+    stripe/services/v2/signals_service
     stripe/services/v2/tax/manual_rule_service
     stripe/services/v2/tax_service
     stripe/services/v2/test_helper_service

--- a/lib/stripe/services/v2/payments_service.rb
+++ b/lib/stripe/services/v2/payments_service.rb
@@ -3,7 +3,7 @@
 
 module Stripe
   module V2
-    class PaymentService < StripeService
+    class PaymentsService < StripeService
       attr_reader :off_session_payments, :settlement_allocation_intents
 
       def initialize(requestor)

--- a/lib/stripe/services/v2/signals_service.rb
+++ b/lib/stripe/services/v2/signals_service.rb
@@ -3,7 +3,7 @@
 
 module Stripe
   module V2
-    class SignalService < StripeService
+    class SignalsService < StripeService
       attr_reader :account_signals
 
       def initialize(requestor)

--- a/lib/stripe/services/v2_services.rb
+++ b/lib/stripe/services/v2_services.rb
@@ -16,9 +16,9 @@ module Stripe
       @money_management = Stripe::V2::MoneyManagementService.new(@requestor)
       @network = Stripe::V2::NetworkService.new(@requestor)
       @orchestrated_commerce = Stripe::V2::OrchestratedCommerceService.new(@requestor)
-      @payments = Stripe::V2::PaymentService.new(@requestor)
+      @payments = Stripe::V2::PaymentsService.new(@requestor)
       @reporting = Stripe::V2::ReportingService.new(@requestor)
-      @signals = Stripe::V2::SignalService.new(@requestor)
+      @signals = Stripe::V2::SignalsService.new(@requestor)
       @tax = Stripe::V2::TaxService.new(@requestor)
       @test_helpers = Stripe::V2::TestHelperService.new(@requestor)
     end

--- a/rbi/stripe/services/v2/payments_service.rbi
+++ b/rbi/stripe/services/v2/payments_service.rbi
@@ -4,7 +4,7 @@
 # typed: true
 module Stripe
   module V2
-    class PaymentService < StripeService
+    class PaymentsService < StripeService
       attr_reader :off_session_payments
       attr_reader :settlement_allocation_intents
     end

--- a/rbi/stripe/services/v2/signals_service.rbi
+++ b/rbi/stripe/services/v2/signals_service.rbi
@@ -4,7 +4,7 @@
 # typed: true
 module Stripe
   module V2
-    class SignalService < StripeService
+    class SignalsService < StripeService
       attr_reader :account_signals
     end
   end


### PR DESCRIPTION
### Why?

The codegen incorrectly singularized V2 namespace-promoted service names (`Stripe::V2::PaymentService` instead of `Stripe::V2::PaymentsService`). This was a latent bug that only manifested when new V2 namespaces were added.

### What?

- Renames `Stripe::V2::PaymentService` to `Stripe::V2::PaymentsService`

### See Also

## Changelog

- ⚠️ Renames `Stripe::V2::PaymentService` to `Stripe::V2::PaymentsService` to more closely match our API naming