### PR TITLE
docs: clarify private preview SDK access in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Stripe.add_beta_version("feature_beta", "v3")
 
 ### Private Preview SDKs
 
-Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `11.2.0-alpha.2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-ruby?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`.
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `11.2.0-alpha.2`. You can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-ruby?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`. Note that access to specific private preview API features may require separate approval.
 
 ### Custom requests
 


### PR DESCRIPTION
### Why?
The private preview SDK section previously said "These are invite-only features. Once invited, you can install..." — implying users need an invitation to _install_ the SDK. In reality, anyone can install the `-alpha.X` SDK versions. It's only the private preview API _features_ that may require separate access approval.

This corrects the framing so developers aren't confused or discouraged from installing the SDK when they see "invite-only."

### What?
- README: remove "invite-only" language from the Private Preview SDKs section
- Clarify that SDK installation is open to anyone, and that separate approval may be required for specific private preview API features

### See Also
<!-- N/A -->