### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -462,13 +462,18 @@ module Stripe
     private def execute_request_internal(method, path,
                                          base_address, params, opts, usage,
                                          &read_body_chunk_block)
+      # The single place request paths are validated: every entry point funnels
+      # through here, and this runs before anything derives meaning from the path
+      # (api_mode is sniffed from its prefix, merge_query_params parses it as a
+      # URI). merge_query_params only strips the query, so the origin-relative
+      # property still holds by the time api_url concatenates the base address.
+      Util.validate_path!(path)
+
       api_mode = Util.get_api_mode(path)
       opts = RequestOptions.merge_config_and_opts(config, opts)
 
       raise ArgumentError, "method should be a symbol" \
       unless method.is_a?(Symbol)
-      raise ArgumentError, "path should be a string" \
-      unless path.is_a?(String)
 
       base_url ||= config.base_addresses[base_address]
 

--- a/lib/stripe/api_requestor.rb
+++ b/lib/stripe/api_requestor.rb
@@ -462,11 +462,6 @@ module Stripe
     private def execute_request_internal(method, path,
                                          base_address, params, opts, usage,
                                          &read_body_chunk_block)
-      # The single place request paths are validated: every entry point funnels
-      # through here, and this runs before anything derives meaning from the path
-      # (api_mode is sniffed from its prefix, merge_query_params parses it as a
-      # URI). merge_query_params only strips the query, so the origin-relative
-      # property still holds by the time api_url concatenates the base address.
       Util.validate_path!(path)
 
       api_mode = Util.get_api_mode(path)

--- a/lib/stripe/resources/v2/core/event_notification.rb
+++ b/lib/stripe/resources/v2/core/event_notification.rb
@@ -53,9 +53,12 @@ module Stripe
 
         # Retrieves the Event that generated this EventNotification.
         def fetch_event
-          resp = @client.raw_request(:get, "/v2/core/events/#{id}", opts: { stripe_context: context,
-                                                                            "Stripe-Request-Trigger" => "event=#{id}", },
-                                                                    usage: ["fetch_event"])
+          # `id` comes from the notification body, so escape it the way generated
+          # services do -- otherwise it can inject extra path or query segments.
+          path = "/v2/core/events/#{CGI.escape(id)}"
+          resp = @client.raw_request(:get, path, opts: { stripe_context: context,
+                                                         "Stripe-Request-Trigger" => "event=#{id}", },
+                                                 usage: ["fetch_event"])
           @client.deserialize(resp.http_body, api_mode: :v2)
         end
       end

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -380,14 +380,14 @@ module Stripe
     #
     # The absolute URL is built by concatenating a base address onto this path,
     # and no base address ends in a slash. A path like "@evil.example/v1/x" or
-    # ".evil.example/v1/x" would therefore land inside the authority component
-    # and send the request -- Authorization header included -- to a host of the
-    # path's choosing. Some request paths originate in remote data (a webhook
-    # body's related_object.url, a list object's url, a response's
-    # next_page_url), so the path cannot be assumed to be well-formed.
+    # ".evil.example/v1/x" would modify the resulting host and direct the request
+    # (including the API key) to a non-Stripe host.
     #
-    # Stripe only ever issues plain paths, so anything else is tampering and is
-    # rejected rather than sanitized.
+    # Because some relative urls arrive from potentially untrusted sources (like
+    # webhook bodies), we have to be a little defensive.
+    #
+    # So, we require that a path starts with a leading slash and that URI.parse
+    # finds no scheme or authority in it.
     def self.validate_path!(path)
       unless path.is_a?(String) && path.start_with?("/") && !path.start_with?("//")
         raise ArgumentError,

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -375,6 +375,38 @@ module Stripe
       res.zero?
     end
 
