### PR TITLE
Remove `payment_method_types` from manual tests

### DIFF
--- a/test/stripe/payment_intent_test.rb
+++ b/test/stripe/payment_intent_test.rb
@@ -23,7 +23,7 @@ module Stripe
       payment_intent = Stripe::PaymentIntent.create(
         amount: 1234,
         currency: "usd",
-        payment_method_types: ["card"]
+        allowed_payment_method_types: ["card"]
       )
       assert_requested :post, "#{Stripe.api_base}/v1/payment_intents"
       assert payment_intent.is_a?(Stripe::PaymentIntent)


### PR DESCRIPTION
### Why?

We have a few manual tests that send `payment_method_types` in a `payment_intent`-related test. That field has already been removed from beta, so preview tests are failing. It's also being removed from GA in the next release, so fixing it in master saves us hassle later.

### What?

- swap `payment_method_types` to `allowed_payment_method_types` in manual tests
