### PR TITLE
Add `.pre_handle` method to `EventNotificationHandler`

### DIFF
--- a/examples/event_notification_handler_endpoint.rb
+++ b/examples/event_notification_handler_endpoint.rb
@@ -8,8 +8,7 @@
 #     - write a fallback callback to handle unrecognized event notifications
 #     - create a StripeClient called client
 #     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
-#     - register a pre_handle hook that deduplicates events we've already processed, before any
-#       callback (registered handler or fallback) runs
+#     - register a pre_handle hook that deduplicates events by id before any callback runs
 #     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
 #     - use handler.handle() to process the received notification webhook body
 
@@ -26,30 +25,36 @@ handler = client.notification_handler(webhook_secret) do |notif, _client, _detai
   puts "Received unhandled notification:", notif.type
 end
 
-# Stripe may occasionally deliver the same event notification more than once. pre_handle
-# runs after the payload is parsed but before any callback fires, so it's a good place to
-# deduplicate by event id (e.g. against a store like Redis) and skip already-processed events.
-seen_event_ids = {}
-handler.pre_handle do |event_notification, _client|
-  if seen_event_ids[event_notification.id]
-    puts "Skipping already-processed event:", event_notification.id
-    next false
-  end
-
-  seen_event_ids[event_notification.id] = true
-  true
-end
-
-handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|
-  meter = event_notification.fetch_related_object
-  puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
-end
-
 # Handles events delivered through a channel that has already authenticated them, such as
 # AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
 # this handler skips verification. Callbacks are registered separately from the one above.
 unverified_handler = client.notification_handler_without_verification do |notif, _client, _details|
   puts "Received unhandled notification:", notif.type
+end
+
+# Webhooks can be delivered more than once, so we track ids we've already
+# processed. In production, back this with something durable and shared
+# across processes (e.g. Redis or a database table) instead of an in-memory Set.
+seen_event_ids = Set.new
+
+# Runs before any registered callback. Returning false here skips handling
+# entirely for this delivery, which is useful for deduplicating webhooks.
+dedupe_events = lambda do |event_notification, _client|
+  if seen_event_ids.include?(event_notification.id)
+    puts "Skipping already-processed event:", event_notification.id
+    next false
+  end
+
+  seen_event_ids.add(event_notification.id)
+  true
+end
+handler.pre_handle(&dedupe_events)
+unverified_handler.pre_handle(&dedupe_events)
+
+# can be anywhere in your codebase with access to `handler`
+handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|
+  meter = event_notification.fetch_related_object
+  puts "Meter #{meter.display_name} (#{meter.id}) had a problem"
 end
 
 unverified_handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|

--- a/examples/event_notification_handler_endpoint.rb
+++ b/examples/event_notification_handler_endpoint.rb
@@ -8,6 +8,8 @@
 #     - write a fallback callback to handle unrecognized event notifications
 #     - create a StripeClient called client
 #     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+#     - register a pre_handle hook that deduplicates events we've already processed, before any
+#       callback (registered handler or fallback) runs
 #     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
 #     - use handler.handle() to process the received notification webhook body
 
@@ -22,6 +24,20 @@ client = Stripe::StripeClient.new(api_key)
 
 handler = client.notification_handler(webhook_secret) do |notif, _client, _details|
   puts "Received unhandled notification:", notif.type
+end
+
+# Stripe may occasionally deliver the same event notification more than once. pre_handle
+# runs after the payload is parsed but before any callback fires, so it's a good place to
+# deduplicate by event id (e.g. against a store like Redis) and skip already-processed events.
+seen_event_ids = {}
+handler.pre_handle do |event_notification, _client|
+  if seen_event_ids[event_notification.id]
+    puts "Skipping already-processed event:", event_notification.id
+    next false
+  end
+
+  seen_event_ids[event_notification.id] = true
+  true
 end
 
 handler.on_v1_billing_meter_error_report_triggered do |event_notification, _client|

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -35,7 +35,7 @@ module Stripe
     # are called.
     def pre_handle(&hook)
       assert_callback_given(hook)
-      assert_can_register
+      assert_hasnt_handled_events
 
       raise ArgumentError, "A pre_handle callback is already registered" if @pre_handle_callback
 
@@ -44,7 +44,7 @@ module Stripe
 
     # callbacks are expected to be registered once on startup, so registering anything
     # after handling has begun indicates a bug
-    private def assert_can_register
+    private def assert_hasnt_handled_events
       return unless @has_handled_events
 
       raise "Cannot register new callbacks after an event has been handled. This is indicative of a bug."
