### PR TITLE
fail on lint/format failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         ruby-version:  3.1
     - name: Lint
-      run: just lint
+      run: just lint-check
     - name: Build
       run: gem build stripe.gemspec
     - name: 'Upload Artifact'

--- a/test/stripe/telemetry_id_test.rb
+++ b/test/stripe/telemetry_id_test.rb
@@ -14,7 +14,12 @@ module Stripe
     end
 
     context ".config_dir" do
-      if RUBY_PLATFORM !~ /mingw|mswin/
+      if RUBY_PLATFORM =~ /mingw|mswin/
+        should "return APPDATA/Stripe on Windows" do
+          refute_nil TelemetryId.config_dir
+          assert TelemetryId.config_dir.end_with?("Stripe")
+        end
+      else
         should "return XDG_CONFIG_HOME/stripe when XDG_CONFIG_HOME is set" do
           with_env("XDG_CONFIG_HOME" => "/tmp/xdg") do
             assert_equal "/tmp/xdg/stripe", TelemetryId.config_dir
@@ -31,11 +36,6 @@ module Stripe
           with_env("XDG_CONFIG_HOME" => "") do
             assert_equal ::File.expand_path("~/.config/stripe"), TelemetryId.config_dir
           end
-        end
-      else
-        should "return APPDATA/Stripe on Windows" do
-          refute_nil TelemetryId.config_dir
-          assert TelemetryId.config_dir.end_with?("Stripe")
         end
       end
     end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Ruby's `just lint` would autoformat files. So we ended up in a situation where CI passes, but includes a diff. That's not a big deal, but it means later codegen runs will produce a GA PR even if there's no change to generated code. A separate bug meant that that codegen PR used a stale branch, so a missed bit of formatting in ruby + (separately) a new generate meant codegen was failing upstream. 🍝 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- use `just lint-check` instead of `just lint` in CI, which fails instead of autocorrecting
- format a previously unformatted test file

### See Also
<!-- Include any links or additional information that help explain this change. -->
