### PR TITLE
Merge to private-preview

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,6 +18,10 @@
 - Version: `lib/stripe/version.rb`
 - Sorbet type definitions: `rbi/`. NEVER read `rbi/stripe.rbi`, since it's a huge file that collects data already present in other `.rbi` files
 
+## RBI Type Annotations
+
+When adding or modifying public methods on non-generated files, you **must** also update the corresponding `rbi/stripe/stripe_client.rbi` with matching Sorbet type signatures. This file provides type information for tools and IDEs.
+
 ## Generated Code
 
 - Files containing `File generated from our OpenAPI spec` at the top are generated; do not edit. Similarly, any code block starting with `The beginning of the section generated from our OpenAPI spec` is generated and should not be edited directly.

--- a/lib/stripe/resources/v2/core/event_notification.rb
+++ b/lib/stripe/resources/v2/core/event_notification.rb
@@ -32,10 +32,11 @@ module Stripe
       end
 
       class EventNotification
-        attr_reader :id, :type, :created, :context, :livemode, :reason
+        attr_reader :id, :object, :type, :created, :context, :livemode, :reason
 
         def initialize(event_payload, client)
           @id = event_payload[:id]
+          @object = event_payload[:object]
           @type = event_payload[:type]
           @created = event_payload[:created]
           @livemode = event_payload[:livemode]

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -60,18 +60,43 @@ module Stripe
     extend Gem::Deprecate
     deprecate :request, :raw_request, 2024, 9
 
+    # Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from
+    # an incoming webhook after verifying its authenticity. To work with a webhook that has already been
+    # verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see
+    # `parse_event_notification_without_verification`.
     def parse_event_notification(payload, sig_header, secret, tolerance: Webhook::DEFAULT_TOLERANCE)
       payload = payload.force_encoding("UTF-8") if payload.respond_to?(:force_encoding)
 
       # v2 events use the same signing mechanism as v1 events
       Webhook::Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
+      build_event_notification(payload)
+    end
 
-      parsed = JSON.parse(payload, symbolize_names: true)
+    # Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from
+    # an incoming webhook without first verifying its authenticity. Should be used after calling
+    # `Webhook::Signature.verify_header` or with input from a trusted source (such as
+    # [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or
+    # [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify &
+    # parse in a single call, use `parse_event_notification` instead.
+    def parse_event_notification_without_verification(payload)
+      build_event_notification(Webhook.send(:_maybe_extract_from_cloud_provider_envelope, payload))
+    end
+
+    private def build_event_notification(payload)
+      parsed = if payload.is_a?(String)
+                 JSON.parse(payload, symbolize_names: true)
+               else
+                 payload
+               end
 
       if parsed[:object] == "event"
         raise ArgumentError,
-              "You passed a webhook payload to StripeClient#parse_event_notification, which " \
-              "expects an event notification. Use Webhook.construct_event instead."
+              "You passed a webhook payload to a method that expects a thin event notification. Use the corresponding construct_event* method instead."
+      end
+
+      if parsed[:object] != "v2.core.event"
+        raise ArgumentError,
+              "Unexpected object type '#{parsed[:object]}'. Expected 'v2.core.event' for an event notification."
       end
 
       cls = Util.event_notification_classes.fetch(parsed[:type], Stripe::Events::UnknownEventNotification)

--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -4,10 +4,10 @@ module Stripe
   module Webhook
     DEFAULT_TOLERANCE = 300
 
-    # Initializes an Event object from a JSON payload.
-    #
-    # This may raise JSON::ParserError if the payload is not valid JSON, or
-    # SignatureVerificationError if the signature verification fails.
+    # Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an
+    # incoming webhook after verifying its authenticity. To work with a webhook that has already been
+    # verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see
+    # `construct_event_without_verification`.
     def self.construct_event(payload, sig_header, secret,
                              tolerance: DEFAULT_TOLERANCE)
       Signature.verify_header(payload, sig_header, secret, tolerance: tolerance)
@@ -17,16 +17,56 @@ module Stripe
       # flood a target's memory if they were on an older version of Ruby that
       # doesn't GC symbols. It also decreases the likelihood that we receive a
       # bad payload that fails to parse and throws an exception.
