### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "digest"
+require "socket"
 require "stripe/instrumentation"
 
 module Stripe
@@ -1066,6 +1068,31 @@ module Stripe
     # in so that we can generate a rich user agent header to help debug
     # integrations.
     class SystemProfiler
+      UNAME_HASH = begin
+        parts = []
+        parts << if RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
+                   begin
+                     `ver 2>NUL`.strip
+                   rescue StandardError
+                     ""
+                   end
+                 else
+                   begin
+                     `uname -a 2>/dev/null`.strip
+                   rescue StandardError
+                     ""
+                   end
+                 end
+        parts << begin
+          Socket.gethostname
+        rescue StandardError
+          ""
+        end
+        Digest::MD5.hexdigest(parts.join(" "))
+      rescue StandardError
+        ""
+      end
+
       AI_AGENTS = [
         # aiAgents: The beginning of the section generated from our OpenAPI spec
         %w[ANTIGRAVITY_CLI_ALIAS antigravity],
@@ -1101,7 +1128,10 @@ module Stripe
           engine: defined?(RUBY_ENGINE) ? RUBY_ENGINE : "",
         }.delete_if { |_k, v| v.nil? }
 
-        ua[:platform] = RUBY_PLATFORM if Stripe.enable_telemetry?
+        if Stripe.enable_telemetry?
+          ua[:platform] = RUBY_PLATFORM
+          ua[:source] = UNAME_HASH unless UNAME_HASH.empty?
+        end
 
         ai_agent = detect_ai_agent
         ua[:ai_agent] = ai_agent unless ai_agent.empty?

--- a/test/stripe/api_requestor_test.rb
+++ b/test/stripe/api_requestor_test.rb
@@ -1799,6 +1799,32 @@ module Stripe
       ensure
         Stripe.enable_telemetry = false
       end
+
+      should "omit source when UNAME_HASH is empty" do
+        original = APIRequestor::SystemProfiler::UNAME_HASH
+        APIRequestor::SystemProfiler.send(:remove_const, :UNAME_HASH)
+        APIRequestor::SystemProfiler.const_set(:UNAME_HASH, "")
+        Stripe.enable_telemetry = true
+        ua = APIRequestor::SystemProfiler.user_agent
+        refute ua.key?(:source)
+      ensure
+        APIRequestor::SystemProfiler.send(:remove_const, :UNAME_HASH)
+        APIRequestor::SystemProfiler.const_set(:UNAME_HASH, original)
+        Stripe.enable_telemetry = false
+      end
+
+      should "include source when UNAME_HASH is non-empty" do
+        original = APIRequestor::SystemProfiler::UNAME_HASH
+        APIRequestor::SystemProfiler.send(:remove_const, :UNAME_HASH)
+        APIRequestor::SystemProfiler.const_set(:UNAME_HASH, "abc123")
+        Stripe.enable_telemetry = true
+        ua = APIRequestor::SystemProfiler.user_agent
+        assert_equal "abc123", ua[:source]
+      ensure
+        APIRequestor::SystemProfiler.send(:remove_const, :UNAME_HASH)
+        APIRequestor::SystemProfiler.const_set(:UNAME_HASH, original)
+        Stripe.enable_telemetry = false
+      end
     end
 
     context ".detect_ai_agent" do


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
