### PR TITLE
Fix OAuth authorize response type defaulting 🪿✨

### DIFF
--- a/lib/stripe/services/oauth_service.rb
+++ b/lib/stripe/services/oauth_service.rb
@@ -11,7 +11,7 @@ module Stripe
 
       params[:client_id] = client_id(params)
 
-      params[:response_type] = "code" if params.include?(:response_type)
+      params[:response_type] ||= "code"
 
       query = Util.encode_parameters(params, :v1)
 

--- a/test/stripe/oauth_service_test.rb
+++ b/test/stripe/oauth_service_test.rb
@@ -24,10 +24,21 @@ module Stripe
         assert_equal("/oauth/authorize", uri.path)
 
         assert_equal(["foo"], params["client_id"])
+        assert_equal(["code"], params["response_type"])
         assert_equal(["read_write"], params["scope"])
         assert_equal(["test@example.com"], params["stripe_user[email]"])
         assert_equal(["https://example.com/profile/test"], params["stripe_user[url]"])
         assert_equal(["US"], params["stripe_user[country]"])
+      end
+
+      should "preserve an explicit response type" do
+        client = Stripe::StripeClient.new("sk_test_fake_key", client_id: "foo")
+        uri_str = client.v1.oauth.authorize_url(response_type: "token")
+
+        uri = URI.parse(uri_str)
+        params = CGI.parse(uri.query)
+
+        assert_equal(["token"], params["response_type"])
       end
 
       should "optionally return an express path" do


### PR DESCRIPTION
### Why?
Reported in https://github.com/stripe/stripe-ruby/issues/1952.  `OAuthService#authorize_url` omits `response_type=code` when callers provide no value and overwrites explicit values with `code`. This aligns `OAuthService` with the legacy OAuth helper so the default is applied only when needed.

### What?
- Default `response_type` to `code` when absent or falsey.
- Preserve an explicit `response_type` and add regression coverage for both behaviors.

### See Also

## Changelog
- Fixes `OAuthService#authorize_url` to default `response_type` to `code` without overwriting an explicit value.