-      data = JSON.parse(payload, symbolize_names: true)
+      _build_v1_event(payload)
+    end
+
+    # Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an
+    # incoming webhook without first verifying its authenticity. Should be used after calling
+    # `Webhook::Signature.verify_header` or with input from a trusted source (such as
+    # [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or
+    # [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify &
+    # construct in a single call, use `Webhook.construct_event` instead.
+    def self.construct_event_without_verification(payload)
+      _build_v1_event(_maybe_extract_from_cloud_provider_envelope(payload))
+    end
+
+    def self._build_v1_event(payload)
+      data = payload.is_a?(String) ? JSON.parse(payload, symbolize_names: true) : payload
 
       if data[:object] == "v2.core.event"
         raise ArgumentError,
-              "You passed an event notification to Webhook.construct_event, which expects " \
-              "a webhook payload. Use StripeClient#parse_event_notification instead."
+              "You passed a thin event notification to a method that expects a webhook body. " \
+              "Use the corresponding #parse_event_notification* method instead"
       end
 
       Event.construct_from(data, {}, nil, :v1, APIRequestor.active_requestor)
     end
+    private_class_method :_build_v1_event
+
+    def self._maybe_extract_from_cloud_provider_envelope(payload)
+      payload = payload.encode("utf-8") if payload.respond_to?(:encode)
+      data = JSON.parse(payload, symbolize_names: true)
+
+      # Could add as many checks as we want here, but we'll start simple
+      if data.key?(:detail)
+        # AWS
+        # https://docs.stripe.com/event-destinations/eventbridge#event-structure
+        data[:detail]
+      elsif data.key?(:specversion) && data.key?(:data)
+        # Azure
+        # https://docs.stripe.com/event-destinations/eventgrid#event-structure
+        data[:data]
+      elsif %w[event v2.core.event].include?(data[:object])
+        # Raw Stripe event: pass through as-is
+        data
+      else
+        raise ArgumentError,
+              "Unrecognized event format. The payload must be an " \
+              "AWS EventBridge/Azure Event Grid event envelope or a Stripe webhook " \
+              "(thin event notification or snapshot)."
+      end
+    end
+    private_class_method :_maybe_extract_from_cloud_provider_envelope
 
     module Signature
       EXPECTED_SCHEME = "v1"
@@ -46,12 +86,8 @@ module Stripe
                                 timestamped_payload)
       end
 
-      # Generates a value that would be added to a `Stripe-Signature` for a
-      # given webhook payload.
-      #
-      # Note that this isn't needed to verify webhooks in any way, and is
-      # mainly here for use in test cases (those that are both within this
-      # project and without).
+      # Compute the `Stripe-Signature` header for a given webhook body & secret. Useful for signing
+      # payloads in unit tests.
       def self.generate_header(timestamp, signature, scheme: EXPECTED_SCHEME)
         raise ArgumentError, "timestamp should be an instance of Time" \
           unless timestamp.is_a?(Time)
@@ -73,16 +109,9 @@ module Stripe
       end
       private_class_method :get_timestamp_and_signatures
 
-      # Verifies the signature header for a given payload.
-      #
-      # Raises a SignatureVerificationError in the following cases:
-      # - the header does not match the expected format
-      # - no signatures found with the expected scheme
-      # - no signatures matching the expected signature
-      # - a tolerance is provided and the timestamp is not within the
-      #   tolerance
-      #
-      # Returns true otherwise
+      # Verifies the authenticity (and recency) of a webhook, raising a `SignatureVerificationError` if
+      # there's a mismatch. Useful for quickly validating incoming webhooks before storing them for later
+      # processing (at which time you can use the `*_without_verification` methods for parsing).
       def self.verify_header(payload, header, secret, tolerance: nil)
         begin
           timestamp, signatures =

--- a/rbi/stripe/resources/v2/core/event_notification.rbi
+++ b/rbi/stripe/resources/v2/core/event_notification.rbi
@@ -28,6 +28,8 @@ module Stripe
         sig { returns(String) }
         def id; end
         sig { returns(String) }
