### PR TITLE
Validate that webhook secrets are non-empty

### DIFF
--- a/examples/event_notification_handler_endpoint.rb
+++ b/examples/event_notification_handler_endpoint.rb
@@ -16,8 +16,9 @@ require "stripe"
 require "sinatra"
 
 api_key = ENV.fetch("STRIPE_API_KEY", nil)
-# Retrieve the webhook secret from the environment variable
-webhook_secret = ENV.fetch("WEBHOOK_SECRET", nil)
+# Retrieve the webhook secret from the environment variable. This is required;
+# `ENV.fetch` without a default raises a KeyError if it's not set.
+webhook_secret = ENV.fetch("WEBHOOK_SECRET")
 
 client = Stripe::StripeClient.new(api_key)
 

--- a/examples/event_notification_webhook_handler.rb
+++ b/examples/event_notification_webhook_handler.rb
@@ -18,8 +18,9 @@ require "stripe"
 require "sinatra"
 
 api_key = ENV.fetch("STRIPE_API_KEY", nil)
-# Retrieve the webhook secret from the environment variable
-webhook_secret = ENV.fetch("WEBHOOK_SECRET", nil)
+# Retrieve the webhook secret from the environment variable. This is required;
+# `ENV.fetch` without a default raises a KeyError if it's not set.
+webhook_secret = ENV.fetch("WEBHOOK_SECRET")
 
 client = Stripe::StripeClient.new(api_key)
 

--- a/lib/stripe/webhook.rb
+++ b/lib/stripe/webhook.rb
@@ -135,6 +135,14 @@ module Stripe
           )
         end
 
+        if secret.nil? || secret.empty?
+          raise SignatureVerificationError.new(
+            "No webhook secret value was provided. It should start with " \
+            "`whsec_`",
+            header, http_body: payload
+          )
+        end
+
         expected_sig = compute_signature(timestamp, payload, secret)
         unless signatures.any? { |s| Util.secure_compare(expected_sig, s) }
           raise SignatureVerificationError.new(

--- a/test/stripe/webhook_test.rb
+++ b/test/stripe/webhook_test.rb
@@ -160,6 +160,22 @@ module Stripe
         assert_match("No signatures found matching the expected signature for payload", e.message)
       end
 
+      should "raise a SignatureVerificationError when the secret is an empty string" do
+        header = Test::WebhookHelpers.generate_header(payload: EVENT_PAYLOAD)
+        e = assert_raises(Stripe::SignatureVerificationError) do
+          Stripe::Webhook::Signature.verify_header(EVENT_PAYLOAD, header, "")
+        end
+        assert_match("No webhook secret value was provided. It should start with `whsec_`", e.message)
+      end
+
+      should "raise a SignatureVerificationError when the secret is nil" do
+        header = Test::WebhookHelpers.generate_header(payload: EVENT_PAYLOAD)
+        e = assert_raises(Stripe::SignatureVerificationError) do
+          Stripe::Webhook::Signature.verify_header(EVENT_PAYLOAD, header, nil)
+        end
+        assert_match("No webhook secret value was provided. It should start with `whsec_`", e.message)
+      end
+
       should "raise a SignatureVerificationError when the timestamp is not within the tolerance" do
         header = Test::WebhookHelpers.generate_header(payload: EVENT_PAYLOAD, timestamp: Time.now - 15)
         e = assert_raises(Stripe::SignatureVerificationError) do


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a potential security issue where, if the user passes an empty string into the event validation functions, the SDK would still generate a signature. If an attacker knew that a victim was inadvertently using an empty webhook secret, the attacker could send signed webhooks (using the empty secret) that a victim's integration would treat as valid.

The solution is to throw an error if the webhook secret is empty. This ensures all payloads are validated against an actual secret.

We also updated our examples to have better defaults, helping users to avoid this issue.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- verify that a webhook secret is non-empty & non-null when verifying a webhook
- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
