### PR TITLE
Upgrade CI runners from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions: {}
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -46,8 +46,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.ruby-version }})
-    # this version of jruby isn't available in the new latest (24.04) so we have to pin (or update jruby)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     strategy:
@@ -73,7 +72,7 @@ jobs:
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
       startsWith(github.ref, 'refs/tags/v')
     needs: [build, test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         # following https://docs.stripe.com/sdks/versioning?lang=ruby#stripe-sdk-language-version-support-policy
-        ruby-version: [2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4.0.0, truffleruby-25.0.0]
+        ruby-version: [2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4.7.0, truffleruby-25.0.0]
     steps:
     - uses: extractions/setup-just@v2
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Why?
ubuntu-22.04 is EOL next year and our more powerful runners are already on ubuntu-24.04.  this upgrades stripe-ruby to ubuntu-24.04 so we can stay ahead of the EOL and standardize on a single runner version

### What?
- `build` job: `ubuntu-22.04` → `ubuntu-24.04`
- `test` job: `ubuntu-22.04` → `ubuntu-24.04`
- `test` job: upgrade `jruby-9.4.0.0` to `jruby-9.4.7.0` for compatibility with `ubuntu-24.04` and removed stale comment
- `publish` job: `ubuntu-22.04` → `ubuntu-24.04`

### See Also
- DEVSDK-2337: https://go/j/DEVSDK-2337

