### PR TITLE
Add non-verified methods to managed handlers

### DIFF
--- a/examples/event_notification_handler_endpoint.rb
+++ b/examples/event_notification_handler_endpoint.rb
@@ -31,6 +31,18 @@ handler.on_v1_billing_meter_error_report_triggered do |event_notification, _clie
   puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
 end
 
+# Handles events delivered through a channel that has already authenticated them, such as
+# AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+# this handler skips verification. Callbacks are registered separately from the one above.
+unverified_handler = client.notification_handler_without_verification do |notif, _client, _details|
+  puts "Received unhandled notification:", notif.type
+end
+
+unverified_handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|
+  meter = event_notification.fetch_related_object
+  puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
+end
+
 post "/webhook" do
   webhook_body = request.body.read
   sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
@@ -42,4 +54,10 @@ post "/webhook" do
     puts "Signature verification failed:", e.message
     status 400
   end
+end
+
+post "/webhook-from-cloud-provider" do
+  # handle takes only the body here; there's no signature to check
+  unverified_handler.handle(request.body.read)
+  status 200
 end

--- a/lib/stripe/api_version.rb
+++ b/lib/stripe/api_version.rb
@@ -4,5 +4,6 @@
 module Stripe
   module ApiVersion
     CURRENT = "2026-07-29.preview"
+    CURRENT_MAJOR = ""
   end
 end

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -125,5 +125,9 @@ module Stripe
     def notification_handler(webhook_secret, &fallback_callback)
       ::Stripe::StripeEventNotificationHandler.new(self, webhook_secret, &fallback_callback)
     end
+
+    def notification_handler_without_verification(&fallback_callback)
+      ::Stripe::StripeEventNotificationHandler.without_verification(self, &fallback_callback)
+    end
   end
 end

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -10,8 +10,6 @@ module Stripe
     end
   end
 
-  # Shared registration and dispatch machinery for the two handlers below.
-  #
   # Shared internal registration and dispatch machinery for the two user-facing event handlers.
   class StripeEventNotificationHandlerBase
     def initialize(client, &fallback_callback)

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -10,19 +10,10 @@ module Stripe
     end
   end
 
-  # A variant of StripeEventNotificationHandler that parses events without
-  # verifying webhook signatures. Intended for pre-authenticated channels
-  # like AWS EventBridge or Azure Event Grid.
+  # Shared registration and dispatch machinery for the two handlers below.
   #
-  # Do not instantiate directly. Use
-  # StripeEventNotificationHandler.without_verification or
-  # client.notification_handler_without_verification instead.
-  class StripeEventNotificationHandlerWithoutVerification
-    # Construct through the factories so that skipping signature verification is
-    # always an explicit choice. StripeEventNotificationHandler makes `new`
-    # public again for itself, since verifying handlers are built directly.
-    private_class_method :new
-
+  # Shared internal registration and dispatch machinery for the two user-facing event handlers.
+  class StripeEventNotificationHandlerBase
     def initialize(client, &fallback_callback)
       raise ArgumentError, "You must pass a block to act as a fallback" if fallback_callback.nil?
 
@@ -31,10 +22,6 @@ module Stripe
 
       @registered_handlers = {}
       @has_handled_events = false
-    end
-
-    def handle(webhook_body)
-      dispatch(@client.parse_event_notification_without_verification(webhook_body))
     end
 
     def registered_event_types
@@ -51,10 +38,6 @@ module Stripe
     end
 
     private def dispatch(notif)
-      # we're ok with this not being a thread-safe write since registering
-      # handlers should happen synchronously on startup before any multi-threaded reads happen
-      @has_handled_events = true
-
       event_client = new_client_with_context(notif.context)
 
       handler = @registered_handlers[notif.type]
@@ -603,9 +586,7 @@ module Stripe
   # Verifies incoming webhook signatures before routing events to the callbacks
   # registered on it. This is the handler you want unless events reach you
   # through a channel that has already authenticated them.
-  class StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
-    public_class_method :new
-
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerBase
     def initialize(client, webhook_secret, &fallback_callback)
       super(client, &fallback_callback)
 
@@ -619,11 +600,31 @@ module Stripe
     end
 
     def handle(webhook_body, sig_header)
