### PR TITLE
Fix webhook tolerance reference

### DIFF
--- a/rbi/stripe/stripe_client.rbi
+++ b/rbi/stripe/stripe_client.rbi
@@ -16,7 +16,7 @@ module Stripe
       )
         .returns(::Stripe::V2::Core::EventNotification)
     end
-    def parse_event_notification(payload, sig_header, secret, tolerance: Webhook::DEFAULT_TOLERANCE); end
+    def parse_event_notification(payload, sig_header, secret, tolerance: ::Stripe::Webhook::DEFAULT_TOLERANCE); end
 
     # Constructs a [thin event notification](https://docs.stripe.com/event-destinations#thin-payload) from
     # an incoming webhook without first verifying its authenticity. Should be used after calling


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Inside our rbi files, references to other stripe types should be absolute, not relative

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added `::Stripe::` to the signature for `parse_event_notification`

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-ruby/issues/1961
- [RUN_DEVSDK-2971](https://go/j/RUN_DEVSDK-2971)
