### PR TITLE
Make Error fields generated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Layout/LineLength:
   Exclude:
     - "lib/stripe/object_types.rb"
     - "lib/stripe/stripe_client.rb"
+    - "lib/stripe/error_object.rb"
     - "lib/stripe/resources/**/*.rb"
     - "lib/stripe/services/**/*.rb"
     - "lib/stripe/events/**/*.rb"

--- a/lib/stripe/error_object.rb
+++ b/lib/stripe/error_object.rb
@@ -11,69 +11,93 @@ module Stripe
     # methods would cause users to run into `NoMethodError` exceptions and
     # get in the way of generic error handling.
 
+    # errorFields: The beginning of the section generated from our OpenAPI spec
+    # For card errors resulting from a card issuer decline, a short string indicating [how to proceed with an error](https://docs.stripe.com/declines#retrying-issuer-declines) if they provide one.
+    def advice_code
+      @values[:advice_code]
+    end
+
     # For card errors, the ID of the failed charge.
     def charge
       @values[:charge]
     end
 
-    # For some errors that could be handled programmatically, a short string
-    # indicating the error code reported.
+    # For some errors that could be handled programmatically, a short string indicating the [error code](https://docs.stripe.com/error-codes) reported.
     def code
       @values[:code]
     end
 
-    # For card errors resulting from a card issuer decline, a short string
-    # indicating the card issuer's reason for the decline if they provide one.
+    # For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://docs.stripe.com/declines#issuer-declines) if they provide one.
     def decline_code
       @values[:decline_code]
     end
 
-    # A URL to more information about the error code reported.
+    # A URL to more information about the [error code](https://docs.stripe.com/error-codes) reported.
     def doc_url
       @values[:doc_url]
     end
 
-    # A human-readable message providing more details about the error. For card
-    # errors, these messages can be shown to your users.
+    # A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
     def message
       @values[:message]
     end
 
-    # If the error is parameter-specific, the parameter related to the error.
-    # For example, you can use this to display a message near the correct form
-    # field.
+    # For card errors resulting from a card issuer decline, a 2 digit code which indicates the advice given to merchant by the card network on how to proceed with an error.
+    def network_advice_code
+      @values[:network_advice_code]
+    end
+
+    # For payments declined by the network, an alphanumeric code which indicates the reason the payment failed.
+    def network_decline_code
+      @values[:network_decline_code]
+    end
+
+    # If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field.
     def param
       @values[:param]
     end
 
-    # The PaymentIntent object for errors returned on a request involving a
-    # PaymentIntent.
+    # The PaymentIntent object for errors returned on a request involving a PaymentIntent.
     def payment_intent
       @values[:payment_intent]
     end
 
-    # The PaymentMethod object for errors returned on a request involving a
-    # PaymentMethod.
+    # The PaymentMethod object for errors returned on a request involving a PaymentMethod.
     def payment_method
       @values[:payment_method]
     end
 
-    # The SetupIntent object for errors returned on a request involving a
-    # SetupIntent.
+    # If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors.
+    def payment_method_type
+      @values[:payment_method_type]
+    end
+
+    # A URL to the request log entry in your dashboard.
+    def request_log_url
+      @values[:request_log_url]
+    end
+
+    # The SetupIntent object for errors returned on a request involving a SetupIntent.
     def setup_intent
       @values[:setup_intent]
     end
 
-    # The source object for errors returned on a request involving a source.
+    # The PaymentSource object for errors returned on a request involving a PaymentSource.
     def source
       @values[:source]
     end
 
-    # The type of error returned. One of `api_error`, `card_error`,
-    # `idempotency_error`, or `invalid_request_error`.
+    # The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
     def type
       @values[:type]
     end
+
+    # The user message associated with the error.
+    def user_message
+      @values[:user_message]
+    end
+
+    # errorFields: The end of the section generated from our OpenAPI spec
   end
 
   # Represents on OAuth error returned by the OAuth API.

--- a/test/stripe/errors_test.rb
+++ b/test/stripe/errors_test.rb
@@ -14,6 +14,12 @@ module Stripe
         end
       end
 
+      should "expose network_advice_code from error body" do
+        e = StripeError.new("message", json_body: { error: { type: "card_error", network_advice_code: "02" } })
+        assert_not_nil e.error
+        assert_equal "02", e.error.network_advice_code
+      end
+
       context "#idempotent_replayed?" do
         should "initialize from header" do
           e = StripeError.new("message", http_headers: { "idempotent-replayed" => "true" })


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our main API Error class has always been handwritten. As new fields have been added to `api_errors` in the spec over time (e.g. `advice_code`, `network_advice_code`, `network_decline_code`), we haven't picked them up in the SDKs.

This makes most of those properties generated so they stay in sync.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Makes the fields on the API error object generated from the OpenAPI spec
- Adds section markers so codegen can maintain these fields going forward
- add tests
- except error.rb from the long line linter 😠

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2568](https://go/j/RUN_DEVSDK-2568)
- https://github.com/stripe/stripe-go/issues/2384