+        def object; end
+        sig { returns(String) }
         def type; end
         sig { returns(String) }
         def created; end

--- a/rbi/stripe/stripe_client.rbi
+++ b/rbi/stripe/stripe_client.rbi
@@ -3,6 +3,10 @@
 
 module Stripe
   class StripeClient
+    # Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from
+    # an incoming webhook after verifying its authenticity. To work with a webhook that has already been
+    # verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see
+    # `parse_event_notification_without_verification`.
     sig do
       params(
         payload: String,
@@ -12,6 +16,15 @@ module Stripe
       )
         .returns(::Stripe::V2::Core::EventNotification)
     end
-    def parse_event_notification(payload, sig_header, secret, tolerance:); end
+    def parse_event_notification(payload, sig_header, secret, tolerance: Webhook::DEFAULT_TOLERANCE); end
+
+    # Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from
+    # an incoming webhook without first verifying its authenticity. Should be used after calling
+    # `Webhook::Signature.verify_header` or with input from a trusted source (such as
+    # [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or
+    # [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify &
+    # parse in a single call, use `parse_event_notification` instead.
+    sig { params(payload: String).returns(::Stripe::V2::Core::EventNotification) }
+    def parse_event_notification_without_verification(payload); end
   end
 end

--- a/rbi/stripe/webhook.rbi
+++ b/rbi/stripe/webhook.rbi
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+# typed: true
+
+module Stripe
+  module Webhook
+    DEFAULT_TOLERANCE = 300
+
+    # Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an
+    # incoming webhook after verifying its authenticity. To work with a webhook that has already been
+    # verified (i.e. one from a cloud provider, an asynchronous queue, or during testing), see
+    # `construct_event_without_verification`.
+    sig do
+      params(
+        payload: String,
+        sig_header: String,
+        secret: String,
+        tolerance: T.nilable(Integer)
+      )
+        .returns(::Stripe::Event)
+    end
+    def self.construct_event(payload, sig_header, secret, tolerance: DEFAULT_TOLERANCE); end
+
+    # Constructs a [snapshot event](https://docs.stripe.com/event-destinations#snapshot-payload) from an
+    # incoming webhook without first verifying its authenticity. Should be used after calling
+    # `Webhook::Signature.verify_header` or with input from a trusted source (such as
+    # [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or
+    # [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify &
+    # construct in a single call, use `Webhook.construct_event` instead.
+    sig { params(payload: String).returns(::Stripe::Event) }
+    def self.construct_event_without_verification(payload); end
+
+    module Signature
+      EXPECTED_SCHEME = "v1"
+
+      # Computes a webhook signature given a time (probably the current time),
+      # a payload, and a signing secret.
+      sig do
+        params(
+          timestamp: Time,
+          payload: String,
+          secret: String
+        )
+          .returns(String)
+      end
+      def self.compute_signature(timestamp, payload, secret); end
+
+      # Compute the `Stripe-Signature` header for a given webhook body & secret. Useful for signing
+      # payloads in unit tests.
+      sig do
+        params(
+          timestamp: Time,
+          signature: String,
+          scheme: String
+        )
+          .returns(String)
+      end
+      def self.generate_header(timestamp, signature, scheme: EXPECTED_SCHEME); end
+
+      # Verifies the authenticity (and recency) of a webhook, raising a `SignatureVerificationError` if
+      # there's a mismatch. Useful for quickly validating incoming webhooks before storing them for later
+      # processing (at which time you can use the `*_without_verification` methods for parsing).
+      sig do
+        params(
+          payload: String,
+          header: String,
+          secret: String,
+          tolerance: T.nilable(Integer)
+        )
+          .returns(T::Boolean)
+      end
+      def self.verify_header(payload, header, secret, tolerance: nil); end
+    end
+  end
+end

