### PR TITLE
Handle break in auto-paging blocks 🪿✨

### DIFF
--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -85,9 +85,11 @@ module Stripe
         end
 
         break if page.empty?
-rescue LocalJumpError => e
-  raise unless e.reason == :break
-  break
+      rescue LocalJumpError => e
+        raise unless e.reason == :break
+
+        break
+      end
     end
 
     # Returns true if the page object contains no elements.

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -85,9 +85,9 @@ module Stripe
         end
 
         break if page.empty?
-      rescue LocalJumpError
-        break
-      end
+rescue LocalJumpError => e
+  raise unless e.reason == :break
+  break
     end
 
     # Returns true if the page object contains no elements.

--- a/lib/stripe/list_object.rb
+++ b/lib/stripe/list_object.rb
@@ -85,6 +85,8 @@ module Stripe
         end
 
         break if page.empty?
+      rescue LocalJumpError
+        break
       end
     end
 

--- a/lib/stripe/search_result_object.rb
+++ b/lib/stripe/search_result_object.rb
@@ -71,9 +71,9 @@ module Stripe
         page = page.next_search_result_page
 
         break if page.empty?
-      rescue LocalJumpError
-        break
-      end
+rescue LocalJumpError => e
+  raise unless e.reason == :break
+  break
     end
 
     # Fetches the next page in the resource list (if there is one).

--- a/lib/stripe/search_result_object.rb
+++ b/lib/stripe/search_result_object.rb
@@ -71,9 +71,11 @@ module Stripe
         page = page.next_search_result_page
 
         break if page.empty?
-rescue LocalJumpError => e
-  raise unless e.reason == :break
-  break
+      rescue LocalJumpError => e
+        raise unless e.reason == :break
+
+        break
+      end
     end
 
     # Fetches the next page in the resource list (if there is one).

--- a/lib/stripe/search_result_object.rb
+++ b/lib/stripe/search_result_object.rb
@@ -71,6 +71,8 @@ module Stripe
         page = page.next_search_result_page
 
         break if page.empty?
+      rescue LocalJumpError
+        break
       end
     end
 

--- a/lib/stripe/v2_list_object.rb
+++ b/lib/stripe/v2_list_object.rb
@@ -58,9 +58,11 @@ module Stripe
           break if page.next_page_url.nil?
 
           page = page.fetch_next_page
-rescue LocalJumpError => e
-  raise unless e.reason == :break
-  break
+        rescue LocalJumpError => e
+          raise unless e.reason == :break
+
+          break
+        end
       end
 
       # Returns true if the page object contains no elements.

--- a/lib/stripe/v2_list_object.rb
+++ b/lib/stripe/v2_list_object.rb
@@ -58,6 +58,8 @@ module Stripe
           break if page.next_page_url.nil?
 
           page = page.fetch_next_page
+        rescue LocalJumpError
+          break
         end
       end
 

--- a/lib/stripe/v2_list_object.rb
+++ b/lib/stripe/v2_list_object.rb
@@ -58,9 +58,9 @@ module Stripe
           break if page.next_page_url.nil?
 
           page = page.fetch_next_page
-        rescue LocalJumpError
-          break
-        end
+rescue LocalJumpError => e
+  raise unless e.reason == :break
+  break
       end
 
       # Returns true if the page object contains no elements.

--- a/test/stripe/list_object_test.rb
+++ b/test/stripe/list_object_test.rb
@@ -162,6 +162,21 @@ module Stripe
       assert_equal expected, actual
     end
 
+    should "support break inside #auto_paging_each block" do
+      list = TestListObject.construct_from(data: [{ id: 1 }, { id: 2 }],
+                                           has_more: true,
+                                           url: "/things",
+                                           object: "list")
+
+      actual = []
+      list.auto_paging_each do |obj|
+        actual << obj
+        break if actual.size == 1
+      end
+
+      assert_equal 1, actual.size
+    end
+
     should "provide #empty?" do
       list = Stripe::ListObject.construct_from(data: [])
       assert list.empty?

--- a/test/stripe/search_result_object_test.rb
+++ b/test/stripe/search_result_object_test.rb
@@ -88,6 +88,21 @@ module Stripe
       assert_equal expected, actual
     end
 
+    should "support break inside #auto_paging_each block" do
+      list = TestSearchResultObject.construct_from(data: [{ id: 1 }, { id: 2 }],
+                                                   has_more: true,
+                                                   next_page: "next_page_token_1",
+                                                   url: "/things")
+
+      actual = []
+      list.auto_paging_each do |obj|
+        actual << obj
+        break if actual.size == 1
+      end
+
+      assert_equal 1, actual.size
+    end
+
     should "provide #empty?" do
       list = Stripe::SearchResultObject.construct_from(data: [])
       assert list.empty?

--- a/test/stripe/v2_list_object_test.rb
+++ b/test/stripe/v2_list_object_test.rb
@@ -105,6 +105,21 @@ module Stripe
 
         assert_equal expected, actual
       end
+
+      should "support break inside #auto_paging_each block" do
+        list = TestV2ListObject.construct_from({
+          data: [{ id: 1 }, { id: 2 }],
+          next_page_url: "/v2/things?page=page_2",
+        }, {}, nil, :v2, APIRequestor.new("sk_test_123"))
+
+        actual = []
+        list.auto_paging_each do |obj|
+          actual << obj
+          break if actual.size == 1
+        end
+
+        assert_equal 1, actual.size
+      end
     end
 
     context "#fetch_next_page" do


### PR DESCRIPTION
### Why?
Calling `break` inside a block passed directly to `auto_paging_each` raises `LocalJumpError` instead of stopping iteration.

### What?
- Rescue `LocalJumpError` in the v1 list, search result, and v2 list auto-paging loops, with regression coverage for each implementation.

### See Also
http://go/j/RUN_DEVSDK-2688

## Changelog
- Rescues `LocalJumpError` to prevent crash when calling `break` inside an `auto_paging_each`