### PR TITLE
Add new `EventNotificationHandler` class for better thin event management

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Layout/LineLength:
   Exclude:
     - "lib/stripe/object_types.rb"
     - "lib/stripe/stripe_client.rb"
+    - "lib/stripe/stripe_event_notification_handler.rb"
     - "lib/stripe/error_object.rb"
     - "lib/stripe/resources/**/*.rb"
     - "lib/stripe/services/**/*.rb"

--- a/examples/event_notification_handler_endpoint.rb
+++ b/examples/event_notification_handler_endpoint.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# typed: false
+
+# event_notification_handler_endpoint.rb - receive and process event notifications (AKA thin events) like
+# "v1.billing.meter.error_report_triggered" using EventNotificationHandler.
+
+# In this example, we:
+#     - write a fallback callback to handle unrecognized event notifications
+#     - create a StripeClient called client
+#     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+#     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
+#     - use handler.handle() to process the received notification webhook body
+
+require "stripe"
+require "sinatra"
+
+api_key = ENV.fetch("STRIPE_API_KEY", nil)
+# Retrieve the webhook secret from the environment variable
+webhook_secret = ENV.fetch("WEBHOOK_SECRET", nil)
+
+client = Stripe::StripeClient.new(api_key)
+
+handler = client.notification_handler(webhook_secret) do |notif, _client, _details|
+  puts "Received unhandled notification:", notif.type
+end
+
+handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|
+  meter = event_notification.fetch_related_object
+  puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
+end
+
+# Handles events delivered through a channel that has already authenticated them, such as
+# AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+# this handler skips verification. Callbacks are registered separately from the one above.
+unverified_handler = client.notification_handler_without_verification do |notif, _client, _details|
+  puts "Received unhandled notification:", notif.type
+end
+
+unverified_handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|
+  meter = event_notification.fetch_related_object
+  puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
+end
+
+post "/webhook" do
+  webhook_body = request.body.read
+  sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
+
+  begin
+    handler.handle(webhook_body, sig_header)
+    status 200
+  rescue Stripe::SignatureVerificationError => e
+    puts "Signature verification failed:", e.message
+    status 400
+  end
+end
+
+post "/webhook-from-cloud-provider" do
+  # handle takes only the body here; there's no signature to check
+  unverified_handler.handle(request.body.read)
+  status 200
+end

--- a/lib/stripe.rb
+++ b/lib/stripe.rb
@@ -54,6 +54,7 @@ require "stripe/api_resource"
 require "stripe/api_resource_test_helpers"
 require "stripe/singleton_api_resource"
 require "stripe/webhook"
+require "stripe/stripe_event_notification_handler"
 require "stripe/stripe_configuration"
 
 # Named API resources — autoloaded on first use to reduce boot time.

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -118,5 +118,31 @@ module Stripe
       data = JSON.parse(data) if data.is_a?(String)
       Util.convert_to_stripe_object(data, {}, api_mode: api_mode, requestor: @requestor)
     end