--- a/test/stripe/cloud_provider_event_test.rb
+++ b/test/stripe/cloud_provider_event_test.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "stripe"
+require "test/unit"
+
+class CloudProviderEventTest < Test::Unit::TestCase
+  EVENTBRIDGE_V1_PAYLOAD = JSON.generate({
+    "version" => "0",
+    "id" => "17e8dff5-d6cd-3770-ace9-aeac02b6ac3f",
+    "detail-type" => "customer.created",
+    "source" => "aws.partner/stripe.com/ed_123",
+    "account" => "506417113029",
+    "time" => "2024-03-07T18:27:56Z",
+    "region" => "us-west-2",
+    "resources" => [],
+    "detail" => {
+      "id" => "evt_test_123",
+      "object" => "event",
+      "api_version" => "2023-10-16",
+      "created" => 1_709_836_076,
+      "data" => { "object" => { "id" => "cus_123", "object" => "customer" } },
+      "livemode" => true,
+      "pending_webhooks" => 0,
+      "request" => { "id" => "req_123", "idempotency_key" => nil },
+      "type" => "customer.created",
+    },
+  })
+
+  EVENTGRID_V1_PAYLOAD = JSON.generate({
+    "specversion" => "1.0",
+    "type" => "customer.created",
+    "source" => "/providers/stripe/ed_test_123",
+    "id" => "9aeb0fdf-c01e-0131-0922-9eb54906e209",
+    "time" => "2025-07-11T14:30:00Z",
+    "subject" => nil,
+    "dataContentType" => "application/cloudevents+json",
+    "data" => {
+      "id" => "evt_test_456",
+      "object" => "event",
+      "api_version" => "2023-10-16",
+      "created" => 1_709_836_076,
+      "data" => { "object" => { "id" => "cus_456", "object" => "customer" } },
+      "livemode" => false,
+      "pending_webhooks" => 0,
+      "request" => { "id" => "req_456", "idempotency_key" => nil },
+      "type" => "customer.created",
+    },
+  })
+
+  EVENTBRIDGE_V2_PAYLOAD = JSON.generate({
+    "version" => "0",
+    "id" => "17e8dff5-d6cd-3770-ace9-aeac02b6ac3f",
+    "detail-type" => "v1.billing.meter.error_report_triggered",
+    "source" => "aws.partner/stripe.com/ed_123",
+    "account" => "506417113029",
+    "time" => "2024-03-07T18:27:56Z",
+    "region" => "us-west-2",
+    "resources" => [],
+    "detail" => {
+      "id" => "evt_234",
+      "object" => "v2.core.event",
+      "type" => "v1.billing.meter.error_report_triggered",
+      "created" => "2022-02-15T00:27:45.330Z",
+      "related_object" => {
+        "id" => "mtr_123",
+        "type" => "billing.meter",
+        "url" => "/v1/billing/meters/mtr_123",
+      },
+    },
+  })
+
+  EVENTGRID_V2_PAYLOAD = JSON.generate({
+    "specversion" => "1.0",
+    "type" => "v1.billing.meter.error_report_triggered",
+    "source" => "/providers/stripe/ed_test_123",
+    "id" => "9aeb0fdf-c01e-0131-0922-9eb54906e209",
+    "time" => "2025-07-11T14:30:00Z",
+    "subject" => nil,
+    "dataContentType" => "application/cloudevents+json",
+    "data" => {
+      "id" => "evt_234",
+      "object" => "v2.core.event",
+      "type" => "v1.billing.meter.error_report_triggered",
+      "created" => "2022-02-15T00:27:45.330Z",
+      "related_object" => {
+        "id" => "mtr_123",
+        "type" => "billing.meter",
+        "url" => "/v1/billing/meters/mtr_123",
+      },
+    },
+  })
+
+  RAW_V1_EVENT_PAYLOAD = JSON.generate({
+    "id" => "evt_test_123",
+    "object" => "event",
+    "api_version" => "2023-10-16",
+    "created" => 1_709_836_076,
+    "data" => { "object" => { "id" => "cus_123", "object" => "customer" } },
+    "livemode" => true,
+    "pending_webhooks" => 0,
+    "request" => { "id" => "req_123", "idempotency_key" => nil },
+    "type" => "customer.created",
+  })
+
+  RAW_V2_EVENT_PAYLOAD = JSON.generate({
+    "id" => "evt_234",
+    "object" => "v2.core.event",
+    "type" => "v1.billing.meter.error_report_triggered",
+    "created" => "2022-02-15T00:27:45.330Z",
+    "related_object" => {
+      "id" => "mtr_123",
+      "type" => "billing.meter",
+      "url" => "/v1/billing/meters/mtr_123",
+    },
+  })
+
+  def setup
+    @client = Stripe::StripeClient.new("sk_test_fake")
+  end
+
+  # parse_event_notification_without_verification tests
+
+  def test_parse_notification_from_eventbridge
+    notification = @client.parse_event_notification_without_verification(EVENTBRIDGE_V2_PAYLOAD)
+    assert_instance_of Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification, notification
+    assert_equal "evt_234", notification.id
+    assert_equal "v1.billing.meter.error_report_triggered", notification.type
+  end
+
+  def test_parse_notification_from_event_grid
+    notification = @client.parse_event_notification_without_verification(EVENTGRID_V2_PAYLOAD)
+    assert_instance_of Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification, notification
+    assert_equal "evt_234", notification.id
+    assert_equal "v1.billing.meter.error_report_triggered", notification.type
+  end
+
+  def test_parse_notification_raises_when_cloud_event_contains_v1_event
+    error = assert_raises(ArgumentError) do
+      @client.parse_event_notification_without_verification(EVENTBRIDGE_V1_PAYLOAD)
+    end
+    assert_match(/construct_event/, error.message)
+  end
+
+  def test_parse_notification_invalid_json
+    assert_raises(JSON::ParserError) do
+      @client.parse_event_notification_without_verification("not valid json")
+    end
+  end
+
+  def test_parse_notification_unrecognized_format
+    error = assert_raises(ArgumentError) do
+      @client.parse_event_notification_without_verification('{"foo": "bar"}')
+    end
+    assert_match(/Unrecognized event format/, error.message)
+  end
+
+  def test_parse_raw_v2_event_notification
+    notification = @client.parse_event_notification_without_verification(RAW_V2_EVENT_PAYLOAD)
+    assert_instance_of Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification, notification
+    assert_equal "evt_234", notification.id
+    assert_equal "v1.billing.meter.error_report_triggered", notification.type
+  end
+
+  def test_construct_event_without_verification_via_webhook_module
+    event = Stripe::Webhook.construct_event_without_verification(EVENTBRIDGE_V1_PAYLOAD)
+    assert_instance_of Stripe::Event, event
+    assert_equal "evt_test_123", event.id
+    assert_equal "customer.created", event.type
+  end
+
+  def test_construct_event_via_webhook_module_rejects_v2_thin_event
+    error = assert_raises(ArgumentError) do
+      Stripe::Webhook.construct_event_without_verification(RAW_V2_EVENT_PAYLOAD)
+    end
+    assert_match(/thin event notification/, error.message)
+  end
+
+  def test_azure_envelope_missing_data_falls_through_construct_event
+    payload = JSON.generate({
+      "specversion" => "1.0",
+      "type" => "customer.created",
+      "source" => "/providers/stripe/ed_test_123",
+      "id" => "test-missing-data",
+    })
+    error = assert_raises(ArgumentError) do
+      Stripe::Webhook.construct_event_without_verification(payload)
+    end
+    assert_match(/Unrecognized event format/i, error.message)
+  end
+
+  def test_azure_envelope_missing_data_falls_through_parse_notification
+    payload = JSON.generate({
+      "specversion" => "1.0",
+      "type" => "customer.created",
+      "source" => "/providers/stripe/ed_test_123",
+      "id" => "test-missing-data",
+    })
+    error = assert_raises(ArgumentError) do
+      @client.parse_event_notification_without_verification(payload)
+    end
+    assert_match(/Unrecognized event format/i, error.message)
+  end
+
+  def test_unexpected_object_type_in_event_notification
+    payload = JSON.generate({
+      "version" => "0",
+      "detail" => {
+        "object" => "customer",
+        "type" => "customer.created",
+        "id" => "cus_123",
+      },
+    })
+    error = assert_raises(ArgumentError) do
+      @client.parse_event_notification_without_verification(payload)
+    end
+    assert_match(/Unexpected object type/, error.message)
+  end
+end

