### PR TITLE
Discard the connection when a request is interrupted

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Exclude:
     - "lib/stripe/api_requestor.rb"
+    - "lib/stripe/connection_manager.rb"
     - "lib/stripe/stripe_object.rb"
     - "lib/stripe/util.rb"
 

--- a/lib/stripe/connection_manager.rb
+++ b/lib/stripe/connection_manager.rb
@@ -66,6 +66,10 @@ module Stripe
     # allows a request body, headers, and query string to be specified.
     def execute_request(method, uri, body: nil, headers: nil, query: nil,
                         &block)
+      # Assigned up front so that the rescue below can tell whether a connection was ever
+      # obtained. Argument validation, for instance, fails before one exists.
+      connection = nil
+
       # Perform some basic argument validation because it's easy to get
       # confused between strings and hashes for things like body and query
       # parameters.
@@ -129,11 +133,37 @@ module Stripe
                      log_timestamp: Util.monotonic_time)
 
       resp
+    rescue Exception # rubocop:disable Lint/RescueException
+      discard_connection(connection)
+      raise
     end
 
     #
     # private
     #
+
+    # Closes a connection and drops it from internal tracking. Accepts `nil` for the case where a
+    # request failed before a connection was obtained.
+    #
+    # `Net::HTTP` closes its own socket when a request fails with a `StandardError`, but an
+    # exception outside that hierarchy — an asynchronous `Thread#raise` from a request-timeout
+    # mechanism, for example — unwinds past those rescue clauses. The socket is then left open
+    # with the response still unread, and because `end_transport` never ran, `@last_communicated`
+    # is unset, which makes `begin_transport` skip both its keep-alive-timeout and EOF checks. The
+    # next request to reuse that connection reads the abandoned response rather than its own.
+    private def discard_connection(connection)
+      return if connection.nil?
+
+      @mutex.synchronize do
+        @active_connections.delete_if { |_, active| active.equal?(connection) }
+      end
+
+      connection.finish
+    rescue IOError
+      # The connection was never started, so there is nothing to close. Swallowed so that this
+      # cleanup can never replace the exception that triggered it.
+      nil
+    end
 
     # `uri` should be a parsed `URI` object.
     private def create_connection(uri)

--- a/test/stripe/connection_manager_test.rb
+++ b/test/stripe/connection_manager_test.rb
@@ -227,6 +227,36 @@ module Stripe
         manager.execute_request(:post, "#{Stripe.api_base}/path")
         assert_equal t + 1.0, manager.last_used
       end
+
+      should "discard the connection when a request is interrupted by a non-StandardError" do
+        stub_request(:post, "#{Stripe.api_base}/path")
+          .to_return(body: JSON.generate(object: "account"))
+
+        @manager.execute_request(:post, "#{Stripe.api_base}/path")
+        refute_empty @manager.instance_variable_get(:@active_connections)
+
+        # `Interrupt` stands in for any exception outside the `StandardError` hierarchy, such as
+        # the asynchronous `Thread#raise` a request-timeout mechanism performs. `Net::HTTP` does
+        # not close its socket for these, so without cleanup the connection would be reused with
+        # the previous response still buffered on it.
+        stub_request(:post, "#{Stripe.api_base}/path").to_raise(Interrupt)
+
+        assert_raises Interrupt do
+          @manager.execute_request(:post, "#{Stripe.api_base}/path")
+        end
+
+        assert_equal({}, @manager.instance_variable_get(:@active_connections))
+      end
+
+      should "keep the connection when a request succeeds" do
+        stub_request(:post, "#{Stripe.api_base}/path")
+          .to_return(body: JSON.generate(object: "account"))
+
+        @manager.execute_request(:post, "#{Stripe.api_base}/path")
+        @manager.execute_request(:post, "#{Stripe.api_base}/path")
+
+        assert_equal 1, @manager.instance_variable_get(:@active_connections).count
+      end
     end
   end
 end


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Net::HTTP closes its own socket when a request fails with a StandardError, but an exception outside that hierarchy unwinds past those rescue clauses -- an asynchronous Thread#raise from a request-timeout mechanism, for example. The socket is then left open with the response still unread, and because end_transport never ran, @last_communicated is unset, which makes begin_transport skip both its keep-alive-timeout and EOF checks. The next request to reuse that connection reads the abandoned response rather than its own, so a PaymentIntent create can come back as, say, a Customer.

Close and untrack the connection when execute_request unwinds for any reason. The connection is captured in a local so cleanup is skipped when a request failed before one was obtained, such as on argument validation.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds `ConnectionManager#discard_connection` private method that closes the TCP socket and removes it from `@active_connections`, swallowing `IOError` if the connection was never started
- Adds `.rubocop.yml` exclusion for the intentional `rescue Exception`
- Adds tests verifying the connection is discarded on non-StandardError interruption and retained on success

### See Also
<!-- Include any links or additional information that help explain this change. -->
#1921 
http://go/j/RUN_DEVSDK-2643

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with nil argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
- Fix connection reuse after a request is interrupted by a non-StandardError exception (e.g. from rack-timeout), which could cause subsequent requests to receive a previous request's response