+      # set before parsing, so that even a failed parse locks out registration.
+      # we're ok with this not being a thread-safe write since registering
+      # handlers should happen synchronously on startup before any multi-threaded reads happen
+      @has_handled_events = true
+
       dispatch(@client.parse_event_notification(
                  webhook_body,
                  sig_header,
                  @webhook_secret
                ))
+    end
+  end
+
+  # A variant of StripeEventNotificationHandler that parses events without verifying webhook signatures. Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid, or your own pre-authenticated queuing system.
+  #
+  # Prefer `StripeEventNotificationHandler#without_verification()` or `client.notification_handler_without_verification()` instead of constructing it directly.
+  class StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandlerBase
+    # Construct through the factories so that skipping signature verification is
+    # always an explicit choice.
+    private_class_method :new
+
+    def handle(webhook_body)
+      @has_handled_events = true
+
+      dispatch(@client.parse_event_notification_without_verification(webhook_body))
     end
   end
 end

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -10,39 +10,31 @@ module Stripe
     end
   end
 
-  class StripeEventNotificationHandler
-    def initialize(client, webhook_secret, &fallback_callback)
+  # A variant of StripeEventNotificationHandler that parses events without
+  # verifying webhook signatures. Intended for pre-authenticated channels
+  # like AWS EventBridge or Azure Event Grid.
+  #
+  # Do not instantiate directly. Use
+  # StripeEventNotificationHandler.without_verification or
+  # client.notification_handler_without_verification instead.
+  class StripeEventNotificationHandlerWithoutVerification
+    # Construct through the factories so that skipping signature verification is
+    # always an explicit choice. StripeEventNotificationHandler makes `new`
+    # public again for itself, since verifying handlers are built directly.
+    private_class_method :new
+
+    def initialize(client, &fallback_callback)
       raise ArgumentError, "You must pass a block to act as a fallback" if fallback_callback.nil?
 
       @client = client
-      @webhook_secret = webhook_secret
       @fallback_callback = fallback_callback
 
       @registered_handlers = {}
       @has_handled_events = false
     end
 
-    def handle(webhook_body, sig_header)
-      # we're ok with this not being a thread-safe write since registering
-      # handlers should happen synchronously on startup before any multi-threaded reads happen
-      @has_handled_events = true
-
-      notif = @client.parse_event_notification(
-        webhook_body,
-        sig_header,
-        @webhook_secret
-      )
-
-      # Create a new client with the event's context to ensure thread-safety
-      event_client = new_client_with_context(notif.context)
-
-      handler = @registered_handlers[notif.type]
-      if handler
-        handler.call(notif, event_client)
-      else
-        @fallback_callback.call(notif, event_client,
-                                UnhandledNotificationDetails.new(!notif.is_a?(Stripe::Events::UnknownEventNotification)))
-      end
+    def handle(webhook_body)
+      dispatch(@client.parse_event_notification_without_verification(webhook_body))
     end
 
     def registered_event_types
@@ -56,6 +48,22 @@ module Stripe
       end
 
       @registered_handlers[event_type] = handler
+    end
+
+    private def dispatch(notif)
+      # we're ok with this not being a thread-safe write since registering
+      # handlers should happen synchronously on startup before any multi-threaded reads happen
+      @has_handled_events = true
+
+      event_client = new_client_with_context(notif.context)
+
+      handler = @registered_handlers[notif.type]
+      if handler
+        handler.call(notif, event_client)
+      else
+        @fallback_callback.call(notif, event_client,
+                                UnhandledNotificationDetails.new(!notif.is_a?(Stripe::Events::UnknownEventNotification)))
+      end
     end
 
     private def new_client_with_context(context)
@@ -590,5 +598,32 @@ module Stripe
       register("v2.orchestrated_commerce.agreement.terminated", &handler)
     end
     # event-handler-methods: The end of the section generated from our OpenAPI spec
+  end
+
+  # Verifies incoming webhook signatures before routing events to the callbacks
+  # registered on it. This is the handler you want unless events reach you
+  # through a channel that has already authenticated them.
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
+    public_class_method :new
+
+    def initialize(client, webhook_secret, &fallback_callback)
+      super(client, &fallback_callback)
+
+      raise ArgumentError, "webhook_secret must be a non-empty string" if webhook_secret.nil? || webhook_secret.empty?
+
+      @webhook_secret = webhook_secret
+    end
+
+    def self.without_verification(client, &fallback_callback)
+      StripeEventNotificationHandlerWithoutVerification.send(:new, client, &fallback_callback)
+    end
+
+    def handle(webhook_body, sig_header)
+      dispatch(@client.parse_event_notification(
+                 webhook_body,
+                 sig_header,
+                 @webhook_secret
+               ))
+    end
   end
 end

