### PR TITLE
Surface `object` property on `EventNotification`

### DIFF
--- a/lib/stripe/resources/v2/core/event_notification.rb
+++ b/lib/stripe/resources/v2/core/event_notification.rb
@@ -32,10 +32,11 @@ module Stripe
       end
 
       class EventNotification
-        attr_reader :id, :type, :created, :context, :livemode, :reason
+        attr_reader :id, :object, :type, :created, :context, :livemode, :reason
 
         def initialize(event_payload, client)
           @id = event_payload[:id]
+          @object = event_payload[:object]
           @type = event_payload[:type]
           @created = event_payload[:created]
           @livemode = event_payload[:livemode]

--- a/rbi/stripe/resources/v2/core/event_notification.rbi
+++ b/rbi/stripe/resources/v2/core/event_notification.rbi
@@ -28,6 +28,8 @@ module Stripe
         sig { returns(String) }
         def id; end
         sig { returns(String) }
+        def object; end
+        sig { returns(String) }
         def type; end
         sig { returns(String) }
         def created; end

--- a/test/stripe/v2_event_test.rb
+++ b/test/stripe/v2_event_test.rb
@@ -106,6 +106,7 @@ module Stripe
           event = parse_signed_event(@v2_push_payload)
           assert event.is_a?(Stripe::V2::Core::EventNotification)
           assert_equal "evt_234", event.id
+          assert_equal "v2.core.event", event.object
           assert_equal "v1.billing.meter.error_report_triggered", event.type
           assert_equal "2022-02-15T00:27:45.330Z", event.created
           assert_nil event.reason


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`object` is present in the original payload, but we didn't surface it on the `EventNotification` class. Because ``v2.core.event"` is the only value that will ever be present, It didn't seem worth adding it to the interface.

I also wanted to better differentiate `EventNotification`s from all other `StripeObject`s (since they _do_ behave differently).

But, that also means interacting with it along with other objects is unnecessarily complicated. From the [original ruby issue](https://github.com/stripe/stripe-ruby/issues/1860):

```rb
def v1?(event)
  (event.try(:object) || event.try(:dig, "object")) == "event"
end

def v2?(event)
  event.is_a?(::Stripe::V2::Core::EventNotification) || # thin event notification
    (event.try(:object) || event.try(:dig, "object")) == "v2.core.event"
end
```

Because the value is present in the original response, it doesn't make sense to eat it.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add public `object` property to `EventNotification`
- add test

### See Also

<!-- Include any links or additional information that help explain this change. -->

- originally brought up in [stripe/stripe-ruby#1860](https://github.com/stripe/stripe-ruby/issues/1860)
- [DEVSDK-3101](https://go/j/DEVSDK-3101)