+    # Asserts that a request path is origin-relative: that it begins with a
+    # single "/" and carries no scheme, authority or userinfo.
+    #
+    # The absolute URL is built by concatenating a base address onto this path,
+    # and no base address ends in a slash. A path like "@evil.example/v1/x" or
+    # ".evil.example/v1/x" would therefore land inside the authority component
+    # and send the request -- Authorization header included -- to a host of the
+    # path's choosing. Some request paths originate in remote data (a webhook
+    # body's related_object.url, a list object's url, a response's
+    # next_page_url), so the path cannot be assumed to be well-formed.
+    #
+    # Stripe only ever issues plain paths, so anything else is tampering and is
+    # rejected rather than sanitized.
+    def self.validate_path!(path)
+      unless path.is_a?(String) && path.start_with?("/") && !path.start_with?("//")
+        raise ArgumentError,
+              "path must be a string beginning with a single \"/\", got: #{path.inspect}"
+      end
+
+      uri =
+        begin
+          URI.parse(path)
+        rescue URI::InvalidURIError
+          raise ArgumentError, "path is not a valid URI: #{path.inspect}"
+        end
+
+      return if uri.scheme.nil? && uri.host.nil? && uri.userinfo.nil?
+
+      raise ArgumentError,
+            "path may not contain a scheme or authority, got: #{path.inspect}"
+    end
+
     # Returns either v1 or v2 as api_mode based on the given path
     def self.get_api_mode(path)
       if path.start_with?("/v2/")

--- a/test/stripe/api_requestor_test.rb
+++ b/test/stripe/api_requestor_test.rb
@@ -1844,5 +1844,101 @@ module Stripe
         assert_equal "", APIRequestor::SystemProfiler.detect_ai_agent({ "CLAUDECODE" => "" })
       end
     end
+
+    ORIGIN_RELATIVE_PATHS = [
+      "/v1/customers/cus_123",
+      "/v1/customers",
+      "/v2/core/accounts?page=page_123&limit=2",
+      # "@" is legal inside a path or query string -- it only opens an authority
+      # when it precedes the first "/".
+      "/v1/customers?email=user%40example.com",
+      "/v1/%5Cevil.example",
+    ].freeze
+
+    HOSTILE_PATHS = [
+      # Concatenated onto a base address with no trailing slash, each of these
+      # moves the request's authority off api.stripe.com.
+      "@evil.example/v1/leak",
+      ":pw@evil.example/v1/leak",
+      ":80@evil.example/v1/leak",
+      # Extends the host into an attacker-owned subdomain
+      # (api.stripe.com.evil.example), which has a valid certificate.
+      ".evil.example/v1/leak",
+      "-evil.example/v1/leak",
+      "https://evil.example/v1/leak",
+      "//evil.example/v1/leak",
+      "",
+      "v1/customers",
+      nil,
+      42,
+    ].freeze
+
+    context "request path validation" do
+      should "accept origin-relative paths" do
+        ORIGIN_RELATIVE_PATHS.each do |path|
+          Util.validate_path!(path)
+        end
+      end
+
+      should "reject paths that could move the request's authority" do
+        HOSTILE_PATHS.each do |path|
+          assert_raises(ArgumentError, "expected #{path.inspect} to be rejected") do
+            Util.validate_path!(path)
+          end
+        end
+      end
+
+      should "reject a hostile path without issuing a request" do
+        # WebMock blocks any unstubbed connection, so no stub plus no WebMock
+        # error is the assertion that nothing left the process.
+        HOSTILE_PATHS.each do |path|
+          assert_raises(ArgumentError, "expected #{path.inspect} to be rejected") do
+            Stripe::StripeClient.new("sk_test_123").raw_request(:get, path)
+          end
+        end
+      end
+
+      should "reject a hostile related_object.url without issuing a request" do
+        payload = JSON.generate(
+          id: "evt_123",
+          object: "v2.core.event",
+          type: "v2.core.account.created",
+          created: "2026-01-01T00:00:00Z",
+          related_object: {
+            id: "acct_123",
+            type: "account",
+            url: "@evil.example/v1/leak",
+          }
+        )
+        header = Test::WebhookHelpers.generate_header(payload: payload)
+
+        client = Stripe::StripeClient.new("sk_test_123")
+        notification = client.parse_event_notification(
+          payload, header, Test::WebhookHelpers::SECRET
+        )
+
+        assert_raises(ArgumentError) do
+          notification.fetch_related_object
+        end
+      end
+
+      should "reject a hostile list object url without issuing a request" do
+        # A signature-verified v1 webhook body is attacker-shaped, and nested
+        # collections in it become ListObjects whose `url` is used as a path.
+        list = Util.convert_to_stripe_object(
+          {
+            object: "list",
+            data: [{ id: "il_123" }],
+            has_more: true,
+            url: "@evil.example/v1/leak",
+          },
+          {}
+        )
+
+        assert_raises(ArgumentError) do
+          list.next_page
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- Encode the `event.id` path param in `fetch_event()` to match the sanitation in the rest of the generated endpoints
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