@@ -60,7 +60,7 @@ module Stripe
       # checked before assert_can_register so a missing block reports as such even
       # once handling has started
       assert_callback_given(handler)
-      assert_can_register
+      assert_hasnt_handled_events
       if @registered_handlers.key?(event_type)
         raise ArgumentError, "Callback for event type \"#{event_type}\" is already registered"
       end

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -27,10 +27,10 @@ module Stripe
     end
 
     def pre_handle(&hook)
-      raise ArgumentError, "Block required to register a pre_handle hook" if hook.nil?
-
+      assert_callback_given(hook)
       assert_can_register
-      raise ArgumentError, "A pre_handle hook has already been registered" if @pre_handle_callback
+
+      raise ArgumentError, "A pre_handle callback is already registered" if @pre_handle_callback
 
       @pre_handle_callback = hook
     end
@@ -38,13 +38,24 @@ module Stripe
     # callbacks are expected to be registered once on startup, so registering anything
     # after handling has begun indicates a bug
     private def assert_can_register
-      raise "Cannot register new event handlers after handling events" if @has_handled_events
+      return unless @has_handled_events
+
+      raise "Cannot register new callbacks after an event has been handled. This is indicative of a bug."
+    end
+
+    # every registration path funnels its block through here so the error stays
+    # consistent across all of them
+    private def assert_callback_given(callback)
+      raise ArgumentError, "Block required to register a callback" if callback.nil?
     end
 
     private def register(event_type, &handler)
+      # checked before assert_can_register so a missing block reports as such even
+      # once handling has started
+      assert_callback_given(handler)
       assert_can_register
       if @registered_handlers.key?(event_type)
-        raise ArgumentError, "Handler already registered for event type: #{event_type}"
+        raise ArgumentError, "Callback for event type \"#{event_type}\" is already registered"
       end
 
       @registered_handlers[event_type] = handler
@@ -65,148 +76,100 @@ module Stripe
     end
 
     # event-handler-methods: The beginning of the section generated from our OpenAPI spec