--- a/rbi/stripe/resources/v2/core/event_notification.rbi
+++ b/rbi/stripe/resources/v2/core/event_notification.rbi
@@ -1,7 +1,6 @@
 # File copied from our code generator; changes here will be overwritten.
 # frozen_string_literal: true
 
-# frozen_string_literal: true
 # typed: true
 
 module Stripe

--- a/rbi/stripe/stripe_client.rbi
+++ b/rbi/stripe/stripe_client.rbi
@@ -39,5 +39,17 @@ module Stripe
       .returns(::Stripe::StripeEventNotificationHandler)
     end
     def notification_handler(webhook_secret, &blk); end
+
+    sig do
+      params(
+        blk: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails
+        ).void
+      )
+      .returns(::Stripe::StripeEventNotificationHandlerWithoutVerification)
+    end
+    def notification_handler_without_verification(&blk); end
   end
 end

--- a/rbi/stripe/stripe_event_notification_handler.rbi
+++ b/rbi/stripe/stripe_event_notification_handler.rbi
@@ -9,14 +9,8 @@ module Stripe
     def is_known_event_type; end
   end
 
-  # A variant of StripeEventNotificationHandler that parses events without
-  # verifying webhook signatures. Intended for pre-authenticated channels
-  # like AWS EventBridge or Azure Event Grid.
-  #
-  # Do not instantiate directly. Use
-  # StripeEventNotificationHandler.without_verification or
-  # client.notification_handler_without_verification instead.
-  class StripeEventNotificationHandlerWithoutVerification
+  # Shared internal registration and dispatch machinery for the two handlers below.
+  class StripeEventNotificationHandlerBase
     sig do
       params(
         client: ::Stripe::StripeClient,
@@ -27,14 +21,6 @@ module Stripe
         .void
     end
     def initialize(client, &on_unhandled_handler); end
-
-    sig do
-      params(
-        webhook_body: String
-      )
-        .void
-    end
-    def handle(webhook_body); end
 
     sig { returns(T::Array[String]) }
     def registered_event_types; end
@@ -562,7 +548,7 @@ module Stripe
 
   # Verifies incoming webhook signatures before routing events to the callbacks
   # registered on it.
-  class StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerBase
     sig do
       params(
         client: ::Stripe::StripeClient,
@@ -594,5 +580,18 @@ module Stripe
         .void
     end
     def handle(webhook_body, sig_header); end
+  end
+
+  # A variant of StripeEventNotificationHandler that parses events without verifying webhook signatures. Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid, or your own pre-authenticated queuing system.
+  #
+  # Prefer `StripeEventNotificationHandler#without_verification()` or `client.notification_handler_without_verification()` instead of constructing it directly.
+  class StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandlerBase
+    sig do
+      params(
+        webhook_body: String
+      )
+        .void
+    end
+    def handle(webhook_body); end
   end
 end

--- a/rbi/stripe/stripe_event_notification_handler.rbi
+++ b/rbi/stripe/stripe_event_notification_handler.rbi
@@ -1,7 +1,6 @@
 # File copied from our code generator; changes here will be overwritten.
 # frozen_string_literal: true
 
-# frozen_string_literal: true
 # typed: true
 
 module Stripe
@@ -10,28 +9,32 @@ module Stripe
     def is_known_event_type; end
   end
 
-  class StripeEventNotificationHandler
+  # A variant of StripeEventNotificationHandler that parses events without
+  # verifying webhook signatures. Intended for pre-authenticated channels
+  # like AWS EventBridge or Azure Event Grid.
+  #
+  # Do not instantiate directly. Use
+  # StripeEventNotificationHandler.without_verification or
+  # client.notification_handler_without_verification instead.
+  class StripeEventNotificationHandlerWithoutVerification
     sig do
       params(
         client: ::Stripe::StripeClient,
-        webhook_secret: String,
         on_unhandled_handler: T.proc.params(
           event_notification: ::Stripe::V2::Core::EventNotification,
           client: ::Stripe::StripeClient,
           details: ::Stripe::UnhandledNotificationDetails).void)
         .void
     end
-    def initialize(client, webhook_secret, &on_unhandled_handler); end
-    end
+    def initialize(client, &on_unhandled_handler); end
 
     sig do
       params(
-        webhook_body: String,
-        sig_header: String
+        webhook_body: String
       )
         .void
     end
-    def handle(webhook_body, sig_header); end
+    def handle(webhook_body); end
 
     sig { returns(T::Array[String]) }
     def registered_event_types; end
@@ -556,3 +559,40 @@ module Stripe
     
     # event-handler-methods: The end of the section generated from our OpenAPI spec
   end
+
+  # Verifies incoming webhook signatures before routing events to the callbacks
+  # registered on it.
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
+    sig do
+      params(
+        client: ::Stripe::StripeClient,
+        webhook_secret: String,
+        on_unhandled_handler: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails).void)
+        .void
+    end
+    def initialize(client, webhook_secret, &on_unhandled_handler); end
+
+    sig do
+      params(
+        client: ::Stripe::StripeClient,
+        on_unhandled_handler: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails).void)
+        .returns(::Stripe::StripeEventNotificationHandlerWithoutVerification)
+    end
+    def self.without_verification(client, &on_unhandled_handler); end
+
+    sig do
+      params(
+        webhook_body: String,
+        sig_header: String
+      )
+        .void
+    end
+    def handle(webhook_body, sig_header); end
+  end
+end