--- a/test/stripe/v2_event_test.rb
+++ b/test/stripe/v2_event_test.rb
@@ -106,6 +106,7 @@ module Stripe
           event = parse_signed_event(@v2_push_payload)
           assert event.is_a?(Stripe::V2::Core::EventNotification)
           assert_equal "evt_234", event.id
+          assert_equal "v2.core.event", event.object
           assert_equal "v1.billing.meter.error_report_triggered", event.type
           assert_equal "2022-02-15T00:27:45.330Z", event.created
           assert_nil event.reason

--- a/test/stripe/v2_event_test.rb
+++ b/test/stripe/v2_event_test.rb
@@ -99,7 +99,7 @@ module Stripe
           e = assert_raises(ArgumentError) do
             @client.parse_event_notification(v1_payload, header, Test::WebhookHelpers::SECRET)
           end
-          assert_match(/Webhook\.construct_event/, e.message)
+          assert_match(/construct_event/, e.message)
         end
 
         should "parse v2 events" do

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -11,6 +11,18 @@ module Stripe
       }
     PAYLOAD
 
+    V2_EVENT_PAYLOAD = JSON.generate({
+      "id" => "evt_234",
+      "object" => "v2.core.event",
+      "type" => "v1.billing.meter.error_report_triggered",
+      "created" => "2022-02-15T00:27:45.330Z",
+      "related_object" => {
+        "id" => "mtr_123",
+        "type" => "billing.meter",
+        "url" => "/v1/billing/meters/mtr_123",
+      },
+    })
+
     context ".compute_signature" do
       should "compute a signature which can then be verified" do
         timestamp = Time.now