-    def on_v1_billing_meter_error_report_triggered(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v1.billing.meter.error_report_triggered", &handler)
+    def on_v1_billing_meter_error_report_triggered(&callback)
+      register("v1.billing.meter.error_report_triggered", &callback)
     end
 
-    def on_v1_billing_meter_no_meter_found(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v1.billing.meter.no_meter_found", &handler)
+    def on_v1_billing_meter_no_meter_found(&callback)
+      register("v1.billing.meter.no_meter_found", &callback)
     end
 
-    def on_v2_commerce_product_catalog_imports_failed(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.commerce.product_catalog.imports.failed", &handler)
+    def on_v2_commerce_product_catalog_imports_failed(&callback)
+      register("v2.commerce.product_catalog.imports.failed", &callback)
     end
 
-    def on_v2_commerce_product_catalog_imports_processing(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.commerce.product_catalog.imports.processing", &handler)
+    def on_v2_commerce_product_catalog_imports_processing(&callback)
+      register("v2.commerce.product_catalog.imports.processing", &callback)
     end
 
-    def on_v2_commerce_product_catalog_imports_succeeded(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.commerce.product_catalog.imports.succeeded", &handler)
+    def on_v2_commerce_product_catalog_imports_succeeded(&callback)
+      register("v2.commerce.product_catalog.imports.succeeded", &callback)
     end
 
-    def on_v2_commerce_product_catalog_imports_succeeded_with_errors(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.commerce.product_catalog.imports.succeeded_with_errors", &handler)
+    def on_v2_commerce_product_catalog_imports_succeeded_with_errors(&callback)
+      register("v2.commerce.product_catalog.imports.succeeded_with_errors", &callback)
     end
 
-    def on_v2_core_account_closed(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account.closed", &handler)
+    def on_v2_core_account_closed(&callback)
+      register("v2.core.account.closed", &callback)
     end
 
-    def on_v2_core_account_created(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account.created", &handler)
+    def on_v2_core_account_created(&callback)
+      register("v2.core.account.created", &callback)
     end
 
-    def on_v2_core_account_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account.updated", &handler)
+    def on_v2_core_account_updated(&callback)
+      register("v2.core.account.updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_customer_capability_status_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.customer].capability_status_updated", &handler)
+    def on_v2_core_account_including_configuration_customer_capability_status_updated(&callback)
+      register("v2.core.account[configuration.customer].capability_status_updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_customer_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.customer].updated", &handler)
+    def on_v2_core_account_including_configuration_customer_updated(&callback)
+      register("v2.core.account[configuration.customer].updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_merchant_capability_status_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.merchant].capability_status_updated", &handler)
+    def on_v2_core_account_including_configuration_merchant_capability_status_updated(&callback)
+      register("v2.core.account[configuration.merchant].capability_status_updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_merchant_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.merchant].updated", &handler)
+    def on_v2_core_account_including_configuration_merchant_updated(&callback)
+      register("v2.core.account[configuration.merchant].updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_recipient_capability_status_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.recipient].capability_status_updated", &handler)
+    def on_v2_core_account_including_configuration_recipient_capability_status_updated(&callback)
+      register("v2.core.account[configuration.recipient].capability_status_updated", &callback)
     end
 
-    def on_v2_core_account_including_configuration_recipient_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[configuration.recipient].updated", &handler)
+    def on_v2_core_account_including_configuration_recipient_updated(&callback)
+      register("v2.core.account[configuration.recipient].updated", &callback)
     end
 
-    def on_v2_core_account_including_defaults_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[defaults].updated", &handler)
+    def on_v2_core_account_including_defaults_updated(&callback)
+      register("v2.core.account[defaults].updated", &callback)
     end
 
-    def on_v2_core_account_including_future_requirements_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[future_requirements].updated", &handler)
+    def on_v2_core_account_including_future_requirements_updated(&callback)
+      register("v2.core.account[future_requirements].updated", &callback)
     end
 
-    def on_v2_core_account_including_identity_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[identity].updated", &handler)
+    def on_v2_core_account_including_identity_updated(&callback)
+      register("v2.core.account[identity].updated", &callback)
     end
 
-    def on_v2_core_account_including_requirements_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account[requirements].updated", &handler)
+    def on_v2_core_account_including_requirements_updated(&callback)
+      register("v2.core.account[requirements].updated", &callback)
     end
 
-    def on_v2_core_account_link_returned(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account_link.returned", &handler)
+    def on_v2_core_account_link_returned(&callback)
+      register("v2.core.account_link.returned", &callback)
     end
 
-    def on_v2_core_account_person_created(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account_person.created", &handler)
+    def on_v2_core_account_person_created(&callback)
+      register("v2.core.account_person.created", &callback)
     end
 
-    def on_v2_core_account_person_deleted(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account_person.deleted", &handler)
+    def on_v2_core_account_person_deleted(&callback)
+      register("v2.core.account_person.deleted", &callback)
     end
 
-    def on_v2_core_account_person_updated(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.account_person.updated", &handler)
+    def on_v2_core_account_person_updated(&callback)
+      register("v2.core.account_person.updated", &callback)
     end
 
-    def on_v2_core_event_destination_ping(&handler)
-      raise ArgumentError, "Block required to register event handler" if handler.nil?
-
-      register("v2.core.event_destination.ping", &handler)
+    def on_v2_core_event_destination_ping(&callback)
+      register("v2.core.event_destination.ping", &callback)
     end
     # event-handler-methods: The end of the section generated from our OpenAPI spec
   end

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -26,6 +26,13 @@ module Stripe
       @registered_handlers.keys.sort
     end
 
+    # Registers a function that will be run before any event-specific callbacks. A useful
+    # place to store event-agnostic logic, such as logging or checking for
+    # [duplicate event deliveries](https://docs.stripe.com/webhooks#handle-duplicate-events).
+    #
+    # Returning `true` causes handling to continue as normal; returning `false` returns from
+    # `.handle()` immediately, so neither the registered callback nor the fallback callback
+    # are called.
     def pre_handle(&hook)
       assert_callback_given(hook)
       assert_can_register

--- a/lib/stripe/stripe_event_notification_handler.rb
+++ b/lib/stripe/stripe_event_notification_handler.rb
@@ -19,14 +19,30 @@ module Stripe
 
       @registered_handlers = {}
       @has_handled_events = false
+      @pre_handle_callback = nil
     end
 
     def registered_event_types
       @registered_handlers.keys.sort
     end
 
-    private def register(event_type, &handler)
+    def pre_handle(&hook)
+      raise ArgumentError, "Block required to register a pre_handle hook" if hook.nil?
+
+      assert_can_register
+      raise ArgumentError, "A pre_handle hook has already been registered" if @pre_handle_callback
+
+      @pre_handle_callback = hook
+    end
+
+    # callbacks are expected to be registered once on startup, so registering anything
+    # after handling has begun indicates a bug
+    private def assert_can_register
       raise "Cannot register new event handlers after handling events" if @has_handled_events
+    end
+
+    private def register(event_type, &handler)
+      assert_can_register
       if @registered_handlers.key?(event_type)
         raise ArgumentError, "Handler already registered for event type: #{event_type}"
       end
@@ -36,6 +52,8 @@ module Stripe
 
     private def dispatch(notif)
       event_client = @client.with_stripe_context(notif.context)
+
+      return if @pre_handle_callback && !@pre_handle_callback.call(notif, event_client)
 
       handler = @registered_handlers[notif.type]
       if handler

--- a/rbi/stripe/stripe_event_notification_handler.rbi
+++ b/rbi/stripe/stripe_event_notification_handler.rbi
@@ -23,6 +23,9 @@ module Stripe
     sig { returns(T::Array[String]) }
     def registered_event_types; end
 
+    sig { params(hook: T.proc.params(event_notification: ::Stripe::V2::Core::EventNotification, client: ::Stripe::StripeClient).returns(T::Boolean)).void }
+    def pre_handle(&hook); end
+
     # event-handler-methods: The beginning of the section generated from our OpenAPI spec
     sig do
       params(blk: T.proc.params(event_notification: ::Stripe::Events::V1BillingMeterErrorReportTriggeredEventNotification, client: ::Stripe::StripeClient).void).void

--- a/test/stripe/stripe_event_notification_handler_test.rb
+++ b/test/stripe/stripe_event_notification_handler_test.rb
@@ -167,7 +167,7 @@ module Stripe
             # Handler body
           end
         end
-        assert_match(/Cannot register new event handlers after handling events/, e.message)
+        assert_match(/Cannot register new callbacks after an event has been handled\. This is indicative of a bug\./, e.message)
       end
 
       should "not allow registering handlers after a failed parse" do
@@ -182,7 +182,7 @@ module Stripe
             # Handler body
           end
         end
-        assert_match(/Cannot register new event handlers after handling events/, e.message)
+        assert_match(/Cannot register new callbacks after an event has been handled\. This is indicative of a bug\./, e.message)
       end
 
       should "not allow registering duplicate handlers" do
@@ -197,7 +197,7 @@ module Stripe
             # Duplicate handler
           end
         end
-        assert_match(/Handler already registered for event type/, e.message)
+        assert_match(/Callback for event type ".*" is already registered/, e.message)
       end
 
       should "route unknown event to on_unhandled handler" do
@@ -251,7 +251,7 @@ module Stripe
         e = assert_raises(ArgumentError) do
           handler.on_v1_billing_meter_error_report_triggered
         end
-        assert_match(/Block required to register event handler/, e.message)
+        assert_match(/Block required to register a callback/, e.message)
       end
 
       should "validate webhook signature" do
@@ -560,7 +560,7 @@ module Stripe
             true
           end
         end
-        assert_match(/Cannot register new event handlers after handling events/, e.message)
+        assert_match(/Cannot register new callbacks after an event has been handled\. This is indicative of a bug\./, e.message)
       end
 
       should "not allow registering more than one pre_handle hook" do
@@ -575,7 +575,7 @@ module Stripe
             true
           end
         end
-        assert_match(/A pre_handle hook has already been registered/, e.message)
+        assert_match(/A pre_handle callback is already registered/, e.message)
       end
 
       should "raise ArgumentError when pre_handle is registered without a block" do
@@ -584,7 +584,7 @@ module Stripe
         e = assert_raises(ArgumentError) do
           handler.pre_handle
         end
-        assert_match(/Block required to register a pre_handle hook/, e.message)
+        assert_match(/Block required to register a callback/, e.message)
       end
     end
 
@@ -715,7 +715,7 @@ module Stripe
             # Handler body
           end
         end
-        assert_match(/Cannot register new event handlers after handling events/, e.message)
+        assert_match(/Cannot register new callbacks after an event has been handled\. This is indicative of a bug\./, e.message)
       end
 
       # neither handler is substitutable for the other, so neither should be a

--- a/test/stripe/stripe_event_notification_handler_test.rb
+++ b/test/stripe/stripe_event_notification_handler_test.rb
@@ -435,6 +435,157 @@ module Stripe
         assert_equal "event_context_456", received_context.to_s
         assert_equal original_context, client_with_config.instance_variable_get(:@requestor).config.stripe_context.to_s
       end
+
+      should "run the registered handler as usual when no pre_handle hook is registered" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler_called = false
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          handler_called = true
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert handler_called
+      end
+
+      should "run the pre_handle hook before the registered handler when it returns true" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        call_order = []
+
+        handler.pre_handle do |_notif, _client|
+          call_order << :pre_handle
+          true
+        end
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          call_order << :handler
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal %i[pre_handle handler], call_order
+      end
+
+      should "not run the registered handler when the pre_handle hook returns false" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler_called = false
+
+        handler.pre_handle do |_notif, _client|
+          false
+        end
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          handler_called = true
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        refute handler_called
+      end
+
+      should "not run the fallback when the pre_handle hook returns false for an unknown event" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.pre_handle do |_notif, _client|
+          false
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: UNKNOWN_EVENT_PAYLOAD)
+        handler.handle(UNKNOWN_EVENT_PAYLOAD, sig_header)
+
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "give the pre_handle hook the context-scoped client without mutating the handler's own client" do
+        client_with_context = StripeClient.new("sk_test_123", stripe_context: "original_context_123")
+        handler = StripeEventNotificationHandler.new(client_with_context, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        received_context = nil
+
+        handler.pre_handle do |_notif, client|
+          received_context = client.instance_variable_get(:@requestor).config.stripe_context
+          true
+        end
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          # Handler body
+        end
+
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        assert_equal "event_context_456", received_context.to_s
+        assert_equal "original_context_123", client_with_context.instance_variable_get(:@requestor).config.stripe_context.to_s
+      end
+
+      should "propagate an error raised by the pre_handle hook without running any callback" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler_called = false
+
+        handler.pre_handle do |_notif, _client|
+          raise StandardError, "pre_handle error!"
+        end
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          handler_called = true
+        end
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+
+        e = assert_raises(StandardError) do
+          handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+        end
+        assert_equal "pre_handle error!", e.message
+        refute handler_called
+        assert_equal 0, @on_unhandled_calls.length
+      end
+
+      should "not allow registering a pre_handle hook after handling events" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        sig_header = Test::WebhookHelpers.generate_header(payload: V1_BILLING_METER_PAYLOAD)
+        handler.handle(V1_BILLING_METER_PAYLOAD, sig_header)
+
+        e = assert_raises(RuntimeError) do
+          handler.pre_handle do |_notif, _client|
+            true
+          end
+        end
+        assert_match(/Cannot register new event handlers after handling events/, e.message)
+      end
+
+      should "not allow registering more than one pre_handle hook" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        handler.pre_handle do |_notif, _client|
+          true
+        end
+
+        e = assert_raises(ArgumentError) do
+          handler.pre_handle do |_notif, _client|
+            true
+          end
+        end
+        assert_match(/A pre_handle hook has already been registered/, e.message)
+      end
+
+      should "raise ArgumentError when pre_handle is registered without a block" do
+        handler = StripeEventNotificationHandler.new(@client, Test::WebhookHelpers::SECRET, &@on_unhandled_handler)
+
+        e = assert_raises(ArgumentError) do
+          handler.pre_handle
+        end
+        assert_match(/Block required to register a pre_handle hook/, e.message)
+      end
     end
 
     context "StripeEventNotificationHandlerWithoutVerification" do
@@ -572,6 +723,27 @@ module Stripe
       should "is a sibling of StripeEventNotificationHandler, not an ancestor" do
         refute StripeEventNotificationHandler < StripeEventNotificationHandlerWithoutVerification
         refute StripeEventNotificationHandlerWithoutVerification < StripeEventNotificationHandler
+      end
+
+      should "gate both the registered handler and the fallback with a pre_handle hook" do
+        handler = StripeEventNotificationHandler.without_verification(@client, &@on_unhandled_handler)
+
+        handler_called = false
+
+        handler.pre_handle do |_notif, _client|
+          false
+        end
+
+        handler.on_v1_billing_meter_error_report_triggered do |_notif, _client|
+          handler_called = true
+        end
+
+        handler.handle(V1_BILLING_METER_PAYLOAD)
+        refute handler_called
+        assert_equal 0, @on_unhandled_calls.length
+
+        handler.handle(UNKNOWN_EVENT_PAYLOAD)
+        assert_equal 0, @on_unhandled_calls.length
       end
     end
   end


### PR DESCRIPTION
### Why?

In final testing, users have expressed interest in being able to centrally run code before any other handler executes. It can be used for centralized logging, event deduplication, and more. I don't want to go full middleware, but this felt like a reasonable way to dip our toe into the waters.

Because users are responsible for [deduplicating events](https://docs.stripe.com/webhooks#handle-duplicate-events), this pre-handle hook (if present) should return a `bool`, signifying whether handling should continue.

If the function returns `true` (or is missing entirely), the handler proceeds like normal (running at-most-one other callback). If it returns `false`, no further callback is run and the original `.handle()` call finishes cleanly.

### What?

- add the `.pre_handle` method
- & associated tests
- update some error messages with correct verbs & consistency
- refactored some internal error handling & renamed variable
- updated example

### See Also

- http://go/j/DEVSDK-3249