--- a/test/stripe/stripe_event_notification_handler_test.rb
+++ b/test/stripe/stripe_event_notification_handler_test.rb
@@ -311,6 +311,20 @@ module Stripe
         assert_equal "Unhandled error!", e.message
       end
 
+      should "raise ArgumentError when initialized with nil webhook_secret" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.new(@client, nil, &@on_unhandled_handler)
+        end
+        assert_match(/webhook_secret must be a non-empty string/, e.message)
+      end
+
+      should "raise ArgumentError when initialized with empty webhook_secret" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.new(@client, "", &@on_unhandled_handler)
+        end
+        assert_match(/webhook_secret must be a non-empty string/, e.message)
+      end
+
       should "handler uses event stripe_context" do
         client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
         handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
@@ -406,6 +420,124 @@ module Stripe
         assert_equal api_key, received_api_key
         assert_equal "event_context_456", received_context.to_s
         assert_equal original_context, client_with_config.requestor.config.stripe_context.to_s
+      end
+    end
+
+    context "StripeEventNotificationHandlerWithoutVerification" do
+      should "raise ArgumentError when initialized without block" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.without_verification(@client)
+        end
+        assert_match(/You must pass a block to act as a fallback/, e.message)
+      end
+
+      should "route event to registered handler without signature" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler_called = false
+        received_notif = nil
+        received_client = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |notif, client|
+          handler_called = true
+          received_notif = notif
+          received_client = client
+        end
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert handler_called
+        assert_not_nil received_notif
+        assert received_notif.is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", received_notif.type
+        assert_equal "evt_123", received_notif.id
+        assert_not_nil received_client
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "handle accepts only webhook body with no signature header argument" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        # Calling handle with only the body must succeed
+        assert_nothing_raised { handler.handle(V1_BILLING_METER_PAYLOAD) }
+
+        # Calling handle with a second argument must raise ArgumentError
+        assert_raises(ArgumentError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "unexpected_sig_header")
+        end
+      end
+
+      should "route known unregistered event to fallback with is_known_event_type true" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal true, call[:details].is_known_event_type
+      end
+
+      should "route unknown event type to fallback with is_known_event_type false" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler.handle(UNKNOWN_EVENT_PAYLOAD)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::UnknownEventNotification)
+        assert_equal "llama.created", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal false, call[:details].is_known_event_type
+      end
+
+      should "propagate event stripe_context to callback client" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.without_verification(client_with_context, &@on_unhandled_handler)
+
+        received_context = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          received_context = client.requestor.config.stripe_context
+        end
+
+        assert_equal "original_context_123", client_with_context.requestor.config.stripe_context.to_s
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert_equal "event_context_456", received_context.to_s
+        assert_equal "original_context_123", client_with_context.requestor.config.stripe_context.to_s
+      end
+
+      # assert_instance_of, not is_a?: the verifying handler is a *subclass* of
+      # this one, so is_a? would also pass for a handler that does verify
+      should "class method factory returns StripeEventNotificationHandlerWithoutVerification" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+        assert_instance_of StripeEventNotificationHandlerWithoutVerification, handler
+      end
+
+      should "client factory method returns StripeEventNotificationHandlerWithoutVerification" do
+        handler = @client.notification_handler_without_verification(&@on_unhandled_handler)
+        assert_instance_of StripeEventNotificationHandlerWithoutVerification, handler
+      end
+
+      should "does not expose the verifying two-argument handle" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+        assert_raises(ArgumentError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "some-sig-header")
+        end
+      end
+
+      should "cannot be instantiated directly" do
+        assert_raises(NoMethodError) do
+          StripeEventNotificationHandlerWithoutVerification.new(@client, &@on_unhandled_handler)
+        end
       end
     end
   end