@@ -70,7 +82,7 @@ module Stripe
         e = assert_raises(ArgumentError) do
           Stripe::Webhook.construct_event(v2_payload, header, Test::WebhookHelpers::SECRET)
         end
-        assert_match(/StripeClient#parse_event_notification/, e.message)
+        assert_match(/parse_event_notification/, e.message)
       end
 
       should "can call refresh on Event data object" do
@@ -91,6 +103,35 @@ module Stripe
 
         event.data.object.refresh
         assert_equal("cus_123", event.data.object.id)
+      end
+    end
+
+    context ".parse_event_notification" do
+      should "return a typed notification from a valid v2 payload with a valid signature" do
+        header = Test::WebhookHelpers.generate_header(payload: V2_EVENT_PAYLOAD)
+        client = Stripe::StripeClient.new("sk_test_fake")
+        notification = client.parse_event_notification(V2_EVENT_PAYLOAD, header, Test::WebhookHelpers::SECRET)
+        assert notification.is_a?(Stripe::V2::Core::EventNotification)
+        assert_equal "evt_234", notification.id
+        assert_equal "v1.billing.meter.error_report_triggered", notification.type
+      end
+
+      should "raise an ArgumentError when given a v1 event payload and suggest construct_event" do
+        payload = EVENT_PAYLOAD.dup
+        header = Test::WebhookHelpers.generate_header(payload: payload)
+        client = Stripe::StripeClient.new("sk_test_fake")
+        e = assert_raises(ArgumentError) do
+          client.parse_event_notification(payload, header, Test::WebhookHelpers::SECRET)
+        end
+        assert_match(/construct_event/, e.message)
+      end
+
+      should "raise a SignatureVerificationError when the signature is invalid" do
+        header = Test::WebhookHelpers.generate_header(payload: V2_EVENT_PAYLOAD, signature: "bad_signature")
+        client = Stripe::StripeClient.new("sk_test_fake")
+        assert_raises(Stripe::SignatureVerificationError) do
+          client.parse_event_notification(V2_EVENT_PAYLOAD, header, Test::WebhookHelpers::SECRET)
+        end
       end
     end
 


### PR DESCRIPTION
### Why?

Routine merge of master changes into the private-preview release channel.

### What?

Merged master into private-preview using sdk-codegen's automerge tooling (`tools/automerge/ruby-private-preview.yaml`). Manual resolution for `rbi/stripe/stripe_client.rbi`: combined master's new `parse_event_notification_without_verification` method with private-preview's `notification_handler` method.

### See Also

## Changelog

No user-facing changes (merge only).