+
+    # Returns a new StripeClient with the same configuration as this one, but
+    # scoped to the given Stripe-Context. Useful when handling event
+    # notifications, where each event may carry its own context.
+    def with_stripe_context(context)
+      config = @requestor.config
+      StripeClient.new(
+        config.api_key,
+        stripe_account: config.stripe_account,
+        stripe_context: context,
+        stripe_version: config.api_version,
+        api_base: config.api_base,
+        uploads_base: config.uploads_base,
+        connect_base: config.connect_base,
+        meter_events_base: config.meter_events_base,
+        client_id: config.client_id
+      )
+    end
+
+    def notification_handler(webhook_secret, &fallback_callback)
+      ::Stripe::StripeEventNotificationHandler.new(self, webhook_secret, &fallback_callback)
+    end
+
+    def notification_handler_without_verification(&fallback_callback)
+      ::Stripe::StripeEventNotificationHandler.without_verification(self, &fallback_callback)
+    end
   end
 end

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+module Stripe
+  class UnhandledNotificationDetails
+    attr_reader :is_known_event_type
+
+    def initialize(is_known_event_type)
+      @is_known_event_type = is_known_event_type
+    end
+  end
+
+  # Shared internal registration and dispatch machinery for the two user-facing event handlers.
+  class StripeEventNotificationHandlerBase
+    def initialize(client, &fallback_callback)
+      raise ArgumentError, "You must pass a block to act as a fallback" if fallback_callback.nil?
+
+      @client = client
+      @fallback_callback = fallback_callback
+
+      @registered_handlers = {}
+      @has_handled_events = false
+    end
+
+    def registered_event_types
+      @registered_handlers.keys.sort
+    end
+
+    private def register(event_type, &handler)
+      raise "Cannot register new event handlers after handling events" if @has_handled_events
+      if @registered_handlers.key?(event_type)
+        raise ArgumentError, "Handler already registered for event type: #{event_type}"
+      end
+
+      @registered_handlers[event_type] = handler
+    end
+
+    private def dispatch(notif)
+      event_client = @client.with_stripe_context(notif.context)
+
+      handler = @registered_handlers[notif.type]
+      if handler
+        handler.call(notif, event_client)
+      else
+        @fallback_callback.call(notif, event_client,
+                                UnhandledNotificationDetails.new(!notif.is_a?(Stripe::Events::UnknownEventNotification)))
+      end
+    end
+
+    # event-handler-methods: The beginning of the section generated from our OpenAPI spec
+    def on_v1_billing_meter_error_report_triggered(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v1.billing.meter.error_report_triggered", &handler)
+    end
+
+    def on_v1_billing_meter_no_meter_found(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v1.billing.meter.no_meter_found", &handler)
+    end
+
+    def on_v2_commerce_product_catalog_imports_failed(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.commerce.product_catalog.imports.failed", &handler)
+    end
+
+    def on_v2_commerce_product_catalog_imports_processing(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.commerce.product_catalog.imports.processing", &handler)
+    end
+
+    def on_v2_commerce_product_catalog_imports_succeeded(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.commerce.product_catalog.imports.succeeded", &handler)
+    end
+
+    def on_v2_commerce_product_catalog_imports_succeeded_with_errors(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.commerce.product_catalog.imports.succeeded_with_errors", &handler)
+    end
+
+    def on_v2_core_account_closed(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account.closed", &handler)
+    end
+
+    def on_v2_core_account_created(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account.created", &handler)
+    end
+
+    def on_v2_core_account_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account.updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_customer_capability_status_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.customer].capability_status_updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_customer_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.customer].updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_merchant_capability_status_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.merchant].capability_status_updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_merchant_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.merchant].updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_recipient_capability_status_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.recipient].capability_status_updated", &handler)
+    end
+
+    def on_v2_core_account_including_configuration_recipient_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[configuration.recipient].updated", &handler)
+    end
+
+    def on_v2_core_account_including_defaults_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[defaults].updated", &handler)
+    end
+
+    def on_v2_core_account_including_future_requirements_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[future_requirements].updated", &handler)
+    end
+
+    def on_v2_core_account_including_identity_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[identity].updated", &handler)
+    end
+
+    def on_v2_core_account_including_requirements_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account[requirements].updated", &handler)
+    end
+
+    def on_v2_core_account_link_returned(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account_link.returned", &handler)
+    end
+
+    def on_v2_core_account_person_created(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account_person.created", &handler)
+    end
+
+    def on_v2_core_account_person_deleted(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account_person.deleted", &handler)
+    end
+
+    def on_v2_core_account_person_updated(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.account_person.updated", &handler)
+    end
+
+    def on_v2_core_event_destination_ping(&handler)
+      raise ArgumentError, "Block required to register event handler" if handler.nil?
+
+      register("v2.core.event_destination.ping", &handler)
+    end
+    # event-handler-methods: The end of the section generated from our OpenAPI spec
+  end
+
+  # Verifies incoming webhook signatures before routing events to the callbacks
+  # registered on it. This is the handler you want unless events reach you
+  # through a channel that has already authenticated them.
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerBase
+    def initialize(client, webhook_secret, &fallback_callback)
+      super(client, &fallback_callback)
+
+      raise ArgumentError, "webhook_secret must be a non-empty string" if webhook_secret.nil? || webhook_secret.empty?
+
+      @webhook_secret = webhook_secret
+    end
+
+    def self.without_verification(client, &fallback_callback)
+      StripeEventNotificationHandlerWithoutVerification.send(:new, client, &fallback_callback)
+    end
+
+    def handle(webhook_body, sig_header)
+      # set before parsing, so that even a failed parse locks out registration.
+      # we're ok with this not being a thread-safe write since registering
+      # handlers should happen synchronously on startup before any multi-threaded reads happen
+      @has_handled_events = true
+
+      dispatch(@client.parse_event_notification(
+                 webhook_body,
+                 sig_header,
+                 @webhook_secret
+               ))
+    end
+  end
+
+  # A variant of StripeEventNotificationHandler that parses events without verifying webhook signatures. Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid, or your own pre-authenticated queuing system.
+  #
+  # Prefer `StripeEventNotificationHandler#without_verification()` or `client.notification_handler_without_verification()` instead of constructing it directly.
+  class StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandlerBase
+    # Construct through the factories so that skipping signature verification is
+    # always an explicit choice.
+    private_class_method :new
+
+    def handle(webhook_body)
+      @has_handled_events = true
+
+      dispatch(@client.parse_event_notification_without_verification(webhook_body))
+    end
+  end
+end

--- a/rbi/stripe/stripe_client.rbi
+++ b/rbi/stripe/stripe_client.rbi
@@ -26,5 +26,39 @@ module Stripe
     # parse in a single call, use `parse_event_notification` instead.
     sig { params(payload: String).returns(::Stripe::V2::Core::EventNotification) }
     def parse_event_notification_without_verification(payload); end
+
+    # Returns a new StripeClient with the same configuration as this one, but
+    # scoped to the given Stripe-Context. Useful when handling event
+    # notifications, where each event may carry its own context.
+    sig do
+      params(context: T.nilable(T.any(String, ::Stripe::StripeContext)))
+        .returns(::Stripe::StripeClient)
+    end
+    def with_stripe_context(context); end
+
+    sig do
+      params(
+        webhook_secret: String,
+        blk: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails
+        ).void
+      )
+      .returns(::Stripe::StripeEventNotificationHandler)
+    end
+    def notification_handler(webhook_secret, &blk); end
+
+    sig do
+      params(
+        blk: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails
+        ).void
+      )
+      .returns(::Stripe::StripeEventNotificationHandlerWithoutVerification)
+    end
+    def notification_handler_without_verification(&blk); end
   end
 end

--- a/rbi/stripe/stripe_event_notification_handler.rbi
+++ b/rbi/stripe/stripe_event_notification_handler.rbi
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+# typed: true
+
+module Stripe
+  class UnhandledNotificationDetails
+    sig { returns(T::Boolean) }
+    def is_known_event_type; end
+  end
+
+  # Shared internal registration and dispatch machinery for the two handlers below.
+  class StripeEventNotificationHandlerBase
+    sig do
+      params(
+        client: ::Stripe::StripeClient,
+        on_unhandled_handler: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails).void)
+        .void
+    end
+    def initialize(client, &on_unhandled_handler); end
+
+    sig { returns(T::Array[String]) }
+    def registered_event_types; end
+
+    # event-handler-methods: The beginning of the section generated from our OpenAPI spec
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v1_billing_meter_error_report_triggered(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V1BillingMeterNoMeterFoundEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v1_billing_meter_no_meter_found(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CommerceProductCatalogImportsFailedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_commerce_product_catalog_imports_failed(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CommerceProductCatalogImportsProcessingEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_commerce_product_catalog_imports_processing(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CommerceProductCatalogImportsSucceededEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_commerce_product_catalog_imports_succeeded(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_commerce_product_catalog_imports_succeeded_with_errors(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountClosedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_closed(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountCreatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_created(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_customer_capability_status_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_customer_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_merchant_capability_status_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_merchant_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_recipient_capability_status_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_configuration_recipient_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingDefaultsUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_defaults_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_future_requirements_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingIdentityUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_identity_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountIncludingRequirementsUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_including_requirements_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountLinkReturnedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_link_returned(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountPersonCreatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_person_created(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountPersonDeletedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_person_deleted(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreAccountPersonUpdatedEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_account_person_updated(&blk);
+    end
+    
+    sig do
+      params(blk: T.proc.params(event_notification: ::Stripe::Events::V2CoreEventDestinationPingEventNotification, client: ::Stripe::StripeClient).void).void
+    end
+    def on_v2_core_event_destination_ping(&blk);
+    end
+    
+    
+    # event-handler-methods: The end of the section generated from our OpenAPI spec
+  end
+
+  # Verifies incoming webhook signatures before routing events to the callbacks
+  # registered on it.
+  class StripeEventNotificationHandler < StripeEventNotificationHandlerBase
+    sig do
+      params(
+        client: ::Stripe::StripeClient,
+        webhook_secret: String,
+        on_unhandled_handler: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails).void)
+        .void
+    end
+    def initialize(client, webhook_secret, &on_unhandled_handler); end
+
+    sig do
+      params(
+        client: ::Stripe::StripeClient,
+        on_unhandled_handler: T.proc.params(
+          event_notification: ::Stripe::V2::Core::EventNotification,
+          client: ::Stripe::StripeClient,
+          details: ::Stripe::UnhandledNotificationDetails).void)
+        .returns(::Stripe::StripeEventNotificationHandlerWithoutVerification)
+    end
+    def self.without_verification(client, &on_unhandled_handler); end
+
+    sig do
+      params(
+        webhook_body: String,
+        sig_header: String
+      )
+        .void
+    end
+    def handle(webhook_body, sig_header); end
+  end
+
+  # A variant of StripeEventNotificationHandler that parses events without verifying webhook signatures. Intended for pre-authenticated channels like AWS EventBridge, Azure Event Grid, or your own pre-authenticated queuing system.
+  #
+  # Prefer `StripeEventNotificationHandler#without_verification()` or `client.notification_handler_without_verification()` instead of constructing it directly.
+  class StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandlerBase
+    sig do
+      params(
+        webhook_body: String
+      )
+        .void
+    end
+    def handle(webhook_body); end
+  end
+end

--- a/test/stripe/stripe_event_notification_handler_test.rb
+++ b/test/stripe/stripe_event_notification_handler_test.rb
@@ -1,0 +1,578 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", __dir__)
+require "json"
+
+module Stripe
+  class StripeEventNotificationHandlerTest < Test::Unit::TestCase
+    V1_BILLING_METER_PAYLOAD = {
+      "id" => "evt_123",
+      "object" => "v2.core.event",
+      "type" => "v1.billing.meter.error_report_triggered",
+      "livemode" => false,
+      "created" => "2022-02-15T00:27:45.330Z",
+      "context" => "event_context_456",
+      "related_object" => {
+        "id" => "mtr_123",
+        "type" => "billing.meter",
+        "url" => "/v1/billing/meters/mtr_123",
+      },
+    }.to_json
+
+    V2_ACCOUNT_CREATED_PAYLOAD = {
+      "id" => "evt_789",
+      "object" => "v2.core.event",
+      "type" => "v2.core.account.created",
+      "livemode" => false,
+      "created" => "2022-02-15T00:27:45.330Z",
+      "context" => nil,
+      "related_object" => {
+        "id" => "acct_abc",
+        "type" => "account",
+        "url" => "/v2/core/accounts/acct_abc",
+      },
+    }.to_json
+
+    V2_ACCOUNT_UPDATED_PAYLOAD = {
+      "id" => "evt_999",
+      "object" => "v2.core.event",
+      "type" => "v2.core.account.updated",
+      "livemode" => false,
+      "created" => "2022-02-15T00:27:45.330Z",
+      "context" => "event_context_999",
+      "related_object" => {
+        "id" => "acct_xyz",
+        "type" => "account",
+        "url" => "/v2/core/accounts/acct_xyz",
+      },
+    }.to_json
+
+    UNKNOWN_EVENT_PAYLOAD = {
+      "id" => "evt_unknown",
+      "object" => "v2.core.event",
+      "type" => "llama.created",
+      "livemode" => false,
+      "created" => "2022-02-15T00:27:45.330Z",
+      "context" => "event_context_unknown",
+      "related_object" => {
+        "id" => "llama_123",
+        "type" => "llama",
+        "url" => "/v1/llamas/llama_123",
+      },
+    }.to_json
+
+    setup do
+      @client = StripeClient.new("sk_test_123")
+      @on_unhandled_calls = []
+      @on_unhandled_handler = lambda { |notif, client, details|
+        @on_unhandled_calls << { notif: notif, client: client, details: details }
+      }
+    end
+
+    context "StripeEventNotificationHandler" do
+      should "raise ArgumentError when initialized without block" do
+        assert_raises(ArgumentError, "You must pass a block to respond to unhandled events") do
+          StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET)
+        end
+      end
+
+      should "route event to registered handler" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler_called = false
+        received_notif = nil
+        received_client = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |notif, client|
+          handler_called = true
+          received_notif = notif
+          received_client = client
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert handler_called
+        assert_not_nil received_notif
+        assert received_notif.is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", received_notif.type
+        assert_equal "evt_123", received_notif.id
+        assert_not_nil received_client
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "route different events to correct handlers" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        billing_handler_called = false
+        account_handler_num_calls = 0
+
+        handler.on_v1_billing_meter_error_report_triggered do |notif, _client|
+          billing_handler_called = true
+          assert notif.is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        end
+
+        handler.on_v2_core_account_created do |notif, _client|
+          account_handler_num_calls += 1
+          assert notif.is_a?(Stripe::Events::V2CoreAccountCreatedEventNotification)
+        end
+
+        sig_header1 = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header1)
+
+        sig_header2 = Test::WebhookHelpers.generate_header(payload: V2_ACCOUNT_CREATED_PAYLOAD)
+        handler.handle(V2_ACCOUNT_CREATED_PAYLOAD, sig_header2)
+
+        sig_header2 = Test::WebhookHelpers.generate_header(payload: V2_ACCOUNT_CREATED_PAYLOAD)
+        handler.handle(V2_ACCOUNT_CREATED_PAYLOAD, sig_header2)
+
+        assert billing_handler_called
+        assert_equal 2, account_handler_num_calls
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "handler receives correct event type and data" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        received_event = nil
+        received_client = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |notif, client|
+          received_event = notif
+          received_client = client
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert received_event.is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", received_event.type
+        assert_equal "evt_123", received_event.id
+        assert_equal "mtr_123", received_event.related_object.id
+        assert received_client.is_a?(StripeClient)
+      end
+
+      should "not allow registering handlers after handling events" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # Handler body
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        e = assert_raises(RuntimeError) do
+          handler.on_v2_core_account_created do |_notif, _client|
+            # Handler body
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
+      should "not allow registering handlers after a failed parse" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        assert_raises(Stripe::SignatureVerificationError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "t=1,v1=not-a-sig")
+        end
+
+        e = assert_raises(RuntimeError) do
+          handler.on_v2_core_account_created do |_notif, _client|
+            # Handler body
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
+      should "not allow registering duplicate handlers" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # First handler
+        end
+
+        e = assert_raises(ArgumentError) do
+          handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+            # Duplicate handler
+          end
+        end
+        assert_match(/Handler already registered for event type/, e.message)
+      end
+
+      should "route unknown event to on_unhandled handler" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: UNKNOWN_EVENT_PAYLOAD)
+        handler.handle(UNKNOWN_EVENT_PAYLOAD, sig_header)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::UnknownEventNotification)
+        assert_equal "llama.created", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal false, call[:details].is_known_event_type
+      end
+
+      should "route known unregistered event to on_unhandled handler" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal true, call[:details].is_known_event_type
+      end
+
+      should "not call on_unhandled for registered events" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # Handler body
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "raise error when handler is registered without block" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        e = assert_raises(ArgumentError) do
+          handler.on_v1_billing_meter_error_report_triggered
+        end
+        assert_match(/Block required to register event handler/, e.message)
+      end
+
+      should "validate webhook signature" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        assert_raises(Stripe::SignatureVerificationError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "invalid_signature")
+        end
+      end
+
+      should "return empty list when no event types registered" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        assert_equal [], handler.registered_event_types
+      end
+
+      should "return single registered event type" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # Handler body
+        end
+
+        assert_equal ["v1.billing.meter.error_report_triggered"], handler.registered_event_types
+      end
+
+      should "return multiple registered event types" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        # Register in non-alphabetical order
+        handler.on_v2_core_account_updated do |_notif, _client|
+          # Handler body
+        end
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # Handler body
+        end
+        handler.on_v2_core_account_created do |_notif, _client|
+          # Handler body
+        end
+
+        assert_equal ["v1.billing.meter.error_report_triggered", "v2.core.account.created", "v2.core.account.updated"], handler.registered_event_types
+      end
+
+      should "handler can raise errors without breaking handler" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          raise StandardError, "Handler error!"
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+
+        e = assert_raises(StandardError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+        end
+        assert_equal "Handler error!", e.message
+      end
+
+      should "on_unhandled handler can raise errors" do
+        error_handler = lambda { |_notif, _client, _details|
+          raise StandardError, "Unhandled error!"
+        }
+
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &error_handler)
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: UNKNOWN_EVENT_PAYLOAD)
+
+        e = assert_raises(StandardError) do
+          handler.handle(UNKNOWN_EVENT_PAYLOAD, sig_header)
+        end
+        assert_equal "Unhandled error!", e.message
+      end
+
+      should "raise ArgumentError when initialized with nil webhook_secret" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.new(@client, nil, &@on_unhandled_handler)
+        end
+        assert_match(/webhook_secret must be a non-empty string/, e.message)
+      end
+
+      should "raise ArgumentError when initialized with empty webhook_secret" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.new(@client, "", &@on_unhandled_handler)
+        end
+        assert_match(/webhook_secret must be a non-empty string/, e.message)
+      end
+
+      should "handler uses event stripe_context" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        received_context = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          received_context = client.instance_variable_get(:@requestor).config.stripe_context
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal "event_context_456", received_context.to_s
+      end
+
+      should "restore stripe_context after handler success" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          assert_equal "event_context_456", client.instance_variable_get(:@requestor).config.stripe_context.to_s
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+
+      should "restore stripe_context after handler error" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          assert_equal "event_context_456", client.instance_variable_get(:@requestor).config.stripe_context.to_s
+          raise StandardError, "Handler error!"
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+
+        e = assert_raises(StandardError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+        end
+        assert_equal "Handler error!", e.message
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+
+      should "set stripe_context to nil when event has no context" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        received_context = "not_nil"
+
+        handler.on_v2_core_account_created do |_notif, client|
+          received_context = client.instance_variable_get(:@requestor).config.stripe_context
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V2_ACCOUNT_CREATED_PAYLOAD)
+        handler.handle(V2_ACCOUNT_CREATED_PAYLOAD, sig_header)
+
+        assert_nil received_context
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+
+      should "handler client retains configuration except context" do
+        api_key = "sk_test_custom_key"
+        original_context = "original_context_xyz"
+
+        client_with_config = StripeClient.new(api_key, stripe_context: original_context)
+        handler = StripeEventNotificationHandler.new(client_with_config, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        received_api_key = nil
+        received_context = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          received_api_key = client.instance_variable_get(:@requestor).config.api_key
+          received_context = client.instance_variable_get(:@requestor).config.stripe_context
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal api_key, received_api_key
+        assert_equal "event_context_456", received_context.to_s
+        assert_equal original_context, client_with_config.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+    end
+
+    context "StripeEventNotificationHandlerWithoutVerification" do
+      should "raise ArgumentError when initialized without block" do
+        e = assert_raises(ArgumentError) do
+          StripeEventNotificationHandler.without_verification(@client)
+        end
+        assert_match(/You must pass a block to act as a fallback/, e.message)
+      end
+
+      should "route event to registered handler without signature" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler_called = false
+        received_notif = nil
+        received_client = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |notif, client|
+          handler_called = true
+          received_notif = notif
+          received_client = client
+        end
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert handler_called
+        assert_not_nil received_notif
+        assert received_notif.is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", received_notif.type
+        assert_equal "evt_123", received_notif.id
+        assert_not_nil received_client
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "handle accepts only webhook body with no signature header argument" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        # Calling handle with only the body must succeed
+        assert_nothing_raised { handler.handle(V1_BILLING_METER_PAYLOAD) }
+
+        # Calling handle with a second argument must raise ArgumentError
+        assert_raises(ArgumentError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "unexpected_sig_header")
+        end
+      end
+
+      should "route known unregistered event to fallback with is_known_event_type true" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification)
+        assert_equal "v1.billing.meter.error_report_triggered", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal true, call[:details].is_known_event_type
+      end
+
+      should "route unknown event type to fallback with is_known_event_type false" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler.handle(UNKNOWN_EVENT_PAYLOAD)
+
+        assert_equal 1, @on_unhandled_calls.length
+
+        call = @on_unhandled_calls[0]
+        assert call[:notif].is_a?(Stripe::Events::UnknownEventNotification)
+        assert_equal "llama.created", call[:notif].type
+        assert call[:client].is_a?(StripeClient)
+        assert call[:details].is_a?(UnhandledNotificationDetails)
+        assert_equal false, call[:details].is_known_event_type
+      end
+
+      should "propagate event stripe_context to callback client" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.without_verification(client_with_context, &@on_unhandled_handler)
+
+        received_context = nil
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, client|
+          received_context = client.instance_variable_get(:@requestor).config.stripe_context
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+
+        assert_equal "event_context_456", received_context.to_s
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+
+      should "class method factory returns StripeEventNotificationHandlerWithoutVerification" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+        assert_instance_of StripeEventNotificationHandlerWithoutVerification, handler
+      end
+
+      should "client factory method returns StripeEventNotificationHandlerWithoutVerification" do
+        handler = @client.notification_handler_without_verification(&@on_unhandled_handler)
+        assert_instance_of StripeEventNotificationHandlerWithoutVerification, handler
+      end
+
+      should "does not expose the verifying two-argument handle" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+        assert_raises(ArgumentError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, "some-sig-header")
+        end
+      end
+
+      should "cannot be instantiated directly" do
+        assert_raises(NoMethodError) do
+          StripeEventNotificationHandlerWithoutVerification.new(@client, &@on_unhandled_handler)
+        end
+      end
+
+      should "not allow registering handlers after a failed parse" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        assert_raises(JSON::ParserError) do
+          handler.handle("not json")
+        end
+
+        e = assert_raises(RuntimeError) do
+          handler.on_v2_core_account_created do |_notif, _client|
+            # Handler body
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
+      # neither handler is substitutable for the other, so neither should be a
+      # subclass of the other; each defines its own `handle` over a shared base
+      should "is a sibling of StripeEventNotificationHandler, not an ancestor" do
+        refute StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
+        refute StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandler
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The event notification handler code has been in the `beta` and `private-preview` branches since last year, but it's time to take it to GA!

This PR is entirely pre-approved code from previous PRs. It takes the static files from codegen, plus all the manual changes I made directly in `beta` to get everything working. It's stacked on top of the non-verified work from this week, too. Once this lands, the managed handler code should be in sync across all channels.

Notably, the static files that we used to share functionality are no longer sourced from codegen. Instead, they're now true manual files in `master` whose changes will flow into preview branches like normal.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `EventNotificationHandler` class & supporting infrastructure (ability to copy a `StripeClient`, etc)
- add `stripeClient` methods for creating a handler bound to that client
- add example
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://stripe.dev/blog/event-notification-handlers-thin-events
- [internal doc](https://docs.google.com/document/d/1hRpQLMLGfOHhZwXrYt5tvsKT-oIya11M4atunvTOih0/edit?tab=t.w21fiib3jsl3#heading=h.p5iqpr8dzdsz)
- Initial PR: https://github.com/stripe/stripe-ruby/pull/1724
- Update PR (adds non-verified handlers): https://github.com/stripe/stripe-ruby/pull/1935

## Changelog

- We've been putting a lot of time into rethinking the event handling experience in the SDKs. This new class is the culmination [of that effort](https://stripe.dev/blog/event-notification-handlers-thin-events).
- They're designed for a tight coupling with both `StripeClient` and the fully-typed nature of [thin events](https://docs.stripe.com/event-destinations#thin-events). This delivers painless event destination upgrades, in-editor checks for common mistakes, and better code modularity.
- Now that we've released [thin event notifications for v1 objects](https://docs.stripe.com/changelog#2026-08-26.dahlia), these new handlers are our recommended path for all integrations using thin event notifications.
- See more detailed docs here: https://docs.stripe.com/webhooks/event-notification-handlers