--- a/test/stripe/stripe_event_notification_handler_test.rb
+++ b/test/stripe/stripe_event_notification_handler_test.rb
@@ -171,6 +171,21 @@ module Stripe
         assert_match(/Cannot register new event handlers after handling events/, e.message)
       end
 
+      should "not allow registering handlers after a failed parse" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        assert_raises(Stripe::SignatureVerificationError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "t=1,v1=not-a-sig")
+        end
+
+        e = assert_raises(RuntimeError) do
+          handler.on_v2_core_account_created do |_notif, _client|
+            # Handler body
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
       should "not allow registering duplicate handlers" do
         handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
 
@@ -515,8 +530,6 @@ module Stripe
         assert_equal "original_context_123", client_with_context.requestor.config.stripe_context.to_s
       end
 
-      # assert_instance_of, not is_a?: the verifying handler is a *subclass* of
-      # this one, so is_a? would also pass for a handler that does verify
       should "class method factory returns StripeEventNotificationHandlerWithoutVerification" do
         handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
         assert_instance_of StripeEventNotificationHandlerWithoutVerification, handler
@@ -538,6 +551,28 @@ module Stripe
         assert_raises(NoMethodError) do
           StripeEventNotificationHandlerWithoutVerification.new(@client, &@on_unhandled_handler)
         end
+      end
+
+      should "not allow registering handlers after a failed parse" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        assert_raises(JSON::ParserError) do
+          handler.handle("not json")
+        end
+
+        e = assert_raises(RuntimeError) do
+          handler.on_v2_core_account_created do |_notif, _client|
+            # Handler body
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
+      # neither handler is substitutable for the other, so neither should be a
+      # subclass of the other; each defines its own `handle` over a shared base
+      should "is a sibling of StripeEventNotificationHandler, not an ancestor" do
+        refute StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
+        refute StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandler
       end
     end
   end


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

On the back of my work in [DEVSDK-3085](https://go/j/DEVSDK-3085), we're adding support for non-verified webhook handing to the managed handlers. There were two key design stipulations:

1. It should be impossible to handle a webhook on the with-verification handler without supplying a signature header. As a result, we have to be very careful about overwriting/mixing our `handle` methods and if/when we call the signature verification methods.
2. The without-verification handler should feel like an implementation detail (where possible). Users should feel like they're interacting with "The" event notification handler

To that end, the main entrypoint for the non-verified handler is a new method on the client and a static method on the with-verification handler. The non-verified handlers are public in each language so users can interact with them normally, but the intention is that they're not something the user thinks much about on their own.

Design wise, the exact implementation varied between languages, but the general idea was the same. I moved all the generated `on_*` methods onto a private base class, then added sibling handlers for the "with" and "without" verification paths. That way they each have distinct `handle` methods and it's impossible for a caller to see the "wrong" one. If we had used inheritance, then the child would have the parent's `handle` signature exposed, which is confusing (even if we overrode it to always error). 

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Add `StripeEventNotificationHandlerWithoutVerification` class and associated constructors, docstrings, and client methods
- add tests
- update examples

### See Also

<!-- Include any links or additional information that help explain this change. -->

- Original handler PR: https://github.com/stripe/stripe-ruby/pull/1724
- Non-verified event parsing: https://github.com/stripe/stripe-ruby/pull/1918
